### PR TITLE
Process tweaks

### DIFF
--- a/build.coffee
+++ b/build.coffee
@@ -24,12 +24,15 @@ set_metadata_defaults = (files, metalsmith, done) ->
             # Link to original path
             files[k].orig_path = k
             # Autotoc defaults to true
-            files[k].autotoc = true if files[k].autotoc == undefined
             # Set domain templates
-            if 'events' in v.collection and not files[k].layout
-                files[k].layout = 'events.pug'
-            if 'news' in v.collection and not files[k].layout
-                files[k].layout = 'news.pug'
+            if 'events' in v.collection
+                files[k].layout = 'events.pug' if files[k].layout == undefined
+                files[k].autotoc = false if files[k].autotoc == undefined
+            else if 'news' in v.collection
+                files[k].layout = 'news.pug' if files[k].layout == undefined
+                files[k].autotoc = false if files[k].autotoc == undefined
+            else
+                files[k].autotoc = true if files[k].autotoc == undefined
     done()
 
 fs = require('fs')

--- a/build.coffee
+++ b/build.coffee
@@ -18,17 +18,18 @@ bower = (files, metalsmith, done) ->
     done()
 
 set_metadata_defaults = (files, metalsmith, done) ->
-    # Simple way to apply domain templates en masse
+    # Simple way to apply metadata defaults
     for k, v of files
         if k.endsWith('.md')
+            # Link to original path
             files[k].orig_path = k
+            # Autotoc defaults to true
             files[k].autotoc = true if files[k].autotoc == undefined
+            # Set domain templates
             if 'events' in v.collection and not files[k].layout
                 files[k].layout = 'events.pug'
             if 'news' in v.collection and not files[k].layout
                 files[k].layout = 'news.pug'
-                #if files[k].date == undefined
-                #    files[k].date = '2010-01-01'
     done()
 
 fs = require('fs')

--- a/build.coffee
+++ b/build.coffee
@@ -20,13 +20,15 @@ bower = (files, metalsmith, done) ->
 set_metadata_defaults = (files, metalsmith, done) ->
     # Simple way to apply domain templates en masse
     for k, v of files
-        files[k].orig_path = k
-        if 'events' in v.collection and not files[k].layout
-            files[k].layout = 'events.pug'
-        if 'news' in v.collection and not files[k].layout
-            files[k].layout = 'news.pug'
-            #if files[k].date == undefined
-            #    files[k].date = '2010-01-01'
+        if k.endsWith('.md')
+            files[k].orig_path = k
+            files[k].autotoc = true if files[k].autotoc == undefined
+            if 'events' in v.collection and not files[k].layout
+                files[k].layout = 'events.pug'
+            if 'news' in v.collection and not files[k].layout
+                files[k].layout = 'news.pug'
+                #if files[k].date == undefined
+                #    files[k].date = '2010-01-01'
     done()
 
 fs = require('fs')

--- a/build.coffee
+++ b/build.coffee
@@ -17,14 +17,10 @@ bower = (files, metalsmith, done) ->
     include('fonts', bower_files.self().ext(['eot','otf','ttf','woff','woff2']).files)
     done()
 
-link_to_orig_path = (files, metalsmith, done) ->
-    for k, v of files
-        files[k].orig_path = k
-    done()
-
 apply_collection_defaults = (files, metalsmith, done) ->
     # Simple way to apply domain templates en masse
     for k, v of files
+        files[k].orig_path = k
         if 'events' in v.collection and not files[k].layout
             files[k].layout = 'events.pug'
         if 'news' in v.collection and not files[k].layout
@@ -32,7 +28,6 @@ apply_collection_defaults = (files, metalsmith, done) ->
             #if files[k].date == undefined
             #    files[k].date = '2010-01-01'
     done()
-
 
 fs = require('fs')
 path = require('path')
@@ -155,10 +150,8 @@ ms = metalsmith(__dirname)
             sortBy: "date"
             reverse: true
     .use timer 'metalsmith-collections'
-    .use link_to_orig_path
-    .use timer 'link_to_orig_path'
-    .use apply_collection_defaults
-    .use timer 'apply_collection_defaults'
+    .use set_metadata_defaults
+    .use timer 'set_metadata_defaults'
     .use handlebars_partial_handling
     .use timer 'handlebars_partial_handling'
     .use subs

--- a/build.coffee
+++ b/build.coffee
@@ -17,7 +17,7 @@ bower = (files, metalsmith, done) ->
     include('fonts', bower_files.self().ext(['eot','otf','ttf','woff','woff2']).files)
     done()
 
-apply_collection_defaults = (files, metalsmith, done) ->
+set_metadata_defaults = (files, metalsmith, done) ->
     # Simple way to apply domain templates en masse
     for k, v of files
         files[k].orig_path = k

--- a/layouts/default.pug
+++ b/layouts/default.pug
@@ -5,7 +5,7 @@ block content
         if toc
             div.col-md-9
                 if !skip_title_render
-                    h1.pageTitle !{ title }
+                    h1.pageTitle #{ title }
                 div !{ contents }
             div.col-md-3
                 div.affix#sidebar

--- a/layouts/default.pug
+++ b/layouts/default.pug
@@ -4,8 +4,7 @@ block content
     section.section-content
         if toc
             div.col-md-9
-                if !skip_title_render
-                    h1.pageTitle #{ title }
+                +renderPageTitle
                 div !{ contents }
             div.col-md-3
                 div.affix#sidebar
@@ -13,6 +12,5 @@ block content
         else
             div.col-md-12
                 section.section-content
-                    if !skip_title_render
-                        h1.pageTitle !{ title }
+                    +renderPageTitle
                     div !{ contents }

--- a/layouts/events.pug
+++ b/layouts/events.pug
@@ -3,7 +3,7 @@ extends layout.pug
 block content
     section.section-content
         div.col-md-9
-            h1 !{ title } - !{ tease }
+            h1 #{ title } - #{ tease }
             ul.list-unstyled
                 li
                     strong Date: 

--- a/layouts/events.pug
+++ b/layouts/events.pug
@@ -3,7 +3,7 @@ extends layout.pug
 block content
     section.section-content
         div.col-md-9
-            h1 #{ title } - #{ tease }
+            +renderPageTitle
             ul.list-unstyled
                 li
                     strong Date: 

--- a/layouts/layout.pug
+++ b/layouts/layout.pug
@@ -8,6 +8,15 @@ mixin renderToc(items)
                 if toc_item.children.length > 0
                     +renderToc(toc_item.children)
 
+mixin renderPageTitle()
+    if !skip_title_render
+        h1.pageTitle #{ title }
+        +renderPageTease
+
+mixin renderPageTease()
+    if tease
+        p: em #{tease}
+
 head( lang="en" )
     block title
         title=title

--- a/layouts/news.pug
+++ b/layouts/news.pug
@@ -2,21 +2,10 @@ extends layout.pug
 
 block content
     section.section-content
-        if toc
-            div.col-md-9
+        div.col-md-12
+            section.section-content
                 h1 #{ title }
                 if tease
                     p: em #{tease}
                 p.small #{helpers.moment(date).format("MMMM Do YYYY")}
                 div !{ contents }
-            div.col-md-3
-                div.affix#sidebar
-                    +renderToc(toc)
-        else
-            div.col-md-12
-                section.section-content
-                    h1 #{ title }
-                    if tease
-                        p: em #{tease}
-                    p.small #{helpers.moment(date).format("MMMM Do YYYY")}
-                    div !{ contents }

--- a/layouts/news.pug
+++ b/layouts/news.pug
@@ -4,8 +4,6 @@ block content
     section.section-content
         div.col-md-12
             section.section-content
-                h1.pageTitle #{ title }
-                if tease
-                    p: em #{tease}
+                +renderPageTitle
                 p.small #{helpers.moment(date).format("MMMM Do YYYY")}
                 div !{ contents }

--- a/layouts/news.pug
+++ b/layouts/news.pug
@@ -4,7 +4,7 @@ block content
     section.section-content
         div.col-md-12
             section.section-content
-                h1 #{ title }
+                h1.pageTitle #{ title }
                 if tease
                     p: em #{tease}
                 p.small #{helpers.moment(date).format("MMMM Do YYYY")}

--- a/src/admin/config/apache-external-user-auth/index.md
+++ b/src/admin/config/apache-external-user-auth/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 ## External user authentication
 

--- a/src/admin/config/external-user-auth/index.md
+++ b/src/admin/config/external-user-auth/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 ## External user authentication
 

--- a/src/admin/config/jobs/index.md
+++ b/src/admin/config/jobs/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Job Configuration
 ---
 {{> Admin/LinkBox }}

--- a/src/admin/config/performance/cluster/index.md
+++ b/src/admin/config/performance/cluster/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Running Galaxy Tools on a Cluster
 ---
 {{> Admin/Config/Performance/LinkBox }}

--- a/src/admin/config/performance/cluster/legacy/index.md
+++ b/src/admin/config/performance/cluster/legacy/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Running Galaxy Tools on a Cluster
 ---
 {{> Admin/Config/Performance/LinkBox }}

--- a/src/admin/config/performance/production-server/index.md
+++ b/src/admin/config/performance/production-server/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Running Galaxy in a production environment
 ---
 The [basic installation instructions](/src/admin/get-galaxy/index.md) are suitable for development by a single user, but when setting up Galaxy for a multi-user production environment, there are some additional steps that should be taken for the best performance.

--- a/src/admin/config/performance/scaling/index.md
+++ b/src/admin/config/performance/scaling/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Scaling and Load Balancing
 ---
 {{> Admin/Config/Performance/LinkBox }}

--- a/src/admin/config/proftpd-with-ad/index.md
+++ b/src/admin/config/proftpd-with-ad/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Setting up ProFTPd for galaxy uploads in an Active Directory environment
 ---
 * You want to enable FTP file uploads?

--- a/src/admin/faq/index.md
+++ b/src/admin/faq/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Frequently Asked Questions for Galaxy Administration
 ---
 {{> Admin/LinkBox }} 

--- a/src/admin/get-galaxy/index.md
+++ b/src/admin/get-galaxy/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Get Galaxy
 ---
 Here you will find information on obtaining and setting up a Galaxy instance with default configuration. 

--- a/src/admin/index.md
+++ b/src/admin/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Galaxy Administration
 

--- a/src/admin/internals/data-sources/index.md
+++ b/src/admin/internals/data-sources/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='right'>
 

--- a/src/admin/license/index.md
+++ b/src/admin/license/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='right'></div>
 

--- a/src/admin/running-tests/index.md
+++ b/src/admin/running-tests/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 ## Running Tests
 

--- a/src/admin/tools/add-tool-from-toolshed-tutorial/index.md
+++ b/src/admin/tools/add-tool-from-toolshed-tutorial/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Installing Tools into Galaxy
 ---
 ## Ways to get tools into Galaxy

--- a/src/admin/tools/add-tool-tutorial/index.md
+++ b/src/admin/tools/add-tool-tutorial/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 ## Adding custom tools to Galaxy
 

--- a/src/admin/tools/data-managers/api/index.md
+++ b/src/admin/tools/data-managers/api/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 ----
 

--- a/src/admin/tools/data-managers/data-manager-json-syntax/index.md
+++ b/src/admin/tools/data-managers/data-manager-json-syntax/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Data Manager JSON Syntax
 

--- a/src/admin/tools/data-managers/data-manager-xml-syntax/index.md
+++ b/src/admin/tools/data-managers/data-manager-xml-syntax/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Galaxy Data Manager XML File
 

--- a/src/admin/tools/data-managers/how-to/define/index.md
+++ b/src/admin/tools/data-managers/how-to/define/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Defining Data Managers
 

--- a/src/admin/tools/data-managers/testing/index.md
+++ b/src/admin/tools/data-managers/testing/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Writing Data Manager Tests
 

--- a/src/admin/tools/multiple-output-files/index.md
+++ b/src/admin/tools/multiple-output-files/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Strategies for tools that create more than one output file
 

--- a/src/archive/automated-tool-tests/index.md
+++ b/src/archive/automated-tool-tests/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main Tool Shed](/images/logos/ToolShed.jpg)</a></div>
 

--- a/src/archive/dev-news-briefs/2010-07-16/index.md
+++ b/src/archive/dev-news-briefs/2010-07-16/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # July 16, 2010 New Development News Brief
 

--- a/src/archive/dev-news-briefs/2011-04-08/index.md
+++ b/src/archive/dev-news-briefs/2011-04-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 8, 2011 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2011-08-30/index.md
+++ b/src/archive/dev-news-briefs/2011-08-30/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 30, 2011 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2011-10-25/index.md
+++ b/src/archive/dev-news-briefs/2011-10-25/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # October 25, 2011 Galaxy Development News Brief
 

--- a/src/archive/dev-news-briefs/2011-11-18/index.md
+++ b/src/archive/dev-news-briefs/2011-11-18/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # November 18, 2011 Galaxy Development News Brief
 

--- a/src/archive/dev-news-briefs/2012-01-20/index.md
+++ b/src/archive/dev-news-briefs/2012-01-20/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 20, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-01-27/index.md
+++ b/src/archive/dev-news-briefs/2012-01-27/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 27, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-03-12/index.md
+++ b/src/archive/dev-news-briefs/2012-03-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: March 12, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-05-11/index.md
+++ b/src/archive/dev-news-briefs/2012-05-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: May 11, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-07-20/index.md
+++ b/src/archive/dev-news-briefs/2012-07-20/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: July 20, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-09-07/index.md
+++ b/src/archive/dev-news-briefs/2012-09-07/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: September 07, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-09-20/index.md
+++ b/src/archive/dev-news-briefs/2012-09-20/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: September 20, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-10-05/index.md
+++ b/src/archive/dev-news-briefs/2012-10-05/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October 5, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-10-23/index.md
+++ b/src/archive/dev-news-briefs/2012-10-23/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October 23, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-11-14/index.md
+++ b/src/archive/dev-news-briefs/2012-11-14/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: November 14, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-12-03/index.md
+++ b/src/archive/dev-news-briefs/2012-12-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: December 03, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2012-12-20/index.md
+++ b/src/archive/dev-news-briefs/2012-12-20/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: December 20, 2012 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2013-01-11/index.md
+++ b/src/archive/dev-news-briefs/2013-01-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 11, 2013 Galaxy Development News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2013-02-08/index.md
+++ b/src/archive/dev-news-briefs/2013-02-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: February 8, 2013 Galaxy News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2013-04-01/index.md
+++ b/src/archive/dev-news-briefs/2013-04-01/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 1, 2013 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2013-06-03/index.md
+++ b/src/archive/dev-news-briefs/2013-06-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: June 3, 2013 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2013-08-12/index.md
+++ b/src/archive/dev-news-briefs/2013-08-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 12, 2013 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2013-11-04/index.md
+++ b/src/archive/dev-news-briefs/2013-11-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: November 04, 2014 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2014-02-10/index.md
+++ b/src/archive/dev-news-briefs/2014-02-10/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: February 10, 2014 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2014-04-14/index.md
+++ b/src/archive/dev-news-briefs/2014-04-14/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 14, 2014 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2014-06-02/index.md
+++ b/src/archive/dev-news-briefs/2014-06-02/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: June 2, 2014 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2014-08-11/index.md
+++ b/src/archive/dev-news-briefs/2014-08-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 11, 2014 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2014-10-06/index.md
+++ b/src/archive/dev-news-briefs/2014-10-06/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October 06, 2014 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2015-01-13/index.md
+++ b/src/archive/dev-news-briefs/2015-01-13/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 13, 2015 Galaxy Distribution News Brief
 ---
 <div class='right'></div>

--- a/src/archive/dev-news-briefs/2015-03/index.md
+++ b/src/archive/dev-news-briefs/2015-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: March 2015 Galaxy Release (v 15.03)
 ---
 <div class='right'></div>

--- a/src/cite-u-like/index.md
+++ b/src/cite-u-like/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 ![citeulike](/src/images/logos/CiteULikeLogo.png)
 

--- a/src/citing-galaxy/index.md
+++ b/src/citing-galaxy/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Citing Galaxy
 ---
 <div class='center'><a href='http://genomebiology.com/2010/11/8/R86'><img src="/src/citing-galaxy/GenomeBiologyColver20108.gif" alt="Genome Biology" height="125" /></a> 

--- a/src/cloud/index.md
+++ b/src/cloud/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy on the Cloud
 ---
 Researchers' compute requirements vary widely over time and formerly required either buying and maintaining compute resources (with most of it idle, most of the time), or reserving time and a fixed amount of compute resources on institutional clusters.

--- a/src/cloud/jetstream/faq/index.md
+++ b/src/cloud/jetstream/faq/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Frequently Asked Questions for Galaxy on Jetstream
 ---
 See [Learn/FAQ](/src/learn/faq/index.md) for questions about using any Galaxy instance.  

--- a/src/cloud/jetstream/index.md
+++ b/src/cloud/jetstream/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy on Jetstream
 ---
 {{> Cloud/Jetstream/LinkBox }}

--- a/src/cloud/jetstream/ssh/index.md
+++ b/src/cloud/jetstream/ssh/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Cloud/Jetstream/LinkBox }}
 

--- a/src/cloud/jetstream/storage/index.md
+++ b/src/cloud/jetstream/storage/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Using volume storage
 ---
 [Jetstream instances](http://jetstream-cloud.org/general-vms.php) come with a

--- a/src/cloud/jetstream/troubleshooting/index.md
+++ b/src/cloud/jetstream/troubleshooting/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Troubleshooting Galaxy on Jetstream
 ---
 {{> Cloud/Jetstream/LinkBox }}

--- a/src/cloudman/CustomizeGalaxyCloud.md
+++ b/src/cloudman/CustomizeGalaxyCloud.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Customizing Galaxy CloudMan
 ---
 ## Adding system users to the cluster

--- a/src/cloudman/aws/capacity-planning/index.md
+++ b/src/cloudman/aws/capacity-planning/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> CloudMan/LinkBoxHorizontal }}
 

--- a/src/cloudman/aws/getting-started/index.md
+++ b/src/cloudman/aws/getting-started/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Getting Started with Galaxy CloudMan
 ---
 {{> CloudMan/Header }}

--- a/src/cloudman/building/index.md
+++ b/src/cloudman/building/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Building Galaxy CloudMan components
 ---
 {{> CloudMan/LinkBoxHorizontal }}

--- a/src/cloudman/capacity-planning/index.md
+++ b/src/cloudman/capacity-planning/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> CloudMan/Header }}
 

--- a/src/cloudman/cluster-types/index.md
+++ b/src/cloudman/cluster-types/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> CloudMan/Header }}
 

--- a/src/cloudman/customizing/index.md
+++ b/src/cloudman/customizing/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Customizing Galaxy CloudMan
 ---
 {{> CloudMan/LinkBoxHorizontal }}

--- a/src/cloudman/faq/index.md
+++ b/src/cloudman/faq/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Frequently Asked Questions for CloudMan
 ---
 {{> CloudMan/LinkBoxHorizontal }}

--- a/src/cloudman/getting-started/index.md
+++ b/src/cloudman/getting-started/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Getting Started with Galaxy on the Cloud
 ---
 {{> CloudMan/LinkBoxHorizontal }}

--- a/src/cloudman/getting-started/pre201703/index.md
+++ b/src/cloudman/getting-started/pre201703/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Getting Started with Galaxy on the Cloud
 ---
 {{> CloudMan/Header }}

--- a/src/cloudman/index.md
+++ b/src/cloudman/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'><img src="/src/images/galaxy-logos/cloudman-logo.jpg" alt="CloudMan" width="60%" /></div>
 

--- a/src/cloudman/services/galaxy/index.md
+++ b/src/cloudman/services/galaxy/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='right'></div> 
 

--- a/src/cloudman/sharing/index.md
+++ b/src/cloudman/sharing/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Cloning and sharing CloudMan clusters
 ---
 {{> CloudMan/LinkBoxHorizontal }}

--- a/src/cloudman/troubleshooting/index.md
+++ b/src/cloudman/troubleshooting/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> CloudMan/Header }}
 

--- a/src/community/deployment/index.md
+++ b/src/community/deployment/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Deployment Catalog
 ---
 <div class='right'></div>

--- a/src/community/galaxy-admins/future/index.md
+++ b/src/community/galaxy-admins/future/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: [GalaxyAdmins](/src/GalaxyAdmins/index.md) Future Directions
 ---
 <div class='center'>

--- a/src/community/galaxy-admins/meetups/2012-07-09/index.md
+++ b/src/community/galaxy-admins/meetups/2012-07-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: 2012-07-09 Conference Call
 ---
 <div class='center'><a href='/src/community/galaxy-admins/index.md'><img src="/src/images/logos/GalaxyAdmins.png" alt="GalaxyAdmins" /></a></div>

--- a/src/community/galaxy-admins/surveys/2012/index.md
+++ b/src/community/galaxy-admins/surveys/2012/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'><a href='/src/community/galaxy-admins/index.md'><img src="/src/images/logos/GalaxyAdmins.png" alt="GalaxyAdmins" /></a></div>
 

--- a/src/community/galaxy-admins/surveys/2014/index.md
+++ b/src/community/galaxy-admins/surveys/2014/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'><a href='/src/community/galaxy-admins/index.md'><img src="/src/images/logos/GalaxyAdmins.png" alt="GalaxyAdmins" /></a></div>
 

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The Galaxy Community
 ---
 A vibrant community of contributors is the reason this project exists. The Galaxy team alone cannot possibly maintain enough servers, wrap enough tools, teach enough workshops, implement all needed features, or answer every question on its own. This is why community is vital to our core mission - enabling reproducible research in life sciences and beyond. Members within the Galaxy community are located all around the world and often form subgroups that can differ in size (small versus large) and degree of privacy (public versus private). This page highlights these groups.

--- a/src/community/log/index.md
+++ b/src/community/log/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'><img src="/src/images/logos/LogBoardWText200.png" alt="Galaxy Community Log Board"  /></div>
 

--- a/src/data-libraries/index.md
+++ b/src/data-libraries/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Data Libraries
 ---
 Galaxy data libraries provide a way to conveniently share Galaxy datasets within a group of Galaxy users or with everybody that has access to a specific instance of Galaxy. The biggest advantages of the data libraries are:

--- a/src/data-providers/cookbook/index.md
+++ b/src/data-providers/cookbook/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: [DataProviders](/src/dataProvider/index.md) Cookbook
 ---
 <div class='left'></div>

--- a/src/develop/api/index.md
+++ b/src/develop/api/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy API
 ---
 In addition to being accessible through a web interface, Galaxy can also be accessed programmatically, through shell scripts and other programs.  The web interface is appropriate for things like exploratory analysis, visualization, construction of workflows, and rerunning workflows on new datasets.

--- a/src/develop/gsoc/2015-ideas/index.md
+++ b/src/develop/gsoc/2015-ideas/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 The Galaxy Project was notified its application to be a Google Summer of Code mentor organization in 2015 was **declined**.
 

--- a/src/develop/gsoc/2016/ideas/index.md
+++ b/src/develop/gsoc/2016/ideas/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 Target improvements for 2016 (in part lesson learned from apply and great feedback from Nicole Deflaux and colleagues at Google Genomics.
 

--- a/src/develop/index.md
+++ b/src/develop/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Galaxy development
 

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Galaxy Documentation
 

--- a/src/events/admin-training2016/basics-session/index.md
+++ b/src/events/admin-training2016/basics-session/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Admin Training: Basic Topics
 ---
 {{> Events/AdminTraining2016/Header }}

--- a/src/events/admin-training2016/logistics/index.md
+++ b/src/events/admin-training2016/logistics/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Admin Training Logistics
 ---
 {{> Events/AdminTraining2016/Header }}

--- a/src/events/archive/index.md
+++ b/src/events/archive/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Beyond the Galaxy Event Horizon
 layout: default.pug
 ---

--- a/src/events/asms2013/index.md
+++ b/src/events/asms2013/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: 61st ASMS Conference on Mass Spectrometry and Allied Topics]
 external_url: http://www.asms.org/conferences/annual-conference
 ---

--- a/src/events/bio-it-world2014/w14/index.md
+++ b/src/events/bio-it-world2014/w14/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Workshop 14: Running a Local Galaxy Instance
 ---
 [Adam Kraut](http://bioteam.net/company-leadership/), [Nate Coraor](/src/people/nate/index.md), [Anushka Brownley](http://bioteam.net/company-leadership/), Tristan Lubinski, [James Reaney](http://www.sgi.com/solutions/genomics)

--- a/src/events/gaw2014/index.md
+++ b/src/events/gaw2014/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Australasia Workshop 2014 (GAW 2014)
 ---
 <div class='center'>

--- a/src/events/gcc2012/abstracts/index.md
+++ b/src/events/gcc2012/abstracts/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Abstract submission is now closed
 ---
 {{> Events/GCC2012/PageHeader }}

--- a/src/events/gcc2012/program/breakouts/bioinformatics-training/index.md
+++ b/src/events/gcc2012/program/breakouts/bioinformatics-training/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Bioinformatics Training and Teaching with Galaxy
 ---
 {{> Events/GCC2012/PageHeader }}

--- a/src/events/gcc2012/program/breakouts/end-users/index.md
+++ b/src/events/gcc2012/program/breakouts/end-users/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy End Users
 ---
 {{> Events/GCC2012/PageHeader }}

--- a/src/events/gcc2012/program/breakouts/workflows-and-api/index.md
+++ b/src/events/gcc2012/program/breakouts/workflows-and-api/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy API and Extending it; Workflow Enhancements
 ---
 {{> Events/GCC2012/PageHeader }}

--- a/src/events/gcc2012/program/index.md
+++ b/src/events/gcc2012/program/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Program
 ---
 {{> Events/GCC2012/PageHeader }}

--- a/src/events/gcc2012/training-day/vms/index.md
+++ b/src/events/gcc2012/training-day/vms/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='right'><a href='/src/events/gcc2012/training-day/vms//index.md'><img src="/src/events/gcc2012/GCC2012TrainingDayLogo.png" alt="Training Day" /></a></div>
 

--- a/src/events/gcc2013/abstracts/index.md
+++ b/src/events/gcc2013/abstracts/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Abstracts
 ---
 {{> Events/GCC2013/Header }}

--- a/src/events/gcc2013/abstracts/posters/index.md
+++ b/src/events/gcc2013/abstracts/posters/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Poster Abstracts
 ---
 {{> Events/GCC2013/Header }}

--- a/src/events/gcc2013/abstracts/talks/index.md
+++ b/src/events/gcc2013/abstracts/talks/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Events/GCC2013/Header }}
 

--- a/src/events/gcc2013/bof/index.md
+++ b/src/events/gcc2013/bof/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Birds of a Feather (BoF) Flock Together at GCC2013
 ---
 {{> Events/GCC2013/Header }}

--- a/src/events/gcc2013/lightning/index.md
+++ b/src/events/gcc2013/lightning/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Lightning Talks
 ---
 {{> Events/GCC2013/Header }}

--- a/src/events/gcc2013/logistics/index.md
+++ b/src/events/gcc2013/logistics/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Logistics
 ---
 {{> Events/GCC2013/Header }}

--- a/src/events/gcc2013/organizers/index.md
+++ b/src/events/gcc2013/organizers/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Organizers
 ---
 {{> Events/GCC2013/Header }}

--- a/src/events/gcc2013/program/index.md
+++ b/src/events/gcc2013/program/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Program
 ---
 {{> Events/GCC2013/Header }}

--- a/src/events/gcc2013/training-day/api/index.md
+++ b/src/events/gcc2013/training-day/api/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Events/GCC2013/Header }}
 

--- a/src/events/gcc2014/abstracts/index.md
+++ b/src/events/gcc2014/abstracts/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Abstracts
 ---
 {{> Events/GCC2014/Header }}

--- a/src/events/gcc2014/abstracts/posters/index.md
+++ b/src/events/gcc2014/abstracts/posters/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Events/GCC2014/Header }}
 

--- a/src/events/gcc2014/abstracts/talks/index.md
+++ b/src/events/gcc2014/abstracts/talks/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Events/GCC2014/Header }}
 

--- a/src/events/gcc2014/hackathon/index.md
+++ b/src/events/gcc2014/hackathon/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Hackathon
 ---
 {{> Events/GCC2014/Header }}

--- a/src/events/gcc2014/lightning/index.md
+++ b/src/events/gcc2014/lightning/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Lightning Talks
 ---
 {{> Events/GCC2014/Header }}

--- a/src/events/gcc2014/logistics/index.md
+++ b/src/events/gcc2014/logistics/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Logistics
 ---
 {{> Events/GCC2014/Header }}

--- a/src/events/gcc2014/photos/index.md
+++ b/src/events/gcc2014/photos/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Events/GCC2014/Header }}
 

--- a/src/events/gcc2014/program/index.md
+++ b/src/events/gcc2014/program/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: GCC2014 Program
 ---
 {{> Events/GCC2014/Header }}

--- a/src/events/gcc2014/training-day/admin-walkthrough/index.md
+++ b/src/events/gcc2014/training-day/admin-walkthrough/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Tutorial: Galaxy Installation and Administration
 ---
 {{> Events/GCC2014/Header }}

--- a/src/events/gmod-summer-school2014/index.md
+++ b/src/events/gmod-summer-school2014/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: GMOD Summer School 2014 - Installing Galaxy
 ---
 <div class='right'></div>

--- a/src/events/index.md
+++ b/src/events/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Event Horizon
 layout: events_index.pug
 ---

--- a/src/ftp-upload/index.md
+++ b/src/ftp-upload/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy FTP Upload
 ---
 # File Upload via FTP

--- a/src/galaxy-project/statistics/index.md
+++ b/src/galaxy-project/statistics/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Project Stats
 ---
 This page contains statistics about the [Galaxy Project](/src/galaxy-project/index.md).  This page is updated every January and July, or whenever the project has a grant due, or whenever an advisory board meeting is set to occur.

--- a/src/galaxy-services/index.md
+++ b/src/galaxy-services/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Services
 ---
 Galaxy is available in all sorts of flavors:  This page lists Galaxy services that either aren't fixed servers, or aren't [fully publicly accessible](/src/public-galaxy-servers/index.md) but that are accessible to a larger group than just the host institution's members.  (Most Galaxy instances are *internal* to an organization - they can only be accessed by members of the host institution.)

--- a/src/galaxy-updates/2012-02/index.md
+++ b/src/galaxy-updates/2012-02/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: February 2012 Galaxy Update
 ---
 <div class='center'>**Looking for the [March 2012 Galaxy Update](/src/galaxy-updates/2012-03/index.md)?  Click [here](/src/galaxy-updates/2012-03/index.md).**<br />Sorry about the bad link in the email announcement!  [Dave C](/src/people/dave-clements/index.md)</div>

--- a/src/galaxy-updates/2012-03/index.md
+++ b/src/galaxy-updates/2012-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: March 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-04/index.md
+++ b/src/galaxy-updates/2012-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-05/index.md
+++ b/src/galaxy-updates/2012-05/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: May 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-06/index.md
+++ b/src/galaxy-updates/2012-06/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: June 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-07/index.md
+++ b/src/galaxy-updates/2012-07/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: July 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-08/index.md
+++ b/src/galaxy-updates/2012-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-09/index.md
+++ b/src/galaxy-updates/2012-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: September 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-10/index.md
+++ b/src/galaxy-updates/2012-10/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-11/index.md
+++ b/src/galaxy-updates/2012-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: November 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2012-12/index.md
+++ b/src/galaxy-updates/2012-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: December 2012 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-01/index.md
+++ b/src/galaxy-updates/2013-01/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-02/index.md
+++ b/src/galaxy-updates/2013-02/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: February 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-03/index.md
+++ b/src/galaxy-updates/2013-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: March 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-04/index.md
+++ b/src/galaxy-updates/2013-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-05/index.md
+++ b/src/galaxy-updates/2013-05/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: May 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-06/index.md
+++ b/src/galaxy-updates/2013-06/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: June 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-07/index.md
+++ b/src/galaxy-updates/2013-07/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: July 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-08/index.md
+++ b/src/galaxy-updates/2013-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-09/index.md
+++ b/src/galaxy-updates/2013-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: September 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-10/index.md
+++ b/src/galaxy-updates/2013-10/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-11/index.md
+++ b/src/galaxy-updates/2013-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: November 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2013-12/index.md
+++ b/src/galaxy-updates/2013-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: December 2013 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-01/index.md
+++ b/src/galaxy-updates/2014-01/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-02/index.md
+++ b/src/galaxy-updates/2014-02/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: February 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-03/index.md
+++ b/src/galaxy-updates/2014-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: March 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-04/index.md
+++ b/src/galaxy-updates/2014-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-05/index.md
+++ b/src/galaxy-updates/2014-05/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: May 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-06/index.md
+++ b/src/galaxy-updates/2014-06/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: June 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-07/index.md
+++ b/src/galaxy-updates/2014-07/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: July 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-08/index.md
+++ b/src/galaxy-updates/2014-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-09/index.md
+++ b/src/galaxy-updates/2014-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: September 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-10/index.md
+++ b/src/galaxy-updates/2014-10/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-11/index.md
+++ b/src/galaxy-updates/2014-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: November 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2014-12/index.md
+++ b/src/galaxy-updates/2014-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: December 2014 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2015-01/index.md
+++ b/src/galaxy-updates/2015-01/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 2015 Galaxy Update
 ---
 <div class='right'></div>

--- a/src/galaxy-updates/2015-02/index.md
+++ b/src/galaxy-updates/2015-02/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: February 2015 Galaxy Update
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-03/index.md
+++ b/src/galaxy-updates/2015-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The March 2015 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-04/index.md
+++ b/src/galaxy-updates/2015-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The April 2015 Galactic News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-05/index.md
+++ b/src/galaxy-updates/2015-05/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The May 2015 Galactic News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-06/index.md
+++ b/src/galaxy-updates/2015-06/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The June 2015 Galactic News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-08/index.md
+++ b/src/galaxy-updates/2015-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The August 2015 Galactic News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-09/index.md
+++ b/src/galaxy-updates/2015-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The September 2015 Galactic News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-10/index.md
+++ b/src/galaxy-updates/2015-10/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: The October 2015 Galactic News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-11/index.md
+++ b/src/galaxy-updates/2015-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galactic November News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2015-12/index.md
+++ b/src/galaxy-updates/2015-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galactic December News!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-01/index.md
+++ b/src/galaxy-updates/2016-01/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: It's a new year in the Galaxy!
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-02/index.md
+++ b/src/galaxy-updates/2016-02/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: February 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-03/index.md
+++ b/src/galaxy-updates/2016-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: March 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-04/index.md
+++ b/src/galaxy-updates/2016-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-05/index.md
+++ b/src/galaxy-updates/2016-05/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: May 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-06/index.md
+++ b/src/galaxy-updates/2016-06/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: June 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-07/index.md
+++ b/src/galaxy-updates/2016-07/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: July 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-08/index.md
+++ b/src/galaxy-updates/2016-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-09/index.md
+++ b/src/galaxy-updates/2016-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: September 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-10/index.md
+++ b/src/galaxy-updates/2016-10/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October 2016 Galaxy News
 ---
 <div class='right'>

--- a/src/galaxy-updates/2016-12/index.md
+++ b/src/galaxy-updates/2016-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: December 2016 Galaxy News
 ---
 <div class='right'><a href='/src/galaxy-updates/index.md'><img src="/src/images/galaxy-logos/GalaxyNews.png" alt="Galaxy News" width=150 /></a></div>

--- a/src/galaxy-updates/2017-01/index.md
+++ b/src/galaxy-updates/2017-01/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: January 2017 Galaxy News
 ---
 <div class='right'><a href='/src/galaxy-updates/index.md'><img src="/src/images/galaxy-logos/GalaxyNews.png" alt="Galaxy News" width=150 /></a></div>

--- a/src/galaxy-updates/2017-03/index.md
+++ b/src/galaxy-updates/2017-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: March 2017 Galaxy News
 ---
 <div class='right'><a href='/src/galaxy-updates/index.md'><img src="/src/images/galaxy-logos/GalaxyNews.png" alt="Galaxy News" width=150 /></a></div>

--- a/src/galaxy-updates/2017-04/index.md
+++ b/src/galaxy-updates/2017-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 2017 Galaxy News
 ---
 <div class='right'><a href='/src/galaxy-updates/index.md'><img src="/src/images/galaxy-logos/GalaxyNews.png" alt="Galaxy News" width=150 /></a></div>

--- a/src/galaxy-updates/index.md
+++ b/src/galaxy-updates/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='right'></div>
 

--- a/src/get-involved/index.md
+++ b/src/get-involved/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Get Involved!
 ---
 <div class='right'></div>

--- a/src/images/galaxy-logos/index.md
+++ b/src/images/galaxy-logos/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Project Logos
 ---
 These are current official Galaxy Project logos, using the current version of the Galaxy Logo created by [Petr Kadlec](http://puradesign.cz/en).

--- a/src/issues/index.md
+++ b/src/issues/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Issue Reporting
 ---
 # Galaxy Issue Reporting and Feature Requests

--- a/src/iuc/index.md
+++ b/src/iuc/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Intergalactic Utilities Commission
 ---
 ## Introduction

--- a/src/learn/advanced-workflow/basic-editing-ex/index.md
+++ b/src/learn/advanced-workflow/basic-editing-ex/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Learn/LinkBox }}
 

--- a/src/learn/advanced-workflow/basic-editing/index.md
+++ b/src/learn/advanced-workflow/basic-editing/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 #acl WikiAdminGroup:read,write,revert All:read
 {{> Learn/LinkBox }}

--- a/src/learn/advanced-workflow/extract/index.md
+++ b/src/learn/advanced-workflow/extract/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 #acl WikiAdminGroup:read,write,revert All:read
 {{> Learn/LinkBox }}

--- a/src/learn/advanced-workflow/index.md
+++ b/src/learn/advanced-workflow/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Learn/LinkBox }}
 # Creating Workflows and Advanced Workflow Options

--- a/src/learn/advanced-workflow/tool-panel/index.md
+++ b/src/learn/advanced-workflow/tool-panel/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 #acl WikiAdminGroup:read,write,revert All:read
 {{> Learn/LinkBox }}

--- a/src/learn/custom-genomes/index.md
+++ b/src/learn/custom-genomes/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Custom Genomes
 ---
 # What is a "Custom Reference Genome" ?

--- a/src/learn/datatypes/index.md
+++ b/src/learn/datatypes/index.md
@@ -1,6 +1,5 @@
 ---
 title: Datatypes
-autotoc: true
 ---
 Galaxy is designed to work with many different **datatypes**. Upon file upload,
 **datatype** can be detected and assigned (when possible) or user specified

--- a/src/learn/faq/index.md
+++ b/src/learn/faq/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: [Frequently Asked Questions](/src/faqs/index.md) for Using Galaxy
 ---
 {{> Learn/LinkBox }}

--- a/src/learn/galaxy-ngs101/index.md
+++ b/src/learn/galaxy-ngs101/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy NGS 101
 ---
 <div class='right'></div>

--- a/src/learn/galaxy101/index.md
+++ b/src/learn/galaxy101/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy 101
 ---
 # Introduction to Galaxy

--- a/src/learn/index.md
+++ b/src/learn/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Learn Galaxy
 ---
 There are many approaches to learning how to *use* Galaxy. The most popular is probably to just dive in and use it. Galaxy is simple enough to use that you can do many analyses just by exploring the interface. However, you may miss much of the power this way. 

--- a/src/learn/managing-datasets/index.md
+++ b/src/learn/managing-datasets/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Managing Datasets in Galaxy
 ---
 ***Datasets*** are the inputs and outputs of each step in an analysis project in Galaxy. Datasets are associated with at least one History, which can be labeled, manipulated, and shared with anyone, whether they have a Galaxy account or not. **Watch the *["Datasets" video](http://vimeo.com/galaxyproject/datasets1)***

--- a/src/learn/platforms/index.md
+++ b/src/learn/platforms/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 {{> Learn/LinkBox }}
 

--- a/src/learn/screencasts/index.md
+++ b/src/learn/screencasts/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Galaxy Screencasts and Demos
 

--- a/src/learn/visualization/index.md
+++ b/src/learn/visualization/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Visualization in Galaxy
 ---
 ----

--- a/src/learn/visualization/phylogenetic-tree/index.md
+++ b/src/learn/visualization/phylogenetic-tree/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Phyloviz: Interactive Phylogenetic Tree Visualizer for Galaxy
 ---
 Phyloviz is an interactive phylogenetic tree visualizer built for Galaxy to give its users a more effective way to access, manipulate, analyze and present data of phylogenetic tree data on galaxy. 

--- a/src/mailing-lists/index.md
+++ b/src/mailing-lists/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Mailing Lists
 ---
 Mailing lists play a vital role in the Galaxy community:

--- a/src/main/faq/index.md
+++ b/src/main/faq/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Frequently Asked Questions about Main
 ---
 {{> FAQs/LinkBox }}

--- a/src/main/index.md
+++ b/src/main/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Main public site
 ---
 The main Galaxy site at http://usegalaxy.org is an installation of the Galaxy software combined with many common tools and data; this site has been available since 2007 for anyone to analyze their data free of charge. The site provides substantial CPU and disk space, making it possible to analyze large datasets. The site supports thousands of users and hundreds of thousands of jobs per month (see [Project Statistics](/src/galaxy-project/statistics)). It is sustained by [TACC](https://www.tacc.utexas.edu/) hardware using allocation generously provided by the [CyVerse](http://www.cyverse.org/) project.  

--- a/src/main/notices/index.md
+++ b/src/main/notices/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Notices about [Main](/src/main/index.md)
 ---
 Dated notices about known usage issues and solutions specifically for Galaxy's [free public server](/src/main/index.md). For the most current status notices as they are initially posted, please follow us at Twitter: [https://twitter.com/galaxyproject](https://twitter.com/galaxyproject) ([Galaxy on Twitter](/src/galaxy-on-twitter/index.md)).

--- a/src/migrating-tools-from-galaxy-distribution/index.md
+++ b/src/migrating-tools-from-galaxy-distribution/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Migrating tools from the Galaxy distribution to the Galaxy Main Tool Shed
 

--- a/src/new-visualization-page/index.md
+++ b/src/new-visualization-page/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Visualization in Galaxy
 ---
 ### Genome Browser (aka Trackster)

--- a/src/outreach/index.md
+++ b/src/outreach/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 ![PoweredByGalaxy](/src/outreach/powered-by-galaxy/PoweredByGalaxy200.png)
 

--- a/src/people/dave-clements/index.md
+++ b/src/people/dave-clements/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Dave Clements
 ---
 <div class='right'>

--- a/src/public-galaxy-servers/index.md
+++ b/src/public-galaxy-servers/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Publicly Accessible Galaxy Servers
 ---
 ![](/src/public-galaxy-servers/80PlusSlide.png)

--- a/src/release-and-update-process/index.md
+++ b/src/release-and-update-process/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Release and Update Process
 ---
 # Release Process

--- a/src/support/about-galaxy/index.md
+++ b/src/support/about-galaxy/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Support: About Galaxy
 

--- a/src/support/account-quotas/index.md
+++ b/src/support/account-quotas/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Account quotas
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/account/index.md
+++ b/src/support/account/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Registering Accounts
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/commercial/index.md
+++ b/src/support/commercial/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Commercial Galaxy Support
 ---
 <div class='right'></div>

--- a/src/support/compressed-fastq/index.md
+++ b/src/support/compressed-fastq/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Datatype Compressed Fastq
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/datatypes-and-tools/index.md
+++ b/src/support/datatypes-and-tools/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Datatypes and Tools
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/download-data/index.md
+++ b/src/support/download-data/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Downloading Data
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/fastqsanger/index.md
+++ b/src/support/fastqsanger/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Datatype Fastqsanger
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/finding-tools/index.md
+++ b/src/support/finding-tools/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Finding Tools
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/how-jobs-execute/index.md
+++ b/src/support/how-jobs-execute/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: How Jobs Execute
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/index.md
+++ b/src/support/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Support
 ---
 ## Quick Start

--- a/src/support/loading-data/index.md
+++ b/src/support/loading-data/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Loading Data
 ---
 [Back to Support Hub](https://galaxyproject.org/support/)

--- a/src/support/metadata/index.md
+++ b/src/support/metadata/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Metadata
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/missing-history/index.md
+++ b/src/support/missing-history/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Missing History
 ---
 [Back to Support Hub](http://wiki.galaxyproject.org/support/)

--- a/src/support/ncbi-sra-fastq/index.md
+++ b/src/support/ncbi-sra-fastq/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: NCBI SRA Fastq
 ---
 [Back to Support Hub](http://wiki.galaxyproject.org/support/)

--- a/src/support/sci-user-galaxies/index.md
+++ b/src/support/sci-user-galaxies/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Sci User Guild for Running Galaxy
 ---
 [Back to Support Hub](http://wiki.galaxyproject.org/support/)

--- a/src/support/tabular/index.md
+++ b/src/support/tabular/index.md
@@ -1,5 +1,4 @@
 ---
- autotoc: true
  title: Datatype Tabular
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/tool-error/index.md
+++ b/src/support/tool-error/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Job and Tool Error Help
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/support/troubleshoot-an-error/index.md
+++ b/src/support/troubleshoot-an-error/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Troubleshoot an Error
 ---
 [Back to Support Hub](/src/support/index.md)

--- a/src/teach/best-practices/index.md
+++ b/src/teach/best-practices/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Best Practices for Teaching
 ---
 # Use the Best Compute Platform

--- a/src/teach/computing-platforms/index.md
+++ b/src/teach/computing-platforms/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Computing Platforms for Teaching with Galaxy
 ---
 There are many [platform choices](/src/choices/index.md) for training with Galaxy. This page discusses the different options including the benefits and drawbacks of each. First, some introductory concepts:

--- a/src/teach/gtn/index.md
+++ b/src/teach/gtn/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Training Network
 ---
 <img src="GTNLogo600.png" class="img-responsive" alt="Galaxy Training Network">

--- a/src/teach/index.md
+++ b/src/teach/index.md
@@ -1,7 +1,6 @@
 ---
 title: Galaxy Teaching Hub
 skip_title_render: true
-autotoc: true
 ---
 
 <div class='center'><a href='/src/teach/index.md'><img src="/src/images/galaxy-logos/GTNLogo300.png" alt="Galaxy Training Network" width="300" /></a></div>

--- a/src/teach/materials/index.md
+++ b/src/teach/materials/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Teaching with Galaxy: Materials
 ---
 {{> Teach/Header }}

--- a/src/teach/resource/galaxy-project-workshop2015/index.md
+++ b/src/teach/resource/galaxy-project-workshop2015/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title:  Galaxy Project Workshop 2015 
 ---
 <div class='right'></div>

--- a/src/teach/resources/index.md
+++ b/src/teach/resources/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy Training: Resources
 ---
 {{> Teach/Header }}

--- a/src/teach/trainers/index.md
+++ b/src/teach/trainers/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Galaxy Trainer Directory
 

--- a/src/team-set-up/index.md
+++ b/src/team-set-up/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Team Set up
 

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Tools in Galaxy
 

--- a/src/toolshed/a-tool-or-a-suite-per-repository/index.md
+++ b/src/toolshed/a-tool-or-a-suite-per-repository/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main Tool Shed](/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/api/index.md
+++ b/src/toolshed/api/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main Tool Shed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/contributions/2014-12/index.md
+++ b/src/toolshed/contributions/2014-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: December, 2014 Galaxy Tool Shed Contributions
 ---
 * [Wiki Root](/src/toolshed/index.md)

--- a/src/toolshed/contributions/2015-04/index.md
+++ b/src/toolshed/contributions/2015-04/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: April 2015 Tool Shed Contributions
 ---
 * [Wiki Root](/src/toolshed/index.md)

--- a/src/toolshed/contributions/2015-07/index.md
+++ b/src/toolshed/contributions/2015-07/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: June and July 2015 Tool Shed Contributions
 ---
 [Wiki Root](/src/toolshed/index.md)

--- a/src/toolshed/contributions/2015-08/index.md
+++ b/src/toolshed/contributions/2015-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: August 2015 Tool Shed Contributions
 ---
 * [Wiki Root](/src/toolshed/index.md)

--- a/src/toolshed/contributions/2015-09/index.md
+++ b/src/toolshed/contributions/2015-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: September 2015 Tool Shed Contributions
 ---
 * [Wiki Root](/src/toolshed/index.md)

--- a/src/toolshed/contributions/2015-11/index.md
+++ b/src/toolshed/contributions/2015-11/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: October-November 2015 Tool Shed Contributions
 ---
 * [Wiki Root](/src/toolshed/index.md)

--- a/src/toolshed/contributions/2015-12/index.md
+++ b/src/toolshed/contributions/2015-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-01/index.md
+++ b/src/toolshed/contributions/2016-01/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-02/index.md
+++ b/src/toolshed/contributions/2016-02/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-03/index.md
+++ b/src/toolshed/contributions/2016-03/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-05/index.md
+++ b/src/toolshed/contributions/2016-05/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-06/index.md
+++ b/src/toolshed/contributions/2016-06/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-07/index.md
+++ b/src/toolshed/contributions/2016-07/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-08/index.md
+++ b/src/toolshed/contributions/2016-08/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-09/index.md
+++ b/src/toolshed/contributions/2016-09/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-10/index.md
+++ b/src/toolshed/contributions/2016-10/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2016-12/index.md
+++ b/src/toolshed/contributions/2016-12/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2017-02/index.md
+++ b/src/toolshed/contributions/2017-02/index.md
@@ -1,6 +1,5 @@
 ---
 title: Tools contributed to the Galaxy Project Tool Shed in [January and February 2017](/src/galaxy-updates/2017-03/index.md).
-autotoc: true
 ---
 * [Wiki Root](/src/toolshed/index.md)
 * [All monthly summaries](/src/toolshed/contributions/index.md)

--- a/src/toolshed/contributions/2017-03/index.md
+++ b/src/toolshed/contributions/2017-03/index.md
@@ -1,6 +1,5 @@
 ---
 title: March 2017 Tool Shed contributions
-autotoc: true
 ---
 Tools contributed to the Galaxy Project Tool Shed in [March 2017](/src/galaxy-updates/2017-04/index.md).
 

--- a/src/toolshed/datatypes-features/index.md
+++ b/src/toolshed/datatypes-features/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main Tool Shed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/galaxy-utilities-in-repositories/index.md
+++ b/src/toolshed/galaxy-utilities-in-repositories/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main Tool Shed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/index.md
+++ b/src/toolshed/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # Galaxy ToolShed
 

--- a/src/toolshed/migrating-tools-from-galaxy-distribution/index.md
+++ b/src/toolshed/migrating-tools-from-galaxy-distribution/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'><img src="/src/images/logos/ToolShed.jpg" alt="Galaxy Main Tool Shed" height="174" /></a> </div>
 

--- a/src/toolshed/publish-tool/index.md
+++ b/src/toolshed/publish-tool/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # How to publish a tool in the Tool Shed
 

--- a/src/toolshed/readme-files/index.md
+++ b/src/toolshed/readme-files/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main Tool Shed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/repository-revisions/index.md
+++ b/src/toolshed/repository-revisions/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main ToolShed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/reviewing-toolshed-repositories/index.md
+++ b/src/toolshed/reviewing-toolshed-repositories/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main ToolShed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/searching-the-toolshed/index.md
+++ b/src/toolshed/searching-the-toolshed/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main ToolShed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/toolshed/workflow-sharing/index.md
+++ b/src/toolshed/workflow-sharing/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <div class='center'> <a href='http://toolshed.g2.bx.psu.edu'>![Galaxy Main ToolShed](/src/images/logos/ToolShed.jpg)</a> </div>
 

--- a/src/tutorials/collections/index.md
+++ b/src/tutorials/collections/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Processing many samples at once with collections
 ---
 # Processing many samples at once

--- a/src/tutorials/g101/index.md
+++ b/src/tutorials/g101/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Galaxy 101
 ---
 [//]: # (Here Hugo shortcodes for vimeo have been replaced to bootsrap-based HTML with the folloing command)

--- a/src/tutorials/histories/index.md
+++ b/src/tutorials/histories/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Histories
 ---
 When data is uploaded from your computer or analysis is done on existing data using Galaxy, each output from those steps

--- a/src/tutorials/ngs/index.md
+++ b/src/tutorials/ngs/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Manupulating NGS data with Galaxy
 ---
 <script type="text/javascript"

--- a/src/tutorials/nt_rnaseq/index.md
+++ b/src/tutorials/nt_rnaseq/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Finding and quantifying new transcripts
 ---
 <blockquote>

--- a/src/tutorials/rb_rnaseq/index.md
+++ b/src/tutorials/rb_rnaseq/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: RNAseq - an introduction
 ---
 # RNAseq: Reference-based

--- a/src/tutorials/var_dip/index.md
+++ b/src/tutorials/var_dip/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Finding variants in diploid genomes
 ---
 <script type="text/javascript"

--- a/src/tutorials/var_hap/index.md
+++ b/src/tutorials/var_hap/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Finding variants in haploid genomes
 ---
 # Introduction

--- a/src/user-defined-toolbox-filters/index.md
+++ b/src/user-defined-toolbox-filters/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # User Defined Toolbox Filters
 

--- a/src/virtual-appliances/index.md
+++ b/src/virtual-appliances/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Virtual Appliances
 ---
 <span style="font-size: larger;"> Hey!  This page is under construction! </span>

--- a/src/visualization-setup/index.md
+++ b/src/visualization-setup/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: How to Set Up Visualizations in a Galaxy Instance
 ---
 This page describes the administration steps needed to get Galaxy visualizations working.

--- a/src/visualizations-registry/cookbook/index.md
+++ b/src/visualizations-registry/cookbook/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 <br />
 </div></div>

--- a/src/visualizations-registry/index.md
+++ b/src/visualizations-registry/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 ---
 # The Visualizations Registry
 

--- a/src/wiki-best-practices/index.md
+++ b/src/wiki-best-practices/index.md
@@ -1,5 +1,4 @@
 ---
-autotoc: true
 title: Wiki Best Practices
 ---
 <div class='right'></div>


### PR DESCRIPTION
@clements In addition to a few build process tweaks, this will swap the default of autotoc: true.

It also prevents autotoc'ing on news and events page (where we do not render a toc anyway), saving some build time.