### PR TITLE
Add links/icon to all headers for permanent linking using metalsmith-headings-identifier

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,6 +1,7 @@
 // Build with Metalsmith
 let metalsmith = require('metalsmith');
 let minimatch = require('minimatch');
+let headingsidentifier = require("metalsmith-headings-identifier");
 
 // Plugin for Bower support
 let bower = function(files, metalsmith, done) {
@@ -253,6 +254,7 @@ let ms = metalsmith(__dirname)
             _: require('lodash')
         }
     })).use(timer('metalsmith-layouts'))
+    .use(headingsidentifier())
     .use(require('metalsmith-less')())
     .use(timer('metalsmith-less'))
     .use(bower)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "metalsmith-broken-link-checker": "^0.1.10",
     "metalsmith-collections": "^0.7.0",
     "metalsmith-filepath": "^1.0.1",
+    "metalsmith-headings-identifier": "0.0.11",
     "metalsmith-in-place": "^1.0.1",
     "metalsmith-layouts": "^1.6.5",
     "metalsmith-less": "^2.0.0",

--- a/src/css/styles.less
+++ b/src/css/styles.less
@@ -285,3 +285,42 @@ div.linkbox a:visited {
 h1.pageTitle {
     margin-top: 0px;
 }
+
+/* headingsidentifier */
+.heading-anchor {
+  display: block;
+  padding-right: 6px;
+  padding-left: 20px;
+  margin-left: -20px;
+  cursor: pointer;
+  position: absolute;
+  top: 3px;
+  bottom: 0;
+  left: 0;
+  text-decoration: none;
+  height: 100%;
+  background: transparent;
+  vertical-align: middle;
+}
+h1,h2,h3,h4,h5,h6 { 
+  position: relative; 
+}
+h1:hover .heading-anchor span:before,
+h2:hover .heading-anchor span:before,
+h3:hover .heading-anchor span:before,
+h4:hover .heading-anchor span:before,
+h5:hover .heading-anchor span:before,
+h6:hover .heading-anchor span:before {
+  content: "\f0c1"; // fa-chain fa-link
+  font-family: FontAwesome;
+  position: absolute;
+  font-size: 14px;
+}
+h1:hover .heading-anchor span:before{
+  top: 8px;
+}
+h4:hover .heading-anchor span:before,
+h5:hover .heading-anchor span:before,
+h6:hover .heading-anchor span:before{
+  font-size: 12px;
+}


### PR DESCRIPTION
I have no experience with metalsmith so feel free to completely redo this. 
This is related to the comment on linking to particular sections on the hub - this should make that easier.

![screen shot 2017-09-29 at 09 37 19](https://user-images.githubusercontent.com/102411/31005639-e322fbf8-a4f9-11e7-85c3-b1095d115df6.png)
