### PR TITLE
Add dev news brief index

### DIFF
--- a/build.coffee
+++ b/build.coffee
@@ -143,6 +143,10 @@ ms = metalsmith(__dirname)
             pattern: "news/*/*.md"
             sortBy: "date"
             reverse: true
+        devnewsbrief:
+            pattern: "archive/dev-news-briefs/*/*.md"
+            sortBy: "date"
+            reverse: true
         events:
             pattern: "events/*/*.md"
             sortBy: "date"

--- a/layouts/devnewsbrief_index.pug
+++ b/layouts/devnewsbrief_index.pug
@@ -1,0 +1,19 @@
+extends layout.pug
+
+block content
+    div.col-md-12
+        section.section-content
+            h1 !{ title }
+            div !{ contents }
+
+            table.table.table-striped
+                tbody
+                    each item in devnewsbrief
+                        tr
+                            td: span.text-nowrap #{helpers.moment(item.date).format("MMMM Do YYYY")}
+                            td: a( href=item.link ) #{item.title}
+                            td: p.small
+                                if item.tease
+                                    | #{item.tease}
+                                else
+                                    | !{helpers._.replace(helpers._.replace(helpers.marked(item.contents), /(<.+?\>|&nbsp;)/g, ''),/\s+/g,' ').slice(0,80) + "..."}

--- a/src/archive/dev-news-briefs/2010-06-08/index.md
+++ b/src/archive/dev-news-briefs/2010-06-08/index.md
@@ -1,4 +1,6 @@
-# June 8, 2010 New Development News Brief
+---
+title: Development News Brief
+date: 2010-06-07
 ---
 
 Here are the highlights of what you will get if you perform the following upgrade:

--- a/src/archive/dev-news-briefs/2010-06-21/index.md
+++ b/src/archive/dev-news-briefs/2010-06-21/index.md
@@ -1,6 +1,7 @@
-# June 21, 2010 New Development News Brief
-
-----
+---
+title: Development News Brief
+date: 2010-06-21
+---
 
 Here are the highlights of what you will get if you perform the following upgrade:
 

--- a/src/archive/dev-news-briefs/2010-07-16/index.md
+++ b/src/archive/dev-news-briefs/2010-07-16/index.md
@@ -1,5 +1,6 @@
 ---
-title: July 16, 2010 New Development News Brief
+title: Development News Brief
+date: 2010-07-16
 ---
 Here are the highlights of what you will get if you perform the following upgrade:
 

--- a/src/archive/dev-news-briefs/2010-07-26/index.md
+++ b/src/archive/dev-news-briefs/2010-07-26/index.md
@@ -1,6 +1,7 @@
-# July 26, 2010 New Development News Brief
-
-----
+---
+title: Development News Brief
+date: 2010-07-26
+---
 
 Here are the highlights of what you will get if you perform the following upgrade:
 

--- a/src/archive/dev-news-briefs/2010-08-20/index.md
+++ b/src/archive/dev-news-briefs/2010-08-20/index.md
@@ -1,6 +1,7 @@
-# August 20, 2010 New Development News Brief
-
-----
+---
+title: Development News Brief
+date: 2010-08-20
+---
 
 Here are the highlights of what you will get if you perform the following upgrade:
 

--- a/src/archive/dev-news-briefs/2010-09-08/index.md
+++ b/src/archive/dev-news-briefs/2010-09-08/index.md
@@ -1,6 +1,7 @@
-# September 8, 2010 Galaxy Development News Brief
-
-----
+---
+title: Development News Brief
+date: 2010-09-08
+---
 
 Here are the highlights of what you will get if you perform the following upgrade:
 

--- a/src/archive/dev-news-briefs/2010-10-05/index.md
+++ b/src/archive/dev-news-briefs/2010-10-05/index.md
@@ -1,6 +1,7 @@
-# October 5, 2010 Galaxy Development News Brief
-
-----
+---
+title: Development News Brief
+date: 2010-10-05
+---
 
 Here are the highlights of what you will get if you perform the following upgrade:
 

--- a/src/archive/dev-news-briefs/2010-11-24/index.md
+++ b/src/archive/dev-news-briefs/2010-11-24/index.md
@@ -1,6 +1,7 @@
-# November 24, 2010 Galaxy Development News Brief
-
-----
+---
+title: Development News Brief
+date: 2010-11-24
+---
 
 Here are the highlights of the following upgrade:
 

--- a/src/archive/dev-news-briefs/2011-01-31/index.md
+++ b/src/archive/dev-news-briefs/2011-01-31/index.md
@@ -1,4 +1,7 @@
-# January 31, 2011 Galaxy Development News Brief
+---
+title: Development News Brief
+date: 2011-01-31
+---
 
 ----
 [Get Galaxy!](http://bitbucket.org/galaxy/galaxy-central/wiki/GetGalaxy)

--- a/src/archive/dev-news-briefs/2011-02-18/index.md
+++ b/src/archive/dev-news-briefs/2011-02-18/index.md
@@ -1,4 +1,7 @@
-# February 18, 2011 Galaxy Development News Brief
+---
+title: Development News Brief
+date: 2011-02-18
+---
 
 ----
 [Get Galaxy!](http://bitbucket.org/galaxy/galaxy-central/wiki/GetGalaxy)

--- a/src/archive/dev-news-briefs/2011-04-08/index.md
+++ b/src/archive/dev-news-briefs/2011-04-08/index.md
@@ -1,6 +1,8 @@
 ---
-title: April 8, 2011 Galaxy Development News Brief
+title: Development News Brief
+date: 2011-04-08
 ---
+
 ----
 [Get Galaxy!](http://bitbucket.org/galaxy/galaxy-central/wiki/GetGalaxy)
  new: `% hg clone http://www.bx.psu.edu/hg/galaxy galaxy-dist`<br />

--- a/src/archive/dev-news-briefs/2011-05-20/index.md
+++ b/src/archive/dev-news-briefs/2011-05-20/index.md
@@ -1,4 +1,7 @@
-# May 20, 2011 Galaxy Development News Brief
+---
+title: Development News Brief
+date: 2011-05-20
+---
 
 ----
 [Get Galaxy!](http://bitbucket.org/galaxy/galaxy-central/wiki/GetGalaxy)

--- a/src/archive/dev-news-briefs/2011-06-23/index.md
+++ b/src/archive/dev-news-briefs/2011-06-23/index.md
@@ -1,4 +1,7 @@
-# June 23, 2011 Galaxy Development News Brief
+---
+title: Development News Brief
+date: 2011-06-23
+---
 
 ----
 [getgalaxy.org](http://bitbucket.org/galaxy/galaxy-central/wiki/GetGalaxy)

--- a/src/archive/dev-news-briefs/2011-08-30/index.md
+++ b/src/archive/dev-news-briefs/2011-08-30/index.md
@@ -1,5 +1,6 @@
 ---
-title: August 30, 2011 Galaxy Development News Brief
+title: Development News Brief
+date: 2011-08-30
 ---
 ## Get Galaxy
 

--- a/src/archive/dev-news-briefs/2011-10-25/index.md
+++ b/src/archive/dev-news-briefs/2011-10-25/index.md
@@ -1,5 +1,6 @@
 ---
-title: October 25, 2011 Galaxy Development News Brief
+title: Development News Brief
+date: 2011-10-25
 ---
 ## Get Galaxy
 

--- a/src/archive/dev-news-briefs/2011-11-18/index.md
+++ b/src/archive/dev-news-briefs/2011-11-18/index.md
@@ -1,5 +1,6 @@
 ---
-title: November 18, 2011 Galaxy Development News Brief
+title: Development News Brief
+date: 2011-11-18
 ---
 ## Get Galaxy
 

--- a/src/archive/dev-news-briefs/2012-01-20/index.md
+++ b/src/archive/dev-news-briefs/2012-01-20/index.md
@@ -1,6 +1,8 @@
 ---
-title: January 20, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-01-20
 ---
+
 ## Get Galaxy
 
 <div class='left'><a href='http://getgalaxy.org/'><img src="http://galaxy.psu.edu/static/getgalaxy.png" alt="getgalaxy" width="50px" /></a></div>

--- a/src/archive/dev-news-briefs/2012-01-27/index.md
+++ b/src/archive/dev-news-briefs/2012-01-27/index.md
@@ -1,6 +1,8 @@
 ---
-title: January 27, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-01-27
 ---
+
 ## Get Galaxy
 
 <div class='left'><a href='http://getgalaxy.org/'><img src="http://galaxy.psu.edu/static/getgalaxy.png" alt="getgalaxy" width="50px" /></a></div>

--- a/src/archive/dev-news-briefs/2012-03-12/index.md
+++ b/src/archive/dev-news-briefs/2012-03-12/index.md
@@ -1,6 +1,8 @@
 ---
-title: March 12, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-03-12
 ---
+
 # Get Galaxy
 
 <div class='left'><a href='http://getgalaxy.org/'><img src="http://galaxy.psu.edu/static/getgalaxy.png" alt="getgalaxy" width="50px" /></a></div>

--- a/src/archive/dev-news-briefs/2012-05-11/index.md
+++ b/src/archive/dev-news-briefs/2012-05-11/index.md
@@ -1,6 +1,8 @@
 ---
-title: May 11, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-05-11
 ---
+
 # Get Galaxy
 
 <div class='left'><a href='http://getgalaxy.org/'><img src="http://galaxy.psu.edu/static/getgalaxy.png" alt="getgalaxy" width="50px" /></a></div>

--- a/src/archive/dev-news-briefs/2012-07-20/index.md
+++ b/src/archive/dev-news-briefs/2012-07-20/index.md
@@ -1,6 +1,8 @@
 ---
-title: July 20, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-07-20
 ---
+
 # Get Galaxy
 
 <div class='left'><a href='http://getgalaxy.org/'><img src="http://galaxy.psu.edu/static/getgalaxy.png" alt="getgalaxy" width="50px" /></a></div>

--- a/src/archive/dev-news-briefs/2012-09-07/index.md
+++ b/src/archive/dev-news-briefs/2012-09-07/index.md
@@ -1,6 +1,8 @@
 ---
-title: September 07, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-09-07
 ---
+
 # Get Galaxy
 
 <div class='left'><a href='http://getgalaxy.org/'><img src="http://galaxy.psu.edu/static/getgalaxy.png" alt="getgalaxy" width=50 /></a></div>

--- a/src/archive/dev-news-briefs/2012-09-20/index.md
+++ b/src/archive/dev-news-briefs/2012-09-20/index.md
@@ -1,6 +1,8 @@
 ---
-title: September 20, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-09-20
 ---
+
 # Get Galaxy
 
 <div class='left'><a href='http://getgalaxy.org/'><img src="http://galaxy.psu.edu/static/getgalaxy.png" alt="getgalaxy" width=50 /></a></div>

--- a/src/archive/dev-news-briefs/2012-10-05/index.md
+++ b/src/archive/dev-news-briefs/2012-10-05/index.md
@@ -1,6 +1,8 @@
 ---
-title: October 5, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-10-05
 ---
+
 # Get Galaxy
 
 <table>

--- a/src/archive/dev-news-briefs/2012-10-23/index.md
+++ b/src/archive/dev-news-briefs/2012-10-23/index.md
@@ -1,6 +1,8 @@
 ---
-title: October 23, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-10-23
 ---
+
 # Get Galaxy
 
 *** Upgrade NOW for an Important [Security Fix](/src/archive/dev-news-briefs/2012-10-23/index.md#compute_tool_security_fix) ***

--- a/src/archive/dev-news-briefs/2012-11-14/index.md
+++ b/src/archive/dev-news-briefs/2012-11-14/index.md
@@ -1,6 +1,8 @@
 ---
-title: November 14, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-11-14
 ---
+
 # Get Galaxy
 
 <table>

--- a/src/archive/dev-news-briefs/2012-12-03/index.md
+++ b/src/archive/dev-news-briefs/2012-12-03/index.md
@@ -1,6 +1,8 @@
 ---
-title: December 03, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-12-03
 ---
+
 # Get Galaxy
 
 <table>

--- a/src/archive/dev-news-briefs/2012-12-20/index.md
+++ b/src/archive/dev-news-briefs/2012-12-20/index.md
@@ -1,6 +1,8 @@
 ---
-title: December 20, 2012 Galaxy Development News Brief
+title: Development News Brief
+date: 2012-12-20
 ---
+
 # Get Galaxy
 
 <table>

--- a/src/archive/dev-news-briefs/2013-01-11/index.md
+++ b/src/archive/dev-news-briefs/2013-01-11/index.md
@@ -1,6 +1,8 @@
 ---
-title: January 11, 2013 Galaxy Development News Brief
+title: Development News Brief
+date: 2013-01-11
 ---
+
 # Get Galaxy
 
 <table>

--- a/src/archive/dev-news-briefs/2013-02-08/index.md
+++ b/src/archive/dev-news-briefs/2013-02-08/index.md
@@ -1,6 +1,8 @@
 ---
-title: February 8, 2013 Galaxy News Brief
+title: Development News Brief
+date: 2013-02-08
 ---
+
 # Get Galaxy
 
 *Please note new* **upgrade** *syntax*

--- a/src/archive/dev-news-briefs/2013-04-01/index.md
+++ b/src/archive/dev-news-briefs/2013-04-01/index.md
@@ -1,6 +1,8 @@
 ---
-title: April 1, 2013 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2013-04-01
 ---
+
 ```wiki red/solid/light
 Due to a security vulnerability, administrators are strongly encouraged to upgrade to the [April 8, 2013 Security Release](/src/news/2013-04-08-galaxy-security-release/index.md), which is was not included in the original April 1, 2013 distribution.```
 

--- a/src/archive/dev-news-briefs/2013-06-03/index.md
+++ b/src/archive/dev-news-briefs/2013-06-03/index.md
@@ -1,6 +1,8 @@
 ---
-title: June 3, 2013 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2013-06-03
 ---
+
 [All News Briefs](/src/docs/index.md)
 
 <br />

--- a/src/archive/dev-news-briefs/2013-08-12/index.md
+++ b/src/archive/dev-news-briefs/2013-08-12/index.md
@@ -1,6 +1,8 @@
 ---
-title: August 12, 2013 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2013-08-12
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2013_08_12](/src/news/2013-08-12-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2013-11-04/index.md
+++ b/src/archive/dev-news-briefs/2013-11-04/index.md
@@ -1,6 +1,8 @@
 ---
-title: November 04, 2014 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2014-11-04
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2013_11_04](/src/news/2013-11-04-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2014-02-10/index.md
+++ b/src/archive/dev-news-briefs/2014-02-10/index.md
@@ -1,6 +1,8 @@
 ---
-title: February 10, 2014 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2014-02-10
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2014_02_10](/src/news/2014-02-10-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2014-04-14/index.md
+++ b/src/archive/dev-news-briefs/2014-04-14/index.md
@@ -1,6 +1,8 @@
 ---
-title: April 14, 2014 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2014-04-14
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2014_04_14](/src/news/2014-04-14-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2014-06-02/index.md
+++ b/src/archive/dev-news-briefs/2014-06-02/index.md
@@ -1,6 +1,8 @@
 ---
-title: June 2, 2014 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2014-06-02
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2014_06_02](/src/news/2014-06-02-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2014-08-11/index.md
+++ b/src/archive/dev-news-briefs/2014-08-11/index.md
@@ -1,6 +1,8 @@
 ---
-title: August 11, 2014 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2014-08-11
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2014_08_11](/src/news/2014-08-11-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2014-10-06/index.md
+++ b/src/archive/dev-news-briefs/2014-10-06/index.md
@@ -1,6 +1,8 @@
 ---
-title: October 06, 2014 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2014-10-06
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2014_10_06](/src/news/2014-10-06-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2015-01-13-stable-additions/index.md
+++ b/src/archive/dev-news-briefs/2015-01-13-stable-additions/index.md
@@ -1,3 +1,8 @@
+---
+title: Development News Brief
+date: 2015-01-13
+---
+
 # Updates added to the last Galaxy Distribution listed below
 
 These represent changes introduced after the initial release. May also be tracked in [Trello](https://trello.com/galaxyproject).<br />

--- a/src/archive/dev-news-briefs/2015-01-13/index.md
+++ b/src/archive/dev-news-briefs/2015-01-13/index.md
@@ -1,6 +1,8 @@
 ---
-title: January 13, 2015 Galaxy Distribution News Brief
+title: Development News Brief
+date: 2015-01-13
 ---
+
 [All News Briefs](/src/docs/index.md)
 <br />
 [Distribution Summary 2015_01_13](/src/news/2015-01-13-galaxy-distribution/index.md)

--- a/src/archive/dev-news-briefs/2015-03/index.md
+++ b/src/archive/dev-news-briefs/2015-03/index.md
@@ -1,5 +1,6 @@
 ---
 title: March 2015 Galaxy Release (v 15.03)
+date: 2015-03-01
 ---
 [All News Briefs](/src/docs/index.md)
 <br />

--- a/src/archive/dev-news-briefs/2015-05/index.md
+++ b/src/archive/dev-news-briefs/2015-05/index.md
@@ -1,1 +1,0 @@
-Describe DevNewsBriefs/2015_05 here.

--- a/src/archive/dev-news-briefs/index.md
+++ b/src/archive/dev-news-briefs/index.md
@@ -1,0 +1,5 @@
+---
+title: Galaxy Dev News Briefs
+layout: devnewsbrief_index.pug
+---
+


### PR DESCRIPTION
Also regularizes the dates / titles. Needed because [I was migrating wiki.galaxyproject.org links in galaxy](https://github.com/galaxyproject/galaxy/pull/4141) and ran across a link to this which was broken. 