### PR TITLE
Makefile enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,19 @@ build: npm-deps bower ## Builds into /build, suitable for copying to webserver.
 serve: npm-deps bower ## Serve locally for viewing
 	$(COFFEE) build.coffee --serve
 
-watch: npm-deps bower ## will serve and attempt to reload files
+watch: npm-deps bower ## Serve and attempt to reload changed files
 	$(COFFEE) build.coffee --watch
 
-check: npm-deps bower ## checks for broken links
+check: npm-deps bower ## Check for broken links
 	$(COFFEE) build.coffee --check
 
-docker-npm-deps:
+docker-npm-deps:  ## [Docker] Install NodeJS dependencies.
 	docker run -v `pwd`:/tmp/hub -w /tmp/hub node /bin/bash -c "npm install && chown -R `id -u`:`id -g` /tmp/hub/node_modules"
 
-docker-bower:
+docker-bower: ## [Docker] Install Bower
 	docker run -v `pwd`:/tmp/hub -w /tmp/hub node /bin/bash -c "node node_modules/bower/bin/bower --allow-root install && chown -R `id -u`:`id -g` /tmp/hub/bower_components"
 
-docker-build: docker-npm-deps docker-bower  ## Single endpoint for docker install
+docker-build: docker-npm-deps docker-bower  ## [Docker] Single endpoint for docker install
 	$(DOCKER) node node node_modules/coffee-script/bin/coffee build.coffee
 
 gitlfs-pull:  ## We use this during the Jenkins build process to fetch LFS contents -- probably not useful locally.

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,5 @@ docker-build: docker-npm-deps docker-bower  ## [Docker] Single endpoint for dock
 
 gitlfs-pull:  ## We use this during the Jenkins build process to fetch LFS contents -- probably not useful locally.
 	$(DOCKER) dannon/gitlfs git lfs pull
+
+.PHONY: gitlfs-pull docker-build docker-bower docker-npm-deps check watch serve build

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ npm-deps: node_modules
 
 .DEFAULT_GOAL := all
 
-bower:
+bower_components: bower.json
 	./node_modules/bower/bin/bower install
+
+bower: bower_components
+
 all: help
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 COFFEE=DEBUG=metalsmith-timer ./node_modules/coffee-script/bin/coffee
 DOCKER=docker run -u `id -u`:`id -g` -v `pwd`:/tmp/hub -w /tmp/hub
 
-npm-deps: ## Install NodeJS dependencies.
+node_modules: package.json
 	npm install
+
+npm-deps: node_modules
 
 .DEFAULT_GOAL := all
 

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ bower:
 all: help
 
 help:
-	@echo "There are no default actions for this Makefile, you must choose an option from the following:\n"
-	@egrep '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo "There are no default actions for this Makefile, you must choose an option from the following:"
+	@egrep '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 build: npm-deps bower ## Builds into /build, suitable for copying to webserver.
 	$(COFFEE) build.coffee


### PR DESCRIPTION
- For non-docker builds, don't run `npm install` every time (no one cares if jenkins takes another 1.5 seconds anyway), only when package.json changes.
- Same for bower / bower.json
- Visually separate docker specific make targets