### PR TITLE
Various cleanups of admin documentation

### DIFF
--- a/partials/Admin/Config/Performance/LinkBox.html
+++ b/partials/Admin/Config/Performance/LinkBox.html
@@ -1,12 +1,8 @@
 <div class='linkbox'>
 **[Performance](../../../../Admin/Config/Performance/ProductionServer)**<br />
-----
 [Cluster](../../../../Admin/Config/Performance/Cluster)<br />
-[Apache|](../../../../Admin/Config/ApacheProxy)<br />
-[Nginx|](../../../../Admin/Config/Performance/nginx Proxy)<br />
+[Apache](../../../../Admin/Config/ApacheProxy)<br />
+[Nginx](../../../../Admin/Config/Performance/nginx Proxy)<br />
 [Purge H&D](../../../../Admin/Config/Performance/Purge Histories and Datasets)<br />
 [Scaling](../../../../Admin/Config/Performance/Scaling)<br />
-----
-&uarr; [Config](../../../../Admin/Config)<br />
-&uarr;&uarr; [Admin](../../../../Admin)<br />
 </div>

--- a/src/admin/config/apache-external-user-auth/index.md
+++ b/src/admin/config/apache-external-user-auth/index.md
@@ -1,27 +1,57 @@
 ---
 title: Apache External User Authentication
 ---
-By default, Galaxy manages its own users.  However, it may be more useful at your site to tie into a local authentication system.  Galaxy does not do this itself - it delegates this responsibility to the upstream proxy server (e.g., Apache or Nginx).  The authentication module (basic authentication, mod_auth_kerb, mod_authn_ldap, mod_auth_cas, Cosign, etc.) is responsible for providing a username, which we will pass through the proxy to Galaxy as `$REMOTE_USER`.
 
-In addition to the modules above, `mod_headers` must be enabled in the Apache config, for some types of authentication.
+# Apache External Authentication
 
-### Basic Authentication
+By default, Galaxy manages its own users. However, it may be more useful at your site to tie into a local authentication system. Galaxy does not do this itself - it delegates this responsibility to the upstream proxy server.
+
+The authentication module (basic authentication, `mod_auth_kerb`, `mod_authn_ldap`, `mod_auth_cas`, `Cosign`, etc.) is responsible for providing a username, which we will pass through the proxy to Galaxy as `$REMOTE_USER`.
+
+In addition to the chosen module above, `mod_headers` must be enabled in the Apache config, for some types of authentication.
+
+## Generic Galaxy Configuration
+
+<div class="alert alert-warning" role="alert">
+This section applies to all authentication methods.
+</div>
+
+On the Galaxy side, set `use_remote_user = True` in `galaxy.ini`. If your auth method doesn't provide a full email address in `$(REMOTE_USER`, you'll also need to set `remote_user_maildomain`:
+
+```
+use_remote_user = True
+remote_user_maildomain = example.org
+```
+
+For example, when using basic authentication, only bare usernames (e.g. "`nate`") will be passed to Galaxy. Since Galaxy usernames are full email addresses, `remote_user_maildomain` needs to be set (e.g. to "`example.org`"). On the other hand, auth methods such as `mod_auth_kerb` set the full `nate@example.org` address, so `remote_user_maildomain` should not be set. If you're not sure, Galaxy will tell you via an error message if `remote_user_maildomain` needs to be set.
+
+Users are automatically created in the Galaxy database if the external auth method allows them through. Users created in this manner may not log in if `use_remote_user` is later disabled, since Galaxy does not have a password stored for the user (since the password is managed by the upstream proxy server.)
+
+### API Exception
+
+If you wish your Galaxy to be accessible to command line clients (e.g. bioblend, blend4j, parsec), you will need to add an exception for authentication on the API. Galaxy will still be secure and protected, but non-browser access will be permitted with an API key. If this exception is not provided, many clients will throw errors as they are redirected to the login site under CAS type authentication, or rejected with unauthorized exception.
+
+```apache
+<Location "/api/">
+    Satisfy Any
+    Allow from all
+</Location>
+```
+
+## Basic Authentication
 
 Basic authentication is configured as it is for any other protected portion of your site (other authentication modules are configured differently):
 
 ```apache
-# Define the authentication method
 AuthType Basic
 AuthName Galaxy
 AuthUserFile /home/nate/htpasswd
 Require valid-user
 ```
 
-
 The following options are used to take the `$REMOTE_USER` variable (set by basic authentication) and set it as a header in the proxied environment:
 
 ```apache
-# Define Galaxy as a valid Proxy
 <Proxy http://localhost:8080>
     Order deny,allow
     Allow from all
@@ -34,17 +64,15 @@ RewriteRule . - [E=RU:%1]
 RequestHeader set REMOTE_USER %{RU}e
 ```
 
-
-These new directives should be placed in a `<Location>` block, depending on the directory from which you are serving Galaxy.  Your entire configuration will now look something like this:
+These new directives should be placed in a `<Location>` block, depending on the directory from which you are serving Galaxy. Your entire configuration will now look something like this:
 
 ```apache
-# Define Galaxy as a valid Proxy
 <Proxy http://localhost:8080>
     Order deny,allow
     Allow from all
 </Proxy>
+
 RewriteEngine on
-# Serving
 <Location "/">
     # Define the authentication method
     AuthType Basic
@@ -59,64 +87,44 @@ RewriteEngine on
 </Location>
 ```
 
+### `mod_authnz_ldap`
 
-On the Galaxy side, set `use_remote_user = True` in `galaxy.ini`.  If your auth method doesn't provide a full email address in `$(REMOTE_USER`, you'll also need to set `remote_user_maildomain`:
-
-```
-use_remote_user = True
-remote_user_maildomain = example.org
-```
-
-
-For example, when using basic authentication, only bare usernames (e.g. "`nate`") will be passed to Galaxy.  Since Galaxy usernames are full email addresses, `remote_user_maildomain` needs to be set (e.g. to "`example.org`").  On the other hand, auth methods such as `mod_auth_kerb` set the full `nate@example.org` address, so `remote_user_maildomain` should not be set.  If you're not sure, Galaxy will tell you via an error message if `remote_user_maildomain` needs to be set.
-
-Users are automatically created in the Galaxy database if the external auth method allows them through.  Users created in this manner may not log in if `use_remote_user` is later disabled, since Galaxy does not have a password stored for the user (since the password is managed by Apache).
-
-### mod_authnz_ldap
-
-The Apache `mod_authnz_ldap` module does not set `$REMOTE_USER` like other auth modules.  The following alternate configuration should allow you to use any LDAP attribute as the username to set in `$REMOTE_USER`:
+The Apache `mod_authnz_ldap` module does not set `$REMOTE_USER` like other auth modules. The following alternate configuration should allow you to use any LDAP attribute as the username to set in `$REMOTE_USER`:
 
 ```apache
-# Define Galaxy as a valid Proxy
 <Proxy http://localhost:8080>
     Order deny,allow
     Allow from all
 </Proxy>
-#!highlight apache
+
 <Location "/">
     AuthType Basic
     AuthBasicProvider ldap
-    AuthLDAPURL "ldaps://server:636/ou=People,dc=example,dc=org?uid?sub?(objectClass=person)"
+    AuthLDAPURL "ldaps://ldap.example.com:636/ou=People,dc=example,dc=org?uid?sub?(objectClass=person)"
     Require valid-user
+
     # Set the REMOTE_USER header to the contents of the LDAP query response's "uid" attribute
     RequestHeader set REMOTE_USER %{AUTHENTICATE_uid}e
 </Location>
 ```
 
-
-The `AuthLDAPURL` and variable in which the username is set will vary and is dependent entirely upon the schema/design of your LDAP database.  If your LDAP server is Windows (Active Directory), you may need to use the `%{AUTHENTICATE_sAMAccountName} ` variable.
+The `AuthLDAPURL` and variable in which the username is set will vary and is dependent entirely upon the schema/design of your LDAP database. If your LDAP server is Windows (Active Directory), you may need to use the `%{AUTHENTICATE_sAMAccountName} ` variable.
 
 Note the S/E after substituted variables, transcluded from the [Apache mod_headers](https://httpd.apache.org/docs/2.2/mod/mod_headers.html) documentation:
 
-<table>
-  <tr>
-    <td> %{FOOBAR}e </td>
-    <td> The contents of the environment variable FOOBAR.</td>
-  </tr>
-  <tr>
-    <td> %{FOOBAR}s </td>
-    <td> The contents of the SSL environment variable FOOBAR, if mod_ssl is enabled.</td>
-  </tr>
-</table>
+Variable | Value
+-------- | ------
+`%{FOOBAR}e` | The contents of the environment variable FOOBAR.
+`%{FOOBAR}s` | The contents of the SSL environment variable FOOBAR, if mod_ssl is enabled.
 
+(If anyone has information regarding setting the username under non-https conditions, please provide it!)
 
-
-### mod_auth_kerb
+## `mod_auth_kerb`
 
 If you are deploying kerberos, it is assumed you know the basics of configuring kerberos enabled webpages.
 
 ```apache
-<Location "/galaxy/">
+<Location "/">
         AuthName "Galaxy"
         AuthType Kerberos
         KrbAuthRealms REALM.EDU
@@ -124,38 +132,33 @@ If you are deploying kerberos, it is assumed you know the basics of configuring 
         Krb5Keytab /etc/http_server_realm.edu.keytab
         KrbSaveCredentials On
         Require valid-user
-        RequestHeader set REMOTE_USER %{REMOTE_USER}s # for some reason you need this statement.
+
+        RequestHeader set REMOTE_USER %{REMOTE_USER}s
 </Location>
 ```
-
 
 We chose to seperate out the keytab for apache, hence the use of Krb5Keytab. Normally that defaults to `/etc/krb5.keytab`.
 
 Note the S/E after substituted variables, transcluded from the [Apache mod_headers](https://httpd.apache.org/docs/2.2/mod/mod_headers.html) documentation:
 
-<table>
-  <tr>
-    <td> %{FOOBAR}e </td>
-    <td> The contents of the environment variable FOOBAR.</td>
-  </tr>
-  <tr>
-    <td> %{FOOBAR}s </td>
-    <td> The contents of the SSL environment variable FOOBAR, if mod_ssl is enabled.</td>
-  </tr>
-</table>
+Variable | Value
+-------- | ------
+`%{FOOBAR}e` | The contents of the environment variable FOOBAR.
+`%{FOOBAR}s` | The contents of the SSL environment variable FOOBAR, if mod_ssl is enabled.
 
+(If anyone has information regarding setting the username under non-https conditions, please provide it!)
 
 ## Logging out Basic Auth'd Users
 
-It's [not supposed to be possible](http://httpd.apache.org/docs/1.3/howto/auth.html#basicfaq) due to how HTTP authentication works.
+It's [not supposed to be possible](https://httpd.apache.org/docs/1.3/howto/auth.html#basicfaq) due to how HTTP authentication works.
 
 However, this is a common problem and many people have come up with varying quality solutions:
 
-* http://stackoverflow.com/questions/4163122/http-basic-authentication-log-out/
-* http://stackoverflow.com/questions/233507/how-to-log-out-user-from-web-site-using-basic-authentication
-* http://trac-hacks.org/wiki/TrueHttpLogoutPatch
+* https://stackoverflow.com/questions/4163122/http-basic-authentication-log-out/
+* https://stackoverflow.com/questions/233507/how-to-log-out-user-from-web-site-using-basic-authentication
+* https://trac-hacks.org/wiki/TrueHttpLogoutPatch
 
-This was [discussed on the galaxy-dev mailing list](http://dev.list.galaxyproject.org/Remote-User-Logout-td4663150.html), and the solution provided by Tim Booth is detailed below. Please test this thoroughly before using it in your galaxy.
+This was [discussed on the galaxy-dev mailing list](https://dev.list.galaxyproject.org/Remote-User-Logout-td4663150.html), and the solution provided by Tim Booth is detailed below. Please test this thoroughly before using it in your galaxy.
 
 ### Creating the Logout area
 
@@ -176,19 +179,18 @@ Require user logout
 The `/usr/share/galaxy-server/logout/.htpasswd` file should contain
 
 ```
-#Password is logout.  This in not a secret.
+#Password is logout. This in not a secret.
 logout:$apr1$0eB1iURY$kwqa0c8tXksbjPQLYqr6s.
 ```
 
 
-### Modifications to your universe_wsgi.ini
+### Galaxy Configuration Modifications
 
-You will probably need to add
+You will probably need to add the following to your `$GALAXY_ROOT/config/galaxy.ini`:
 
 ```
 # Not yet tested on IE.
 remote_user_logout_href = javascript:var r=new XMLHttpRequest();r.onreadystatechange=function(){if(r.readyState==4)window.location.replace('logout.html')};r.open('get','logout.html',true,'logout','logout');r.send();
 ```
-
 
 This code sends an AJAX request to `logout.html` with the username and password of "logout" (variables 4 and 5 in the `r.open` snippet)

--- a/src/admin/config/apache-proxy/index.md
+++ b/src/admin/config/apache-proxy/index.md
@@ -1,12 +1,22 @@
-# Apache proxy to Galaxy
+---
+title: Proxying Galaxy with Apache
+---
+
+# Proxying Galaxy with Apache
 
 For various reasons (performance, authentication, etc.) in a production environment, it's recommended to run Galaxy behind a web server proxy. Although any proxy could work, Apache is the most common. Alternatively, we use [nginx](http://nginx.net/) for our public sites, and [details are available](Admin%2FConfig%2FPerformance%2Fnginx+Proxy) for it, too.
 
-Currently the only recommended way to run Galaxy with Apache is using `mod_rewrite` and `mod_proxy`. fastcgi, AJP or similar connectors may be supported in the future.
+Currently the only recommended way to run Galaxy with Apache is using `mod_rewrite` and `mod_proxy`. Either `mod_proxy_uwsgi` or `mod_proxy_http` may be used from there.
 
 To support proxying, the `mod_proxy`, `mod_http_proxy` and `mod_rewrite` modules must be enabled in the Apache config. The main proxy directives, `ProxyRequests` and `ProxyVia` do **not** need to be enabled.
 
+## Prerequisites
+
+Make sure that inbound (and outbound) traffic to the TCP protocol HTTP on port 80 (and HTTPS on port 443 if using SSL) is permitted by your server's firewall/security.
+
+<div class="alert alert-warning" role="alert">
 Please note that Galaxy should _never_ be located on disk inside Apache's `DocumentRoot`. By default, this would expose all of Galaxy (including datasets) to anyone on the web.
+</div>
 
 ## Basic configuration
 
@@ -14,77 +24,163 @@ Please note that Galaxy should _never_ be located on disk inside Apache's `Docum
 
 For a default Galaxy configuration running on [http://localhost:8080/](http://localhost:8080/), the following lines in the Apache configuration will proxy requests to the Galaxy application:
 
-```
-#!highlight apache
+```apache
+# Rewrite
 RewriteEngine on
 RewriteRule ^(.*) http://localhost:8080$1 [P]
 ```
 
-Thus, all requests on your server (for example, [http://www.example.org/](http://www.example.org/)) are now redirected to Galaxy. Because this example uses the "root" of your web server, you may want to use a [VirtualHost](http://httpd.apache.org/docs/2.2/vhosts/) to be able to run other sites from this same server.
+Or, if using `mod_proxy` with HTTP transport
+
+```apache
+ProxyPass / http://127.0.0.1:8080/
+```
+
+Or, if using `mod_proxy` with uWSGI transport
+
+```apache
+ProxyPass / uwsgi://127.0.0.1:4001/
+```
+
+Thus, all requests on your server are now redirected to Galaxy. Because this example uses the "root" of your web server, you may want to use a [VirtualHost](http://httpd.apache.org/docs/2.2/vhosts/) to be able to run other sites from this same server.
 
 If your Apache server is set up to use `mod_security`, you may need to modify the value of the `SecRequestBodyLimit`. The default value on some systems will limit uploads to only a few kilobytes.
 
-Since Apache is more efficient at serving static content, it is best to serve it directly, reducing the load on the Galaxy process and allowing for more effective compression (if enabled), caching, and pipelining. To do so, your configuration will now become:
+Since Apache is more efficient at serving static content, it is best to serve it directly, reducing the load on the Galaxy process and allowing for more effective compression (if enabled), caching, and pipelining. To do so, your configuration will now include the following, where `$GALAXY_ROOT` should be replaced with the filesystem path to your Galaxy installation
 
-```
-#!highlight apache
+```apache
 RewriteEngine on
-RewriteRule ^/static/style/(.*) /home/nate/galaxy-dist/static/june_2007_style/blue/$1 [L]
-RewriteRule ^/static/scripts/(.*) /home/nate/galaxy-dist/static/scripts/packed/$1 [L]
-RewriteRule ^/static/(.*) /home/nate/galaxy-dist/static/$1 [L]
-RewriteRule ^/favicon.ico /home/nate/galaxy-dist/static/favicon.ico [L]
-RewriteRule ^/robots.txt /home/nate/galaxy-dist/static/robots.txt [L]
-RewriteRule ^(.*) http://localhost:8080$1 [P]
+RewriteRule ^/static/style/(.*) $GALAXY_ROOT/static/june_2007_style/blue/$1 [L]
+RewriteRule ^/static/scripts/(.*) $GALAXY_ROOT/static/scripts/packed/$1 [L]
+RewriteRule ^/static/(.*) $GALAXY_ROOT/static/$1 [L]
+RewriteRule ^/favicon.ico $GALAXY_ROOT/static/favicon.ico [L]
+RewriteRule ^/robots.txt $GALAXY_ROOT/static/robots.txt [L]
 ```
 
-You'll need to ensure that filesystem permissions are set such that the user running your Apache server has access to the Galaxy static/ directory.
+You will need to ensure that filesystem permissions are set such that the user running your Apache server has access to the Galaxy static/ directory.
 
 ### Serving Galaxy at a sub directory (such as /galaxy)
 
-It may be necessary to house Galaxy at an address other than the web server root ( [http://www.example.org/galaxy](http://www.example.org/galaxy), instead of [http://www.example.org](http://www.example.org)). Two changes are necessary:
+It may be necessary to house Galaxy at an address other than the web server root (`http://www.example.org/galaxy`), instead of `http://www.example.org`). To do this, you need to make the following changes:
 
-```
-#!highlight apache
+Two changes are necessary:
+
+1. In the apache config, prefix all of the location directives with your prefix, like so:
+
+```apache
 RewriteEngine on
-RewriteRule ^/galaxy$ /galaxy/ [R]
-RewriteRule ^/galaxy/static/style/(.*) /home/nate/galaxy-dist/static/june_2007_style/blue/$1 [L]
-RewriteRule ^/galaxy/static/scripts/(.*) /home/nate/galaxy-dist/static/scripts/packed/$1 [L]
-RewriteRule ^/galaxy/static/(.*) /home/nate/galaxy-dist/static/$1 [L]
-RewriteRule ^/galaxy/favicon.ico /home/nate/galaxy-dist/static/favicon.ico [L]
-RewriteRule ^/galaxy/robots.txt /home/nate/galaxy-dist/static/robots.txt [L]
-RewriteRule ^/galaxy(.*) http://localhost:8080$1 [P]
+RewriteRule ^/galaxy/static/style/(.*) $GALAXY_ROOT/static/june_2007_style/blue/$1 [L]
+RewriteRule ^/galaxy/static/scripts/(.*) $GALAXY_ROOT/static/scripts/packed/$1 [L]
+RewriteRule ^/galaxy/static/(.*) $GALAXY_ROOT/static/$1 [L]
+RewriteRule ^/galaxy/favicon.ico $GALAXY_ROOT/static/favicon.ico [L]
+RewriteRule ^/galaxy/robots.txt $GALAXY_ROOT/static/robots.txt [L]
 ```
 
 Note the first rewrite rule deals with the missing trailing slash problem. If left out, [http://www.example.org/galaxy](http://www.example.org/galaxy) will result in a 404 error.
 
-Additionally, the Galaxy application needs to be aware that it is running with a prefix (for generating URLs in dynamic pages). This is accomplished by configuring a Paste proxy-prefix filter in the `[app:main]` section of `config/galaxy.ini` and restarting Galaxy:
+If you are using `mod_rewrite` for serving:
 
 ```
-#!highlight ini
+RewriteRule ^/galaxy$ /galaxy/ [R]
+RewriteRule ^/galaxy(.*) http://localhost:8080$1 [P]
+```
+
+Or for `proxy_http`/`proxy_uwsgi`:
+
+```
+ProxyPass /galaxy http://127.0.0.1:8080/galaxy
+# or
+ProxyPass /galaxy uwsgi://127.0.0.1:4001/
+```
+
+2. The Galaxy application needs to be aware that it is running with a prefix (for generating URLs in dynamic pages). This is accomplished by configuring a Paste proxy-prefix filter in the `[app:main]` section of `config/galaxy.ini` and restarting Galaxy:
+
+
+```ini
 [filter:proxy-prefix]
 use = egg:PasteDeploy#prefix
 prefix = /galaxy
 
-
 [app:main]
- 
- 
 filter-with = proxy-prefix
 cookie_path = /galaxy
 ```
 
 `cookie_prefix` should be set to prevent Galaxy's session cookies from clobbering each other if running more than one instance of Galaxy in different subdirectories on the same hostname.
 
-## External user authentication
+### SSL
 
-Moved to its [own page](Admin%2FConfig%2FExternalUserAuth), please check there.
+If you place Galaxy behind a proxy address that uses SSL (i.e., `https://` URLs), edit your galaxy location block (e.g. `location /` when served at the root, or something else like `location /galaxy` when served under a prefix)
+
+```apache
+<Location "/">
+    ...
+    RequestHeader set X-URL-SCHEME https
+    ...
+</Location>
+```
+
+Setting `X-URL-SCHEME` makes Galaxy aware of what type of URL it should generate for external sites like Biomart. This should be added to the existing `<Location />` block if you already have one, and adjusted accordingly if you're serving Galaxy from a subdirectory.
+
+## Advanced Configuration Topics
+
+### Compression and caching
+
+All of Galaxy's static content can be cached on the client side, and everything (including dynamic content) can be compressed on the fly. This will decrease download and page load times for your clients, as well as decrease server load and bandwidth usage. To enable, you'll need to load `mod_deflate` and `mod_expires` in your Apache configuration, and then set:
+
+```apache
+<Location "/">
+    ...
+    # Compress all uncompressed content.
+    SetOutputFilter DEFLATE
+    SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip dont-vary
+    SetEnvIfNoCase Request_URI \.(?:t?gz|zip|bz2)$ no-gzip dont-vary
+    SetEnvIfNoCase Request_URI /history/export_archive no-gzip dont-vary
+</Location>
+<Location "/static">
+    # Allow browsers to cache everything from /static for 6 hours
+    ExpiresActive On
+    ExpiresDefault "access plus 6 hours"
+    ...
+</Location>
+```
+
+The contents above should be added to the existing `<Location "/">` block if you already have one, and adjusted accordingly if you're serving Galaxy from a subdirectory.
+
+### Sending files using Apache
+
+Galaxy sends files (e.g. dataset downloads) by opening the file and streaming it in chunks through the proxy server. However, this ties up the Galaxy process, which can impact the performance of other operations (see [Production Server Configuration](/src/admin/config/performance/production-server/index.md) for a more in-depth explanation).
+
+Apache can assume this task instead and as an added benefit, speed up downloads. This is accomplished through the use of `mod_xsendfile`, a 3rd-party Apache module. Dataset security is maintained in this configuration because Apache will still check with Galaxy to ensure that the requesting user has permission to access the dataset before sending it.
+
+To enable it, you must first install `mod_xsendfile`, this is usually available via your OS's repositories. Once done, add the appropriate `LoadModule` directive to your Apache configuration to load the xsendfile module and the `XSendFile` directives to your proxy configuration:
+
+```apache
+<Location "/">
+     XSendFile on
+     XSendFilePath /
+</Location>
+```
+
+Finally edit your `$GALAXY_ROOT/config/galaxy.ini` and make the following change before restarting Galaxy:
+
+```ini
+[app:main]
+apache_xsendfile = True
+```
+
+For this to work, the user under which your nginx server runs will need read access to Galaxy's `$GALAXY_ROOT/database/files/` directory and its contents.
+
+### External user authentication
+
+- [Apache for External Authentication](/src/admin/config/apache-external-user-auth/index.md)
+- [Built-in Galaxy External Authentication](/src/admin/config/external-user-auth/index.md)
 
 ### Display Sites
 
-Display sites such as UCSC work not by sending data directly from Galaxy to UCSC via the client's browser, but by sending UCSC a URL to the data in Galaxy that the UCSC server will retrieve data from. Since enabling authentication will place **all** of Galaxy behind authentication, such display sites will no longer be able to access data via that URL. If `display_servers` is set to a non-empty value in `galaxy/config/galaxy.ini`, this tells Galaxy it should allow the named servers access to data in Galaxy. However, you still need to configure Apache to allow access to the datasets. An example config is provided here that allows the UCSC Main/Test backends:
+Display sites such as UCSC work not by sending data directly from Galaxy to UCSC via the client's browser, but by sending UCSC a URL to the data in Galaxy that the UCSC server will retrieve data from. Since enabling authentication will place **all** of Galaxy behind authentication, such display sites will no longer be able to access data via that URL. If `display_servers` is set to a non-empty value in `$GALAXY_ROOT/config/galaxy.ini`, this tells Galaxy it should allow the named servers access to data in Galaxy. However, you still need to configure Apache to allow access to the datasets. An example config is provided here that allows the UCSC Main/Test backends:
 
-```
-#!highlight apache
+```apache
 <Location "/root/display_as">
     Satisfy Any
     Order deny,allow
@@ -102,71 +198,16 @@ Display sites such as UCSC work not by sending data directly from Galaxy to UCSC
 
 **PLEASE NOTE that this introduces a security hole** , the impact of which depends on whether you have restricted access to the dataset via Galaxy's [internal dataset permissions](Learn%2FSecurity+Features).
 
-- By default, data in Galaxy is public. Normally with a Galaxy server behind authentication in a proxy server this is of little concern since only clients who've authenticated can access Galaxy. However, if display site exceptions are made as shown above, anyone could use those public sites to bypass authentication and view any **public** dataset on your Galaxy server. If you have not changed from the default and most of your datasets are public, you should consider running your own display sites that are also behind authentication rather than using the public ones. 
+- By default, data in Galaxy is public. Normally with a Galaxy server behind authentication in a proxy server this is of little concern since only clients who've authenticated can access Galaxy. However, if display site exceptions are made as shown above, anyone could use those public sites to bypass authentication and view any **public** dataset on your Galaxy server. If you have not changed from the default and most of your datasets are public, you should consider running your own display sites that are also behind authentication rather than using the public ones.
 
-- For datasets for which access has been restricted to one or more roles (i.e. it is no longer "public"), access for reading via external browsers is only allowed for a brief period, when someone with access permission clicks the "display at..." link. During this period, anyone who has the dataset ID would then be able to use the browser to view this dataset. Although such a scenario is unlikely, it is technically possible. 
+- For datasets for which access has been restricted to one or more roles (i.e. it is no longer "public"), access for reading via external browsers is only allowed for a brief period, when someone with access permission clicks the "display at..." link. During this period, anyone who has the dataset ID would then be able to use the browser to view this dataset. Although such a scenario is unlikely, it is technically possible.
 
-## SSL
 
-If you place Galaxy behind a proxy address that uses SSL (e.g. https:_ URLs), set the following in your Apache config: _
-
-```
-#!highlight apache
-<Location "/">
-    RequestHeader set X-URL-SCHEME https
-</Location>
-```
-
-Setting X-URL-SCHEME makes Galaxy aware of what type of URL it should generate for external sites like Biomart. This should be added to the existing `&lt;Location "/"&gt;` block if you already have one, and adjusted accordingly if you're serving Galaxy from a subdirectory.
-
-## Compression and caching
-
-All of Galaxy's static content can be cached on the client side, and everything (including dynamic content) can be compressed on the fly. This will decrease download and page load times for your clients, as well as decrease server load and bandwidth usage. To enable, you'll need to load `mod_deflate` and `mod_expires` in your Apache configuration, and then set:
-
-```
-#!highlight apache
-<Location "/">
-    # Compress all uncompressed content.
-    SetOutputFilter DEFLATE
-    SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip dont-vary
-    SetEnvIfNoCase Request_URI \.(?:t?gz|zip|bz2)$ no-gzip dont-vary
-    SetEnvIfNoCase Request_URI /history/export_archive no-gzip dont-vary
-</Location>
-<Location "/static">
-    # Allow browsers to cache everything from /static for 6 hours
-    ExpiresActive On
-    ExpiresDefault "access plus 6 hours"
-</Location>
-```
-
-The contents of `&lt;Location "/"&gt;` should be added to the existing `&lt;Location "/"&gt;` block if you already have one, and adjusted accordingly if you're serving Galaxy from a subdirectory.
-
-## Sending files using Apache
-
-Galaxy sends files (e.g. dataset downloads) by opening the file and streaming it in chunks through the proxy server. However, this ties up the Galaxy process, which can impact the performance of other operations (see [Admin/Config/Performance/ProductionServer](Admin%2FConfig%2FPerformance%2FProductionServer) for a more in-depth explanation). Apache can assume this task instead and as an added benefit, speed up downloads. This is accomplished through the use of mod\_xsendfile, a 3rd-party Apache module. Dataset security is maintained in this configuration because Apache will still check with Galaxy to ensure that the requesting user has permission to access the dataset before sending it.
-
-To enable it, you must first [download](https://tn123.org/mod_xsendfile/), compile and install mod\_xsendfile. Once done, add the appropriate `LoadModule` directive to your Apache configuration to load the xsendfile module and the `XSendFile` directives to your proxy configuration:
-
-```
-#!highlight apache
-<Location "/">
-     XSendFile on
-     XSendFilePath /
-</Location>
-```
-
-This should be added to the existing `&lt;Location "/"&gt;` block if you already have one, and adjusted accordingly if you're serving Galaxy from a subdirectory.
-
-Note: If you use a version of mod\_xsendfile older than 0.10, use "XSendFileAllowAbove on" instead of "XSendFilePath /"
-
-Finally, set `apache_xsendfile = True` in the `[app:main]` section of `config/galaxy.ini` and restart Galaxy.
-
-## Proxying multiple galaxy worker threads
+### Proxying multiple galaxy worker threads
 
 If you've configured multiple threads for galaxy in the `config/galaxy.ini` file, you will need a `ProxyBalancer` to manage sending requests to each of the threads. You can do that with apache configuration as follows:
 
-```
-#!highlight apache
+```apache
 <Proxy balancer://galaxy>
  BalancerMember http://localhost:8400
  BalancerMember http://localhost:8401
@@ -179,10 +220,10 @@ If you've configured multiple threads for galaxy in the `config/galaxy.ini` file
 RewriteRule ^(.*) balancer://galaxy$1 [P]
 ```
 
-## Allow Encoded Slashes in URLs
+### Allow Encoded Slashes in URLs
 
 Some Galaxy URLs related to Data Managers contain encoded slashes (%2F) in the path and Apache will not serve these URLs by default. To configure Apache to serve URLs with encoded slashes in the path, add the following line to your Apache configuration file:
 
-```
+```apache
 AllowEncodedSlashes NoDecode
 ```

--- a/src/admin/config/external-user-auth/index.md
+++ b/src/admin/config/external-user-auth/index.md
@@ -1,15 +1,18 @@
 ---
 title: External User Authentication
 ---
-By default, Galaxy manages its own users.  However, it may be more useful at your site to tie into a local authentication system.
 
-Galaxy does now do this by itself (Before we needed to use [Nginx](/src/admin/config/nginx-external-user-auth/index.md) or [Apache](/src/admin/config/apache-external-user-auth/index.md) to handle this).
+By default, Galaxy will manage its own users, allowing standard username/password login. However, it may be more useful at your site to tie into an external authentication system like CAS, LDAP, AD, PAM, etc.
 
-### Activate authentication through LDAP
+Galaxy supports LDAP and AD authentication natively, but you must still use upstream [Nginx](/src/admin/config/nginx-external-user-auth/index.md) or [Apache](/src/admin/config/apache-external-user-auth/index.md) for other authentication schemes like CAS.
+
+If you wish to migrate to a Galaxy-native login, from an existing deployment with upstream Apache or Nginx providing the LDAP/AD connectino, you will to set `external = 'f'` in the `galaxy_user` table for all existing users.
+
+# Activate authentication through LDAP
 
 To be able to authenticate your users through the LDAP, we are going to use a configuration file to enter all the required informations.
 
-#### Tell Galaxy to use auth_conf file
+# Tell Galaxy to use auth_conf file
 
 In `config/galaxy.ini`, uncomment the line `auth_config_file = config/auth_conf.xml`:
 
@@ -21,7 +24,7 @@ auth_config_file = config/auth_conf.xml
 ```
 
 
-#### Configure the auth_conf file
+# Configure the auth_conf file
 
 Copy the `config/auth_conf.xml.sample` and name it `config/auth_conf.xml`:
 
@@ -32,13 +35,13 @@ cp config/auth_conf.xml.sample config/auth_conf.xml
 
 Then configure it appropriately to your LDAP (the documentation in the sample file should be enough).
 
-#### Special Case: AD in CRUK
+# Special Case: AD in CRUK
 
 In CRUK, the Active Directory does not allow to get `sAMAccountName`.
 
 We had to find another solution to get the Authentication working, register properly and get the username.
 
-##### Modifications in auth_conf file
+## Modifications in auth_conf file
 
 Here are the modifications we had to do in the `config/auth_conf.xml`:
 
@@ -74,7 +77,3 @@ params['usernameFromWhoami'] = username_from_whoami
 
 
 Launch Galaxy, and try to login :).
-
-### Switching from Nginx or Apache
-
-If you have been using [Nginx](/src/admin/config/nginx-external-user-auth/index.md) or [Apache](/src/admin/config/apache-external-user-auth/index.md) to handle the external authentication, you need to set external = 'f'  in the galaxy_user table for all existing users.

--- a/src/admin/config/index.md
+++ b/src/admin/config/index.md
@@ -1,8 +1,8 @@
-{{> Admin/LinkBox }}
-{{> Admin/Config/Performance/LinkBox }}
-# Galaxy Configuration
+---
+title: Galaxy Configuration for Admins
+---
 
-Hub page for Galaxy configuration.
+{{> Admin/LinkBox }}
 
 ## Production Galaxy
 
@@ -11,7 +11,7 @@ Hub page for Galaxy configuration.
 * [Galaxy Job Configuration](/src/admin/config/jobs/index.md)
 * [Apache Proxy](/src/admin/config/apache-proxy/index.md)
   * [Apache External User Auth](/src/admin/config/apache-external-user-auth/index.md)
-* [Nginx Proxy](/src/admin/config/nginxProxy/index.md)
+* [Nginx Proxy](/src/admin/config/nginx-proxy/index.md)
   * [Nginx External User Auth](/src/admin/config/nginx-external-user-auth/index.md)
 
 ## Tools
@@ -22,7 +22,7 @@ Hub page for Galaxy configuration.
 
 ## External User Databases
 
-* [ Authentication with LDAP/AD](/src/admin/config/external-user-auth/index.md)
+* [Authentication with LDAP/AD](/src/admin/config/external-user-auth/index.md)
 
 ## FTP
 
@@ -31,8 +31,8 @@ Hub page for Galaxy configuration.
 
 ## Other
 
-* [Eggs](/src/admin/config/Eggs/index.md)
+* [Eggs](/src/admin/config/eggs/index.md)
 * [GenomeSpace](/src/admin/config/genome-space/index.md)
 * [User Information (Collecting information during registration)](/src/admin/config/User Information/index.md)
-* [Running on Windows](/src/admin/config/Windows/index.md)
+* [Running on Windows](/src/admin/config/windows/index.md)
 * [Access Control (ACLs)](/src/admin/config/access-control/index.md)

--- a/src/admin/config/index.md
+++ b/src/admin/config/index.md
@@ -17,7 +17,7 @@ title: Galaxy Configuration for Admins
 ## Tools
 
 * [Tool Dependencies](/src/admin/config/tool-dependencies/index.md)
-* [Set up Visualizations](/src/Visualization Setup/index.md)
+* [Set up Visualizations](/src/visualization-setup/index.md)
 * [Collecting Job Metrics](/src/admin/config/job-metrics/index.md)
 
 ## External User Databases
@@ -26,7 +26,7 @@ title: Galaxy Configuration for Admins
 
 ## FTP
 
-* [Upload via FTP](/src/admin/config/Upload via FTP/index.md)
+* [Upload via FTP](/src/admin/config/upload-via-ftp/index.md)
 * [Setup ProFTPd with AD/LDAP auth](/src/admin/config/proftpd-with-ad/index.md)
 
 ## Other

--- a/src/admin/config/nginx-external-user-auth/index.md
+++ b/src/admin/config/nginx-external-user-auth/index.md
@@ -1,8 +1,50 @@
-## External user authentication
+---
+title: Nginx External User Authentication
+---
 
-The setup for external authentication with nginx varies depending on your authentication methods.  Modules exist for [Kerberos](https://github.com/fintler/nginx-mod-auth-kerb) and [LDAP](http://code.google.com/p/nginx-auth-ldap/) authentication, although those have not been tested.  The [PAM](http://en.wikipedia.org/wiki/Pluggable_authentication_module) nginx authentication module has been used with success, and is suitable for use when you can use the system PAM stack to configure the valid authenticators.  Most likely you'll need to recompile nginx to include your desired authentication module, as none of them are included by default.
+# Nginx External Authentication
 
-You'll need to set up your system's PAM stack, doing this is very site-specific depending on your authentication method, although if your //shell accounts// authenticate the same way as your //galaxy users// you can likely copy the PAM configuration.  A PAM configuration that would be suitable for authentication with Kerberos (placed in `/etc/pam.d/nginx` might look like:
+By default, Galaxy manages its own users. However, it may be more useful at your site to tie into a local authentication system. Galaxy does not do this itself - it delegates this responsibility to the upstream proxy server.
+
+The setup for external authentication with nginx varies depending on your authentication methods. Modules exist for [Kerberos](https://github.com/fintler/nginx-mod-auth-kerb) and [LDAP](http://code.google.com/p/nginx-auth-ldap/) authentication, although those have not been tested.
+
+## Generic Galaxy Configuration
+
+<div class="alert alert-warning" role="alert">
+This section applies to all authentication methods.
+</div>
+
+On the Galaxy side, set `use_remote_user = True` in `galaxy.ini`. If your auth method doesn't provide a full email address in `$(REMOTE_USER`, you'll also need to set `remote_user_maildomain`:
+
+```
+use_remote_user = True
+remote_user_maildomain = example.org
+```
+
+For example, when using basic authentication, only bare usernames (e.g. "`nate`") will be passed to Galaxy. Since Galaxy usernames are full email addresses, `remote_user_maildomain` needs to be set (e.g. to "`example.org`"). On the other hand, auth methods such as `mod_auth_kerb` set the full `nate@example.org` address, so `remote_user_maildomain` should not be set. If you're not sure, Galaxy will tell you via an error message if `remote_user_maildomain` needs to be set.
+
+Users are automatically created in the Galaxy database if the external auth method allows them through. Users created in this manner may not log in if `use_remote_user` is later disabled, since Galaxy does not have a password stored for the user (since the password is managed by the upstream proxy server.)
+
+### API Exception
+
+If you wish your Galaxy to be accessible to command line clients (e.g. bioblend, blend4j, parsec), you will need to add an exception for authentication on the API. Galaxy will still be secure and protected, but non-browser access will be permitted with an API key. If this exception is not provided, many clients will throw errors as they are redirected to the login site under CAS type authentication, or rejected with unauthorized exception.
+
+```nginx
+
+location /api {
+    auth_pam off;
+    allow all;
+    ...
+    proxy_pass http://galaxy_app;
+    ...
+}
+```
+
+## PAM
+
+The [PAM](https://en.wikipedia.org/wiki/Pluggable_authentication_module) nginx authentication module has been used with success, and is suitable for use when you can use the system PAM stack to configure the valid authenticators. Most likely you'll need to recompile nginx to include your desired authentication module, as none of them are included by default.
+
+You'll need to set up your system's PAM stack, doing this is very site-specific depending on your authentication method, although if your //shell accounts// authenticate the same way as your //galaxy users// you can likely copy the PAM configuration. A PAM configuration that would be suitable for authentication with Kerberos (placed in `/etc/pam.d/nginx` might look like:
 
 ```
 auth    [success=1 default=ignore]    pam_krb5.so minimum_uid=1000 ignore_k5login
@@ -25,5 +67,8 @@ location / {
 }
 ```
 
-
 The value of `auth_pam_service_name` must match the filename of the pam configuration you created in `/etc/pam.d/`.
+
+## Other
+
+If you have experience with other authentication stacks, please do not hesitate to share.

--- a/src/admin/config/nginx-proxy/index.md
+++ b/src/admin/config/nginx-proxy/index.md
@@ -1,24 +1,36 @@
-# nginx proxy to Galaxy
+---
+title: Proxying Galaxy with Nginx
+---
+
+# Proxying Galaxy with Nginx
 
 [NGINX](http://nginx.org/en/) is a lightweight http server designed with high performance proxying in mind. The public Galaxy sites ([Main](/src/main/index.md) and [Test](/src/test/index.md)) use nginx to proxy rather than Apache for its simple, fast load balancing and other features.
 
 Galaxy should _never_ be located on disk inside nginx's `root`. By default, this would expose all of Galaxy (including datasets) to anyone on the web.
 
-**Prerequisite:**
-make sure that inbound (and outbound) traffic to the TCP protocol HTTP on port 80 and HTTPS on port 443 is permitted by your server's firewall/security. 
+## Prerequisites
+
+Make sure that inbound (and outbound) traffic to the TCP protocol HTTP on port 80 (and HTTPS on port 443 if using SSL) is permitted by your server's firewall/security.
+
+<div class="alert alert-warning" role="alert">
+Please note that Galaxy should _never_ be located on disk inside Nginx's document root. By default, this would expose all of Galaxy (including datasets) to anyone on the web.
+</div>
 
 ## Basic configuration
 
+### Serving Galaxy at the web server root (/)
+
 For a default Galaxy configuration running on [http://localhost:8080/](http://localhost:8080/) (see [SSL](https://github.com/VJalili/galaxy-site/blob/patch-1/src/admin/config/nginxProxy/index.md#ssl) section for HTTPS), the following lines in the nginx configuration will proxy requests to the Galaxy application:
 
-```
-#!highlight nginx
+```nginx
 http {
-    # ... other http stuff ...
+    ...
+
     upstream galaxy_app {
         server localhost:8080;
     }
-    proxy_next_upstream off;
+
+    proxy_next_upstream off;
     server {
         client_max_body_size 10G;
         # ... other server stuff ...
@@ -27,43 +39,47 @@ http {
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        # serve static content for visualization and interactive environment plugins
-        location ~ ^/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
-            alias /srv/galaxy/config/plugins/$plug_type/$vis_name/static/$static_file;
-        }
-    }
+
+        # serve static content for visualization and interactive environment plugins
+        location ~ ^/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+            alias $GALAXY_ROOT/config/plugins/$plug_type/$vis_name/static/$static_file;
+        }
+    }
 }
 ```
-**Note:**
-- Make sure that you either comment out or modify line containing default configuration for enabled sites.
+
+
+**Notes:**
+
+Make sure that you either comment out or modify line containing default configuration for enabled sites.
+
 ```
 include /etc/nginx/sites-enabled/*;
 ```
 
 - The `proxy_next_upstream off;` disables nginx's round-robin scheme to prevent it from submitting POST requests more than once. This is unsafe, and is useful when using more than one upstream.
-- Replace `/srv/galaxy` with the path to your copy of Galaxy. 
+- Replace `$GALAXY_ROOT` with the path to your copy of Galaxy.
 - The parameter `client_max_body_size` specifies the maximum upload size that can be handled by POST requests through nginx. You should set this to the largest file size that could be reasonable handled by your network. It defaults to 1M files, so will probably need to be increased if you are dealing with genome sized datasets.
 
-Since nginx is more efficient at serving static content, it is best to serve it directly, reducing the load on the Galaxy process and allowing for more effective compression (if enabled), caching, and pipelining. To do so, add the following to `server { } `:
+Since nginx is more efficient at serving static content, it is best to serve it directly, reducing the load on the Galaxy process and allowing for more effective compression (if enabled), caching, and pipelining. To do so, add the following to your existing `server { }` block, replacing `$GALAXY_ROOT` with the correct path.:
 
-```
-#!highlight nginx
+```nginx
 http {
     server {
         location /static {
-            alias /srv/galaxy/static;
+            alias $GALAXY_ROOT/static;
         }
         location /static/style {
-            alias /srv/galaxy/static/style/blue;
+            alias $GALAXY_ROOT/static/style/blue;
         }
         location /static/scripts {
-            alias /srv/galaxy/static/scripts;
+            alias $GALAXY_ROOT/static/scripts;
         }
         location /favicon.ico {
-            alias /srv/galaxy/static/favicon.ico;
+            alias $GALAXY_ROOT/static/favicon.ico;
         }
         location /robots.txt {
-            alias /srv/galaxy/static/robots.txt;
+            alias $GALAXY_ROOT/static/robots.txt;
         }
     }
 }
@@ -74,38 +90,38 @@ You'll need to ensure that filesystem permissions are set such that the user run
 
 ### Serving Galaxy at a sub directory (such as /galaxy)
 
-It may be necessary to house Galaxy at an address other than the web server root (i.e., [http://www.example.org/galaxy](http://www.example.org/galaxy), instead of [http://www.example.org](http://www.example.org)). To do this, you need to make the following changes: 
+It may be necessary to house Galaxy at an address other than the web server root (`http://www.example.org/galaxy`), instead of `http://www.example.org`). To do this, you need to make the following changes:
 
 1. In the nginx config, prefix all of the location directives with your prefix, like so:
 
-```
-#!highlight nginx
+```nginx
 http {
     server {
+        ...
+
         location /galaxy {
             proxy_pass http://galaxy_app;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location /galaxy/static {
-            alias /srv/galaxy/static;
+            alias $GALAXY_ROOT/static;
         }
-        #... other galaxy aliases ...
+
+        ...
     }
 }
 ```
 
 2. The Galaxy application needs to be aware that it is running with a prefix (for generating URLs in dynamic pages). This is accomplished by configuring a Paste proxy-prefix filter in the `[app:main]` section of `config/galaxy.ini` and restarting Galaxy:
 
-```
+
+```ini
 [filter:proxy-prefix]
 use = egg:PasteDeploy#prefix
 prefix = /galaxy
 
-
 [app:main]
- 
- 
 filter-with = proxy-prefix
 cookie_path = /galaxy
 ```
@@ -113,36 +129,29 @@ cookie_path = /galaxy
 `cookie_prefix` should be set to prevent Galaxy's session cookies from clobbering each other if running more than one instance of Galaxy in different subdirectories on the same hostname.
 
 
-## SSL
+### SSL
 
-If you place Galaxy behind a proxy address that uses SSL (i.e., `https://` URLs), set the following in your nginx config:
+If you place Galaxy behind a proxy address that uses SSL (i.e., `https://` URLs), edit your galaxy location block (e.g. `location /` when served at the root, or something else like `location /galaxy` when served under a prefix)
 
-```
-#!highlight nginx
-server {
-    listen       443 ssl http2 default_server;
-    listen       [::]:443 ssl http2 default_server;
-    server_name  _;
-    root         /usr/share/nginx/html;
-
-    ssl_certificate "/etc/pki/nginx/server.crt";
-    ssl_certificate_key "/etc/pki/nginx/private/server.key";
-
-    location / {
-        proxy_set_header X-URL-SCHEME https;
-    }
+```nginx
+location / {
+    ...
+    proxy_set_header X-URL-SCHEME https;
+    ...
 }
 ```
 
 Setting `X-URL-SCHEME` makes Galaxy aware of what type of URL it should generate for external sites like Biomart. This should be added to the existing `location / { } ` block if you already have one, and adjusted accordingly if you're serving Galaxy from a subdirectory.
 
-## Compression and caching
+## Advanced Configuration Topics
+
+### Compression and caching
 
 All of Galaxy's static content can be cached on the client side, and everything (including dynamic content) can be compressed on the fly. This will decrease download and page load times for your clients, as well as decrease server load and bandwidth usage. To enable, you'll need nginx gzip support (which is standard unless compiled with `--without-http_gzip_module`), and the following in your `nginx.conf`:
 
-```
-#!highlight nginx
+```nginx
 http {
+    ...
     gzip on;
     gzip_http_version 1.1;
     gzip_vary on;
@@ -151,21 +160,21 @@ http {
     gzip_types text/plain text/css application/x-javascript text/xml application/xml text/javascript application/json application/javascript;
     gzip_buffers 16 8k;
     gzip_disable "MSIE [1-6].(?!.*SV1)";
+    ...
 }
 ```
 
-For caching, you'll need to add an `expires` directive to the `location /static { } ` blocks:
+For caching, you'll need to add an `expires` directive to the `location /static { }` blocks:
 
-```
-#!highlight nginx
+```nginx
 http {
     server {
         location /static {
-            alias /srv/galaxy/static;
+            alias $GALAXY_ROOT/static;
             expires 24h;
         }
         location /static/style {
-            alias /srv/galaxy/static/style/blue;
+            alias $GALAXY_ROOT/static/style/blue;
             expires 24h;
         }
     }
@@ -174,14 +183,15 @@ http {
 
 The contents of `location /static { }` should be adjusted accordingly if you're serving Galaxy from a subdirectory.
 
-## Sending files using nginx
+### Sending files using Nginx
 
-Galaxy sends files (e.g. dataset downloads) by opening the file and streaming it in chunks through the proxy server. However, this ties up the Galaxy process, which can impact the performance of other operations (see [Admin/Config/Performance/ProductionServer](Admin%2FConfig%2FPerformance%2FProductionServer) for a more in-depth explanation). nginx can assume this task instead and as an added benefit, speed up downloads. This is accomplished through the use of the special `X-Accel-Redirect` header. Dataset security is maintained in this configuration because nginx will still check with Galaxy to ensure that the requesting user has permission to access the dataset before sending it.
+Galaxy sends files (e.g. dataset downloads) by opening the file and streaming it in chunks through the proxy server. However, this ties up the Galaxy process, which can impact the performance of other operations (see [Production Server Configuration](/src/admin/config/performance/production-server/index.md) for a more in-depth explanation).
+
+Nginx can assume this task instead and as an added benefit, speed up downloads. This is accomplished through the use of the special `X-Accel-Redirect` header. Dataset security is maintained in this configuration because nginx will still check with Galaxy to ensure that the requesting user has permission to access the dataset before sending it.
 
 To enable it, add the following to your `nginx.conf`:
 
-```
-#!highlight nginx
+```nginx
 http {
     server {
         location /_x_accel_redirect/ {
@@ -192,27 +202,29 @@ http {
 }
 ```
 
-And the following to the `[app:main]` section of `config/galaxy.ini`:
+Finally edit your `$GALAXY_ROOT/config/galaxy.ini` and make the following change before restarting Galaxy:
 
-```
+```ini
+[app:main]
 nginx_x_accel_redirect_base = /_x_accel_redirect
 ```
 
-For this to work, the user under which your nginx server runs will need read access to Galaxy's `database/files/` directory and its contents.
+For this to work, the user under which your nginx server runs will need read access to Galaxy's `$GALAXY_ROOT/database/files/` directory and its contents.
 
-## Receiving files using nginx
+### Receiving files using nginx
 
 Galaxy receives files (e.g. dataset uploads) by streaming them in chunks through the proxy server and writing the files to disk. However, this again ties up the Galaxy process. nginx can assume this task instead and as an added benefit, speed up uploads. This is accomplished through the use of `nginx_upload_module`, a 3rd-party nginx module.
 
 To enable it, you must first [download](http://www.grid.net.ru/nginx/upload.en.html), compile and install `nginx_upload_module`. This means recompiling nginx. Once done, add the necessary directives to `nginx.conf`:
 
-```
-#!highlight nginx
+```nginx
 user galaxy;
 http {
     server {
+        ...
+
         location /_upload {
-            upload_store /srv/galaxy/database/tmp/upload_store;
+            upload_store $GALAXY_ROOT/database/tmp/upload_store;
             upload_pass_form_field "";
             upload_set_form_field " __${upload_field_name}__ is_composite" "true";
             upload_set_form_field " __${upload_field_name}__ keys" "name path";
@@ -221,6 +233,7 @@ http {
             upload_pass_args on;
             upload_pass /_upload_done;
         }
+
         location /_upload_done {
             set $dst /api/tools;
             if ($args ~ nginx_redir=([^&]+)) {
@@ -228,27 +241,30 @@ http {
             }
             rewrite "" $dst;
         }
+
+        ...
     }
 }
 ```
 
 Note the `user` directive. To ensure that Galaxy has write permission on the uploaded files, nginx's workers will need to run as the same user as Galaxy.
 
-Finally, set the following in the `[app:main]` section of `config/galaxy.ini` and restart Galaxy:
+Finally edit your `$GALAXY_ROOT/config/galaxy.ini` and make the following change before restarting Galaxy:
 
 ```
+[app:main]
 nginx_upload_store = database/tmp/upload_store
 nginx_upload_path = /_upload
 ```
 
 When serving Galaxy with a prefix, as described in the serving Galaxy in a sub-directory section above, you will need to change one line in the `\_upload\_done` section. If your galaxy instance is available from `/galaxy`, then the first line should include this prefix:
 
+```nginx
+set $dst /galaxy/api/tools;
 ```
-#!highlight nginx
-            set $dst /galaxy/api/tools;
-```
 
 
-## External User Authentication
+### External User Authentication
 
-[Moved here](/src/admin/config/external-user-auth/index.md)
+- [Nginx for External Authentication](/src/admin/config/nginx-external-user-auth/index.md)
+- [Built-in Galaxy External Authentication](/src/admin/config/external-user-auth/index.md)

--- a/src/admin/config/windows/index.md
+++ b/src/admin/config/windows/index.md
@@ -1,16 +1,22 @@
- 
+---
+title: Galaxy on Windows
+---
 
-## Running Galaxy in Windows
+# Running Galaxy on Windows
 
 Running Galaxy under Windows was possible at one point, with a bit of effort. After recent changes to dependency management (using Python Wheels instead of Eggs) we have no tutorial or proof of concept how to do it. If you really need to run Galaxy on Windows platform please consider running a Virtual Machine with a Linux on it and then follow tutorial at [http://getgalaxy.org](http://getgalaxy.org)
 
 If you want to develop Galaxy tools please consider using the following image with preinstalled Galaxy, Planemo and other useful tools: [http://planemo.readthedocs.org/en/latest/appliance.html#launching-the-appliance-virtualbox-ova](http://planemo.readthedocs.org/en/latest/appliance.html#launching-the-appliance-virtualbox-ova)
 
+## Running Windows Tools
+
+If instead of running a Windows based Galaxy instance, you wish to just run a handful of tools on a Windows server but host Galaxy on a traditional \*nix-based system, the [Pulsar](/src/admin/config/pulsar/index.md) can used to accomplish this.
+
+## Deprecated Instructions
+
 If you were able to set up Galaxy on Windows with Python Wheels please share your experience.
 
 **The text below is outdated.**
-
-* * *
 
 ### Running old Galaxy (pre 16.01) on Windows
 
@@ -38,9 +44,8 @@ Galaxy's egg building script, `scramble.py` may or may not work for certain eggs
 
 First obtain the source code:
 
-```
-#!highlight sh
-% hg clone http://bitbucket.org/james_taylor/bx-python/
+```console
+$ hg clone http://bitbucket.org/james_taylor/bx-python/
 destination directory: bx-python
 requesting all changes
 adding changesets
@@ -53,35 +58,27 @@ updating working directory
 
 Change to the source directory:
 
-```
-#!highlight sh
-% cd bx-python/trunk
+```console
+$ cd bx-python/trunk
 ```
 
 Edit setup.cfg and add the following:
 
-```
-#!highlight sh
+```ini
 [build]
 compiler = mingw32
 ```
 
 Then build the egg (be sure to include the tag from the `[tags]` section of `galaxy_dist/eggs.ini`:
 
-```
-#!highlight sh
-% python setup.py egg_info -b _dev_r4bf1f32e6b76 bdist_egg
+```console
+$ python setup.py egg_info -b _dev_r4bf1f32e6b76 bdist_egg
 ```
 
-Once built, eggs need to be placed in `galaxy_dist/eggs/&lt;platform&gt;`, where <platform> is the platform-specific output of `galaxy_dist/scripts/get_platforms.py`:
+Once built, eggs need to be placed in `$GALAXY_ROOT/eggs/&lt;platform&gt;`, where <platform> is the platform-specific output of `$GALAXY_ROOT/scripts/get_platforms.py`:
 
-```
-#!highlight sh
-% cp dist/bx_python-0.5.0_r4bf1f32e6b76-py2.4-win32.egg galaxy_dist/eggs/<platform>
+```console
+$ cp dist/bx_python-0.5.0_r4bf1f32e6b76-py2.4-win32.egg galaxy_dist/eggs/<platform>
 ```
 
 Once all the required eggs have been built and copied to the proper egg directory, Galaxy can now be run as normal, see [Admin/GetGalaxy](Admin%2FGetGalaxy) to continue.
-
-## Running Windows Tools
-
-If instead of running a Windows based Galaxy instance, you wish to just run a handful of tools on a Windows server but host Galaxy on a traditional \*nix-based system, the [Pulsar](Admin%2FConfig%2FPulsar) can used to accomplish this.

--- a/src/develop/index.md
+++ b/src/develop/index.md
@@ -1,6 +1,7 @@
 ---
 title: Galaxy Development
 ---
+
 This page collects resources that are helpful to development of various aspects of the Galaxy software. It is aimed to provide help to all of the numerous Galaxy's [contributors](https://www.openhub.net/p/galaxybx). We salute you!
 
 If your interest lies in the development of tools for Galaxy please see the [Adding custom tools tutorial](/src/admin/tools/add-tool-tutorial/index.md).
@@ -18,8 +19,8 @@ You can generate your own copy of the documentation. You might want to do this i
 Contribution of documentation is very welcome. To generate the documentation:
 
 1. Install Sphinx
-1. Go to the `doc` directory and run Sphinx with `make html`
-1. Install missing dependencies, and rerun Sphinx until you get working output.
+2. Go to the `doc` directory and run Sphinx with `make html`
+3. Install missing dependencies, and rerun Sphinx until you get working output.
 
 The generated documentation will be in `doc/build/html/` and can be viewed in a web browser.
 


### PR DESCRIPTION
Also synchronizes some of the nginx / apache docs. Also documents the /api exception needed for CLI clients (thanks @bwlang for the config example)

This also (accidentally) includes the same change as #265 and #267 since neither of those were merged yet and I hadn't seen them.