### PR TITLE
Add timing to build, cache layouts.

### DIFF
--- a/build.coffee
+++ b/build.coffee
@@ -103,13 +103,6 @@ subs = (files, metalsmith, done) ->
                 files[file].contents = contents
     done()
 
-# Extend `marked.Renderer` to increase all heading levels by 1 since we reserve
-# h1 for the page title. Will be passed to `metalsmith-markdown` plugin.
-marked = require("marked")
-class Renderer extends marked.Renderer
-    heading: ( text, level, raw ) =>
-      super( text, level + 1, raw )
-
 timer = require( "metalsmith-timer" )
 
 ms = metalsmith(__dirname)
@@ -138,7 +131,6 @@ ms = metalsmith(__dirname)
     .use timer 'subs'
     .use require('metalsmith-markdown')
         gfm: true
-        renderer: new Renderer()
     .use timer 'metalsmith-markdown'
     .use require('metalsmith-autotoc')
         selector: "h2, h3, h4"

--- a/build.coffee
+++ b/build.coffee
@@ -103,9 +103,19 @@ subs = (files, metalsmith, done) ->
                 files[file].contents = contents
     done()
 
+# Extend `marked.Renderer` to increase all heading levels by 1 since we reserve
+# h1 for the page title. Will be passed to `metalsmith-markdown` plugin.
+marked = require("marked")
+class Renderer extends marked.Renderer
+    heading: ( text, level, raw ) =>
+      super( text, level + 1, raw )
+
+timer = require( "metalsmith-timer" )
+
 ms = metalsmith(__dirname)
     .use require('metalsmith-metadata')
         menu: "config/menu.yaml"
+    .use timer 'metalsmith-metadata'
     .use require('metalsmith-collections')
         news:
             pattern: "news/*/*.md"
@@ -119,28 +129,42 @@ ms = metalsmith(__dirname)
             pattern: "publications/*/*.md"
             sortBy: "date"
             reverse: true
+    .use timer 'metalsmith-collections'
     .use link_to_orig_path
+    .use timer 'link_to_orig_path'
     .use handlebars_partial_handling
+    .use timer 'handlebars_partial_handling'
     .use subs
+    .use timer 'subs'
     .use require('metalsmith-markdown')
         gfm: true
+        renderer: new Renderer()
+    .use timer 'metalsmith-markdown'
     .use require('metalsmith-autotoc')
         selector: "h2, h3, h4"
+    .use timer 'metalsmith-autotoc'
     .use require('metalsmith-alias')()
+    .use timer 'metalsmith-alias'
     .use require('metalsmith-filepath')
         absolute: true
         permalinks: true
+    .use timer 'metalsmith-filepath'
     .use require('metalsmith-layouts')
         engine: "pug"
+        cache: true
         default: "default.pug"
         pattern: "**/*.html"
         helpers:
             moment: require('moment')
             marked: require('marked')
             _: require('lodash')
+    .use timer 'metalsmith-layouts'
     .use require('metalsmith-less')()
+    .use timer 'metalsmith-less'
     .use bower
+    .use timer 'bower'
     .use require('metalsmith-uglify')()
+    .use timer 'metalsmith-uglify'
 
 argv = require('minimist')(process.argv.slice(2))
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "metalsmith-metadata": "^0.0.1",
     "metalsmith-permalinks": "^0.4.0",
     "metalsmith-serve": "^0.0.3",
+    "metalsmith-timer": "0.0.2",
     "metalsmith-uglify": "^1.0.1",
     "metalsmith-watch": "^1.0.0",
     "minimist": "^1.1.1",


### PR DESCRIPTION
Adds metalsmith-timer to each step of the build. This can probably be
refactored for DRY, but works for now. Pass the `cache` option to
layouts which gets passed to pug. The layouts plugin does not compile
templates, this allows pug to cache the compiled version itself. For me
the pug stage of the build goes from 70s to <1s.

Autotoc is now the slowest stage at 15s. Much more usable this way.