### PR TITLE
fix headingsidentifier icon misplacement on Firefox

### DIFF
--- a/src/css/styles.less
+++ b/src/css/styles.less
@@ -315,6 +315,9 @@ h6:hover .heading-anchor span:before {
   font-family: FontAwesome;
   position: absolute;
   font-size: 14px;
+  left: 0px;
+  top: 0px;
+  bottom: 0px;
 }
 h1:hover .heading-anchor span:before{
   top: 8px;


### PR DESCRIPTION
relates to #317 