### PR TITLE
Updated links from Emory to JHU (job openings page).

### DIFF
--- a/src/news/galaxyis-hiring/index.md
+++ b/src/news/galaxyis-hiring/index.md
@@ -5,7 +5,7 @@ date: '2017-02-02'
 
 <div class='newsItemHeader'>[Galaxy is Hiring](/src/news/Galaxy is Hiring/index.md)</div>
 
-The Galaxy project currently has open positions in both the [Penn State](/src/community/Penn State/index.md) and [Emory](/src/community/Emory University/index.md) groups.
+The Galaxy project currently has open positions in both the [Johns Hopkins University] (http://jamestaylor.org/) and [Penn State](http://www.bx.psu.edu/~anton/) groups.
 
 <div class='right'><a href='http://www.bx.psu.edu/~anton/'><img src="/src/images/logos/PennStateLogo.jpg" alt="Opening at Penn State" width="200" /></a></div>
 **[Penn State](/src/community/Penn State/index.md): System administrators/analysts**
@@ -22,16 +22,16 @@ The [Nekrutenko Lab](http://www.bx.psu.edu/~anton/) at the [Huck Institutes of L
 A minimum of 5 year experience with UNIX/Linux system administration is required. Applicants should submit a CV and list of references to [gxyhiring AT galaxyproject DOT org](mailto:gxyhiring AT galaxyproject DOT org). 
 
 
-<div class='right'><a href='http://bx.mathcs.emory.edu/joining/'><img src="/src/images/logos/EmoryLogo.jpg" alt="Openings at Emory" width="200" /></a></div>
+<div class='right'><a href='http://jamestaylor.org/joining/'><img src="/src/images/logos/JohnsHopkinsLogoLarge.gif" alt="Openings at Johns Hopkins University" width="200" /></a></div>
 **[Emory](/src/community/Emory University/index.md): Software Engineers and Post-Docs**
 <br /><br />
 
-The [Taylor Lab](http://bx.mathcs.emory.edu/) in the [Biology](http://www.biology.emory.edu) and [Mathematics & Computer Science](http://www.mathcs.emory.edu) at [Emory University](http://emory.edu/) is looking for 
-[software engineers](http://bx.mathcs.emory.edu/joining/sw/) and [postdoctoral scholars](http://bx.mathcs.emory.edu/joining/postdocs/) to work on the Galaxy project.  
+The [Taylor Lab](http://jamestaylor.org/) in the [Biology](http://bio.jhu.edu/) and [Computer Science](https://www.cs.jhu.edu/) departments at [Johns Hopkins University](http://jhu.edu/) is looking for 
+[software engineers](http://jamestaylor.org/joining/sw/) and [postdoctoral scholars](http://jamestaylor.org/joining/postdocs/) to work on the Galaxy project.  
 
-We are seeking [software engineers](http://bx.mathcs.emory.edu/joining/sw/) with expertise in distributed computing and systems programming, web-based visualization and visual analytics, informatics and data analysis and integration, and bioinformatics application areas such as re-sequencing, de novo assembly, metagenomics, transcriptome analysis and epigenetics.  These are full time positions located in Atlanta, GA.  See the [official posting](http://bx.mathcs.emory.edu/joining/sw/) for full details.
+We are seeking [software engineers](http://jamestaylor.org/joining/sw/) with expertise in distributed computing and systems programming, web-based visualization and visual analytics, informatics and data analysis and integration, and bioinformatics application areas such as re-sequencing, de novo assembly, metagenomics, transcriptome analysis and epigenetics.  These are full time positions located in Baltimore, MD.  See the [official posting](http://jamestaylor.org/joining/sw/) for full details.
 
-[Postdoctoral applicants](http://bx.mathcs.emory.edu/joining/postdocs/) should have expertise in Bioinformatics and Computational Biology and research interests that complement but extend the [lab's current interests](http://bx.mathcs.emory.edu/research/): The Galaxy project; distributed and high-performance computing for data intensive science; vertebrate functional genomics; and genomics and epigenomic mechanisms of gene regulation, the role of transcription factors and chromatin structure in global gene expression, development, and differentiation.  See the [announcement](http://bx.mathcs.emory.edu/joining/postdocs/) for full details.
+[Postdoctoral applicants](http://jamestaylor.org/joining/postdocs/jamestaylor.org) should have expertise in Bioinformatics and Computational Biology and research interests that complement but extend the [lab's current interests](http://jamestaylor.org/research/): The Galaxy project; distributed and high-performance computing for data intensive science; vertebrate functional genomics; and genomics and epigenomic mechanisms of gene regulation, the role of transcription factors and chromatin structure in global gene expression, development, and differentiation.  See the [announcement](http://jamestaylor.org/joining/postdocs/jamestaylor.org) for full details.
 
 <div class='newsItemFooter'>Posted to the [Galaxy News](/src/news/index.md) on 2011-08-29</div>
 


### PR DESCRIPTION
Brought in current links for the job openings page. 