### PR TITLE
Improve collections tutorial

### DIFF
--- a/src/tutorials/collections/index.md
+++ b/src/tutorials/collections/index.md
@@ -5,21 +5,21 @@ title: Processing many samples at once with collections
 <div class="alert alert-warning" role="alert"><i class="fa fa-exclamation-circle" aria-hidden="true"></i> Note:
 <hr>
 	<ul>
-	    <li>you already have basic understanding of how Galaxy works (if you don't, please see [Galaxy 101](/tutorials/g101) tutorial)</li>
+	    <li>you already have a basic understanding of how Galaxy works (if you don't, please see [Galaxy 101](/tutorials/g101) tutorial)</li>
 		<li>you have an account in Galaxy ([see this](/tutorials/g101/#setting-up-galaxy-account) if you don't)</li>
 		<li>you have your browser configured as described [here](/tutorials/g101/#getting-your-display-sorted-out)</li>
 	</ul>
 </div>
 
-Galaxy has a graphical interface where you click on things. If you have just a few items in your history, clicking is easy. But in most real-world analyses you never have just a few datasets. Instead you have many (sometimes thousands).
+Galaxy has a graphical interface where you perform data analysis and organize your data simply by clicking on things. If you have just a few items in your history, clicking is easy. In most real-world analyses you never have just a few datasets, instead you have many (sometimes thousands) and Collections help manage your data to minimize the amount of clicking you have to do. 
 
 
 |      |
 |------|
 |![](/src/tutorials/collections/smallVsLarge.png)|
-|<small>**A history with few datasets** is *easy* to navigate. **A history with many datasets** is *hard* to navigate.</small>
+|<small>**Figure 1. A history with few datasets** is *easy* to navigate. **A history with many datasets** is *hard* to navigate.</small>
 
-Not only clicking on thousands datasets may lead to a severe form of [carpal tunnel syndrome](https://en.wikipedia.org/wiki/Carpal_tunnel_syndrome), it may simply be impossible. **Dataset collections** described here help to resolve this situation and make very large analyses Galaxy-friendly. 
+Not only may clicking on thousands datasets lead to a severe form of [carpal tunnel syndrome](https://en.wikipedia.org/wiki/Carpal_tunnel_syndrome), it may simply be impossible. **Dataset collections** described here help to resolve this situation and make very large analyses Galaxy-friendly. 
 
 # Collections combine datasets to minimize clutter
 
@@ -28,16 +28,16 @@ A typical multi-dataset analysis of next-generation sequencing (NGS) data usuall
 |      |
 |------|
 |![](/src/tutorials/collections/simpleCollection.png)|
-|<small>**A collection** is any number of datasets bundled as a **single** entity. In this example, to, say, map *N* fastq files against the human genome you need to manually start *N* mapping jobs. Yet you first combine individual datasets into a collection, you will only need start mapping job **once** using the collection as input.</small>|
+|<small>**Figure 2. A collection** is any number of datasets bundled as a **single** entity. In this example, to, say, map *N* fastq files against the human genome you need to manually start *N* mapping jobs. Yet if you first combine individual datasets into a collection, you will only need start a mapping job **once** using the collection as input.</small>|
 
 ## Collections reflect data complexity
 
-Previous image shows how multiple fastq datasets can be combined in a single collection. But what if the sequencing data one wants to analyze is from a paired-end (or mate-pair) run where each individual sample is represented by *two* fastq files: forward and reverse? Galaxy collections can accommodate this structure:
+The previous image shows how multiple fastq datasets can be combined in a single collection. But what if the sequencing data one wants to analyze is from a paired-end (or mate-pair) run where each individual sample is represented by *two* fastq files: forward and reverse? Galaxy collections can accommodate this structure:
 
 |      |
 |------|
 |![](/src/tutorials/collections/pairedCollection.png)|
-|<small>**Paired collection** preserves the relationship between read pairs and their respective samples.</small>
+|<small>**Figure 3. Paired collection** preserves the relationship between read pairs and their respective samples.</small>
 
 # Creating collections in practice
 
@@ -45,7 +45,7 @@ Below we explain how collections can be used in Galaxy. We start with an example
 
 ## Creating a collection from datasets in your history
 
-In Galaxy's language there are two interchangeable terms: collection and list. This is because the simplest collections is just a list of datasets.
+In Galaxy's language there are two interchangeable terms: collection and list. This is because the simplest collection is just a list of datasets.
 
 ### A simple collection example
 
@@ -54,7 +54,7 @@ In this example we have six datasets representing single-end (not paired-end) se
 |      |
 |------|
 |![](/src/tutorials/collections/creating_list.png)|
-|<small>**Creating a list (collection) or datasets** (To see a higher resolution image right-click [here](/src/tutorials/collections/creating_list.pdf)). **A**. Click the <i class="fa fa-check-square-o" aria-hidden="true"></i> icon. This will reveal checkboxes to the left of all datasets in the history. **B**. In this case we want to select all datasets, so press "All" button (alternatively datasets can be filtered as shown [here](/tutorials/histories/#searching-for-datasets)). This will put a check mark into all checkboxes. **C**. Click "For all selected..." button. This will reveal a dropdown. **D**. Since this is **not** a paired-end (or mate-pair) data we choose to "Build Dataset List". This will open a dataset collection creator interface. **E**. Within the dataset collection creator interface use the "Name" box to name the dataset. "Hide original elements" checkbox ensures that upon creating the collection the original datasets will be hidden from the history as shown in the next figure. Click "Create list". **F**. A collection named "patients" is now added to the history and original datasets are hidden, so that the history only has one item. **G**. Clicking on collection reveals its content.</small>|
+|<small>**Figure 4. Creating a list (collection) or datasets** (To see a higher resolution image right-click [here](/src/tutorials/collections/creating_list.pdf)). **A**. Click the checkbox<i class="fa-check-square-o" aria-hidden="false"></i> icon. This will reveal checkboxes to the left of all datasets in the history. **B**. In this case we want to select all datasets, so press "All" button (alternatively datasets can be filtered as shown [here](/tutorials/histories/#searching-for-datasets)). This will put a check mark into all checkboxes. **C**. Click "For all selected..." button. This will reveal a dropdown. **D**. Since this is **not** paired-end (or mate-pair) data we will choose to "Build Dataset List". This will open a dataset collection creator interface. **E**. Within the dataset collection creator interface use the "Name" box to name the collection. "Hide original elements" checkbox ensures that upon creating the collection the original datasets will be hidden from the history as shown in the next figure. Click "Create list". **F**. A collection named "patients" is now added to the history and original datasets are hidden, so that the history only has one item. **G**. Clicking on collection reveals its content.</small>|
 
 ### A paired collection example
 
@@ -69,12 +69,12 @@ In this example we have data from three patients. Each is sequenced in paired-en
 | `patient3-f` | Forward dataset for parient 3 |
 | `patient3-r` | Reverse dataset for parient 3 |
 
-This is important because the fact that `-f` and `-r` differentiate forward and reverse datasets will be used by collection creator to organize them into pairs (pane **B** of the figure below). Obviously, there may be other ways forward and reverse read datasets are identified such as `-1` and `-2` or `forward` and `reverse` or any other way. These can be used in exactly the same way we use `-f` and `-r` here.
+This is important because the fact that `-f` and `-r` differentiate forward and reverse datasets will be used by collection creator to organize them into pairs (panel **B** of the figure below). Obviously, there may be other ways forward and reverse read datasets are identified such as `-1` and `-2` or `forward` and `reverse` or any other way. These can be used in exactly the same way we use `-f` and `-r` here.
 
 |      |
 |------|
 |![](/src/tutorials/collections/creating_paired_list.png)|
-|<small>**Creating a list (collection) or datasets** (To see a higher resolution image right-click [here](/src/tutorials/collections/creating_paired_list.pdf)). The starting steps are identical to steps A through C of the previous example. **A**. Here choose "Build List of Dataset pairs" to open dataset collection creator. **B**. In the left text box (highlighter with red box) enter `-f`. These two characters distinguish *forward* datasets in our case. Once this is done matching datasets will appear underneath the text field. In the right text box (highlighted with green) enter `-r`. These two characters distinguish *reverse* datasets in our case. Again, matching datasets will appear under the box. Finally, click "Auto-pair". **C**. Auto-pairing will form dataset pairs. At this point scroll to the bottom of the form, name the collection, and click "Create list". **D**. A new collection will appear in your history. Clicking the collection will reveal its content. **E**. In this example the collection consists of three pairs. **F**. Clicking on any pair will reveal forward and reverse sequence datasets. </small>|
+|<small>**Figure 5. Creating a list (collection) or datasets** (To see a higher resolution image right-click [here](/src/tutorials/collections/creating_paired_list.pdf)). The starting steps are identical to steps A through C of the previous example (figure 4). **A**. Here choose "Build List of Dataset pairs" to open dataset collection creator. **B**. In the left text box (highlighted in red) enter `-f`. These two characters distinguish *forward* datasets in our case. Once this is done matching datasets will appear underneath the text field. In the right text box (highlighted in green) enter `-r`. These two characters distinguish *reverse* datasets in our case. Again, matching datasets will appear under the box. Finally, click "Auto-pair". **C**. Auto-pairing will form dataset pairs. At this point scroll to the bottom of the form, name the collection, and click "Create list". **D**. A new collection will appear in your history. Clicking the collection will reveal its content. **E**. In this example the collection consists of three pairs. **F**. Clicking on any pair will reveal forward and reverse sequence datasets. </small>|
 
 ## Uploading data directly into collections
 
@@ -85,7 +85,7 @@ You can upload data into collections directly bypassing the need to upload datas
 If you have datasets stored on your computer, you can upload them into collection as shown in following video. 
 
 <div class="alert alert-warning" role="alert">
-This approach only works for a relatively small (dozens) number of small (below < 2GB) datasets due to limitations of web browsers.  
+This approach only works for a relatively small (dozens) number of small (below 2GB) datasets due to limitations of web browsers.
 </div>
 
 <div class="embed-responsive embed-responsive-16by9"><iframe src="https://player.vimeo.com/video/217208139?portrait=0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>
@@ -113,7 +113,7 @@ To rename a collection click on its name:
 |      |
 |------|
 |![](/src/tutorials/collections/renaming_collection.png)|
-|<small>**Renaming a collection.** **A**. Click on collection. **B**. Once collection expands, click on its name. **C**. Enter new name and hit Enter. **D**. Go back to history (click "Back to..." link). You may need to refresh history by clicking on the <i class="fa fa-refresh" aria-hidden="true"></i> icon.</small>|
+|<small>**Figure 6. Renaming a collection.** **A**. Click on the collection. **B**. Once the collection expands, click on its name. **C**. Enter a new name and hit Enter. **D**. Go back to history (click "Back to..." link). You may need to refresh the history by clicking on the refresh<i class="fa fa-refresh" aria-hidden="true"></i> icon.</small>|
 
 ## Tagging collections
 
@@ -122,7 +122,7 @@ Collections can be tagged. In particular special name tags described below can p
 |      |
 |------|
 |![](/src/tutorials/collections/tagging_collection.png)|
-|<small>**Tagging a collection**. **A**. Click on collection. **B**. Once collection expands, type tag name in the tagging box. **If want the tag to propagate through the analysis add the hash (`#`) symbol in front of the tag as shown here.** **C**. Hit Enter and go back to history by clicking on "Back to..." link. **D**. Collection is now tagged.</small>|
+|<small>**Figure 7. Tagging a collection**. **A**. Click on collection. **B**. Once collection expands, type tag name in the tagging box. **If you want the tag to propagate through the analysis add the hash (`#`) symbol in front of the tag as shown here.** **C**. Hit Enter and go back to history by clicking the "Back to..." link. **D**. The collection is now tagged.</small>|
 
 ## Using dataset collection tools
 
@@ -131,71 +131,73 @@ Galaxy contains a special set of tools - **Collection operations** - designed fo
 |      |
 |------|
 |![](/src/tutorials/collections/collection_operations.png)|
-|<small>**Collection operations**. **Zip** - combines two collections as a zipper. If you, for example, have two collections representing forward and reverse reads, respectively, this tool can be used to combine them into a single paired collection. **Unzip** - performs opposite of Zip. **Filter Failed** - when running analyses on collections it is possible that some individual analyses on collection elements will fail. This tool allows to filter out failed elements so you can continue your analysis instead of performing it again. **Flatten** - squish collection into a simple list of elements. **Filter from File** - given a file of collection element IDs reduce the collection to only a subset of elements listed in the file. **Relabel from File** - use labels in the file to change the collection element names. **Concatenate** - merge two collection tail-to-head.</small>|
+|<small>**Figure 8. Collection operations**. **Zip** - combines two collections as a zipper. If you, for example, have two collections representing forward and reverse reads, respectively, this tool can be used to combine them into a single paired collection. **Unzip** - performs opposite of Zip. **Filter Failed** - when running analyses on collections it is possible that some individual analyses on collection elements will fail. This tool allows you to filter out failed elements so you can continue your analysis instead of performing it again. **Flatten** - squish collection into a simple list of elements. **Filter from File** - given a file of collection element IDs reduce the collection to only a subset of elements listed in the file. **Relabel from File** - use labels in the file to change the collection element names. **Concatenate** - merge two collection tail-to-head.</small>|
 
 # Using collections
 
-Earlier in this tutorial we have explain what collections are, how they can be created and manipulated. Now let's have a short usage example. 
+Earlier in this tutorial we demonstrated what collections are, how they can be created, and manipulated. Now let's have a short usage example. 
 
 ## Collections are reduced during an analysis
 
-We will start with a paired collection of fastq reads, map them to the human genome, and process mapping results. In this example collection is being *reduced* to a single dataset as analysis of progressing:
+We will start with a paired collection of fastq reads, map them to the human genome, and process mapping results. In this example the collection is being *reduced* to a single dataset as we progress through the analysis pipeline:
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_reduction.png)|
-|<small>**An example of analysis using a collection**. Here analysis begins with a paired collection containing fastq datasets. The entire collection is mapped using BWA (or Bowtie2). The maping step produces another collection as output but this collection is no longer paired (mappers use paired fastq reads to generate a single BAM dataset from each pair). Instead it is a simple list of BAM files. During mapping (see below and also see [this tutorial](/tutorials/ngs/#read-groups)) we set read groups within individual BAM datasets. This effectively labels each read with its origin (e.g., we know that read came from, say, *sample 1*). Because of this we can merge the entire collection of BAM files into a single BAM dataset. Thus - we start with a collection and finish with just a single dataset.</small>|
+|<small>**Figure 9. An example of an analysis using collections**. Here analysis begins with a paired collection containing fastq datasets. The entire collection is mapped using BWA (or Bowtie2). The maping step produces another collection as output but this collection is no longer paired (mappers use paired fastq reads to generate a single BAM dataset from each pair). Instead it is a simple list of BAM files. During mapping (see below and also see [this tutorial](/tutorials/ngs/#read-groups)) we set read groups within individual BAM datasets. This effectively labels each read with its origin (e.g., we know that read came from, say, *sample 1*). Because of this we can merge the entire collection of BAM files into a single BAM dataset. Thus - we start with a collection and finish with just a single dataset.</small>|
 
 We we start with loading a collection into history using any of the methods that have been discussed above:
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_use1.png)|
-|<small>**A collection** is loaded into Galaxy's history.</small>|
+|<small>**Figure 10. A collection** is loaded into Galaxy's history.</small>|
 
 Next, we will tag this collection:
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_use2.png)|
-|<small>**A tagged collection**. Tag "controls" is added as previously described.</small>|
+|<small>**Figure 11. A tagged collection**. The tag "controls" is added as previously described.</small>|
 
-At this point we map contents of the collection using **NGS: Mapping &rarr; BWA-MEM**:
+At this point we map the contents of the collection using **NGS: Mapping &rarr; BWA-MEM**:
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_use3.png)|
-|<small>**Mapping a collection**. Set input control (red arrow) to "Paired Collection". This will allow selecting a collection from the history. Set readgroup dropdown to "Set readgroups (SAM/BAM specifications" (green arrow) and switch the three "Auto-assign" controls to "Yes" (blue arrows). Run the tool.</small>|
+|<small>**Figure 12. Mapping a collection**. Set input type (red arrow) to "Paired Collection". This will allow selecting a collection from the history. Set readgroup dropdown to "Set readgroups (SAM/BAM specifications" (green arrow) and switch the three "Auto-assign" controls to "Yes" (blue arrows). Run the tool.</small>|
 
-Mapping produces another collection containing a list of BAM datasets produced by BWA. In other words every time a tool is run using a collection as input, Galaxy actually runs the tool multiple times on each collection dataset (or a dataset pair in the case of paired data) and bundles outputs into an output collection. 
+Mapping produces another collection containing a list of BAM datasets produced by BWA. In other words every time a tool is run using a collection as input, Galaxy actually runs the tool *N* times on *N* collection elements (or a dataset pair in the case of paired data) and bundles outputs into an output collection. 
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_use4.png)|
-|<small>**Mapping result**. Running BWA will produce another collection in the history. **Note** that tag has propagated onto this collection. This collection contains a list of BAM datasets.</small>|
+|<small>**Figure 13. Mapping result**. Running BWA will produce another collection in the history. **Note** that tag has propagated onto this collection. This collection contains a list of BAM datasets.</small>|
 
-Since while running BWA we have set readgroups info we can now merge a collection into a single BAM dataset using **NGS: Picard &rarr; MargeSam**:
+Since we have assigned readgroup information while running BWA we can now merge a collection into a single BAM dataset using **NGS: Picard &rarr; MergeSam**:
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_use5.png)|
-|<small>**Merging collection** into a single BAM dataset. **Note** that in order to make collections visible to the tool interface you need to click on the <i class="fa fa-folder-o" aria-hidden="true"></i> button.</small>
+|<small>**Figure 14. Merging collection** into a single BAM dataset. **Note** that in order to make collections visible to the tool interface you need to click on the folder<i class="fa fa-folder-o" aria-hidden="true"></i> button.</small>
+
+We have now aligned our reads and merged them to a single file for downstream analysis. Using collections allowed us to execute these operations on groups of samples with minimal clicking.
 
 ## Other analysis outlines
 
-Going forward collections will become the dominant way to represent data within Galaxy. Here are some example of how collections can be used in major NGS applications. In first example provides a high level summary of how collection will help performing a typical RNA-seq analysis of differential gene expression:
+Going forward collections will become the dominant way to represent and manage data within Galaxy. Here are some examples of how collections can be used in typical NGS applications. The first example (below) provides a high level summary of how collections will help performing a typical RNA-seq analysis of differential gene expression:
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_rna.png)|
-|<small>**Example of RNA-seq analysis**. This example starts with multiple paired end datasets representing two conditions. For each condition experiments are performed in several replicates. The analysis proceeds by creating two collections that are analyzed in parallel (the tagging feature described above should make this analysis very straightforward). The DeSeq2 tools reduces collections into a single table listing changes in gene expression between the two conditions (see [RNA seq tutorial](/tutorials/nt_rnaseq/) for full fledged explanation).</small>|
+|<small>**Figure 15. Example of RNA-seq analysis**. This example starts with multiple paired end datasets representing two conditions with several replicates. The analysis proceeds by creating two collections that are analyzed in parallel (the tagging feature described above should make this analysis very straightforward), where reads are mapped to a genome and the mapped reads are then counted upstream of the DeSeq2 tool, whcih reduces the collections into a single table listing changes in gene expression between the two conditions (see [RNA seq tutorial](/tutorials/nt_rnaseq/) for a comprehensive explanation).</small>|
 
 The next analysis highlights main steps if initial processing of ChIP-seq data:
 
 |      |
 |------|
 |![](/src/tutorials/collections/collection_chip.png)|
-|<small>**Example of ChIP-eq analysis**. Here three collections are used to represent data for two ChIP experiments (TF1 and TF2) as well as input DNA control data. The peak calling is performed on individual pairs of TF and Input data as well as on combination of all datasets.</small>|
+|<small>**Figure 16. Example of ChIP-eq analysis**. Here three collections are used to represent data for two ChIP experiments (TF1 and TF2) as well as input DNA control data. The peak calling is performed on individual pairs of TF and input data as well as on combination of all datasets.</small>|
 
 # The future
 


### PR DESCRIPTION
Numbered figures for future reference.
Changed wording in few sections. 

Are the 'filter from file', relabel from file', and 'concatenate' tools for collections moving to Main (soon)?
In figure 12, why are there three seemingly redundant 'Auto-assign' buttons?
In figure 16, wouldn't the called peaks be merged (and not the mapped reads)?

Not fixed: 
- references to icons in figures 4a, 6d, 14,