### PR TITLE
Update python-drmaa and slurm-drmaa references

### DIFF
--- a/src/admin/config/performance/cluster/index.md
+++ b/src/admin/config/performance/cluster/index.md
@@ -117,7 +117,7 @@ The value of *local_slots* is used to define [GALAXY_SLOTS](/src/admin/config/ga
 
 ### Dependencies
 
-Galaxy interfaces with DRMAA via [drmaa-python](http://code.google.com/p/drmaa-python/).  The drmaa-python module is provided with Galaxy, but you must tell it where your DRM's DRMAA library is located, via the `$DRMAA_LIBRARY_PATH` environment variable, for example:
+Galaxy interfaces with DRMAA via [drmaa-python](https://github.com/pygridtools/drmaa-python).  The drmaa-python module is provided with Galaxy, but you must tell it where your DRM's DRMAA library is located, via the `$DRMAA_LIBRARY_PATH` environment variable, for example:
 
 ```console
 galaxy_server% export DRMAA_LIBRARY_PATH=/galaxy/lsf/7.0/linux2.6-glibc2.3-x86_64/lib/libdrmaa.so
@@ -129,7 +129,7 @@ galaxy_server% export DRMAA_LIBRARY_PATH=/galaxy/sge/lib/lx24-amd64/libdrmaa.so
 
 **TORQUE**: The DRMAA runner can also be used (instead of the [PBS](/src/admin/config/performance/cluster/index.md#pbs) runner) to submit jobs to TORQUE, however, problems have been reported when using the `libdrmaa.so` provided with TORQUE.  Using this library will result in a segmentation fault when the drmaa runner attempts to write the job template, and any native job runner options will not be passed to the DRM.  Instead, you should compile the [pbs-drmaa](http://apps.man.poznan.pl/trac/pbs-drmaa/wiki) library and use this as the value for `$DRMAA_LIBRARY_PATH`.
 
-**Slurm**: You will need to install [slurm-drmaa](http://apps.man.poznan.pl/trac/slurm-drmaa). In production on [usegalaxy.org](https://usegalaxy.org) we observed pthread deadlocks in slurm-drmaa that would cause Galaxy job handlers to eventually stop processing jobs until the handler was restarted. Compiling slurm-drmaa using the compiler flags `-g -O0` (keep debugging symbols, disable optimization) caused the deadlock to disappear.
+**Slurm**: You will need to install [slurm-drmaa](https://github.com/natefoo/slurm-drmaa/). In production on [usegalaxy.org](https://usegalaxy.org) we observed pthread deadlocks in slurm-drmaa that would cause Galaxy job handlers to eventually stop processing jobs until the handler was restarted. Compiling slurm-drmaa using the compiler flags `-g -O0` (keep debugging symbols, disable optimization) caused the deadlock to disappear.
 
 ### Parameters and Configuration
 


### PR DESCRIPTION
These old links no longer work, and need updating.