### PR TITLE
Updated link to rendered GTN repository

### DIFF
--- a/src/teach/gtn/index.md
+++ b/src/teach/gtn/index.md
@@ -10,7 +10,7 @@ These pages describes the Galaxy Training Network, and everything else related t
 
 ## Training Resources Directory
 
-The **[Training Resources Directory](https://github.com/galaxyproject/training-material)** is a catalog of training resources for Galaxy.  *Training resources* include tutorials, slides, virtual machines, and entire workshop packages that can be used to teach with Galaxy.
+The **[Training Resources Directory](http://galaxyproject.github.io/training-material/)** is a catalog of training resources for Galaxy.  *Training resources* include tutorials, slides, virtual machines, and entire workshop packages that can be used to teach with Galaxy. Training materials can be created and updated on the GitHub page [here](https://github.com/galaxyproject/training-material).
 
 <div class="alert alert-success" role="alert">Have you created or know of a resource that is useful for teaching with Galaxy? Then please share it! This will help others and also help get the word out about your resource. Use [this Google form](http://bit.ly/gxytrainresourceform) to describe your resource.
 </div>


### PR DESCRIPTION
Replaced the **Training Resources Directory** link to http://galaxyproject.github.io/training-material/, the rendered "beautiful" repository for the training materials. I think this is the default link that should be pointed to as people on this hub page are likely trying to find the link to the actual training materials. Also added a sentence pointing to the training material GitHub page as separate link.