### PR TITLE
Strip use of headingsidentifier, do our own via extension of marked r…

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,6 +4,7 @@ let fs = require('fs');
 let path = require('path');
 let hb_partials = require("handlebars");
 let marked = require("marked");
+let slug = require("slug");
 
 // Plugin for Bower support
 let bower = function(files, metalsmith, done) {
@@ -158,9 +159,9 @@ let subs = function(files, metalsmith, done) {
 // h1 for the page title. Will be passed to `metalsmith-markdown` plugin.
 class Renderer extends marked.Renderer {
     heading( text, level, raw ) {
-        var slug = this.options.headerPrefix + raw.toLowerCase().replace(/[^\w]+/g, '-');
-        return `<h${level + 1} id="${slug}">
-            <a class="heading-anchor" href="#${slug}"><span></span></a>
+        var h_slug = this.options.headerPrefix + slug(raw.toLowerCase());
+        return `<h${level + 1} id="${h_slug}">
+            <a class="heading-anchor" href="#${h_slug}"><span></span></a>
             ${text}
             </h${level + 1}>
 `;

--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 // Build with Metalsmith
 let metalsmith = require('metalsmith');
 let minimatch = require('minimatch');
-let headingsidentifier = require("metalsmith-headings-identifier");
+let slug = require("slug");
 
 // Plugin for Bower support
 let bower = function(files, metalsmith, done) {
@@ -161,8 +161,18 @@ let subs = function(files, metalsmith, done) {
 let marked = require("marked");
 class Renderer extends marked.Renderer {
     heading( text, level, raw ) {
-        return super.heading( text, level + 1, raw );
-    }
+          return '<h'
+            + (level + 1)
+            + ' id="'
+            + this.options.headerPrefix
+            + raw.toLowerCase().replace(/[^\w]+/g, '-')
+            + '">'
+            + `<a class="heading-anchor" href="#${slug(text)}"><span></span></a>`
+            + text
+            + '</h'
+            + (level + 1)
+            + '>\n';
+    };
     table(header, body) {
         return `<table class="table table-striped">
 <thead>
@@ -254,7 +264,6 @@ let ms = metalsmith(__dirname)
             _: require('lodash')
         }
     })).use(timer('metalsmith-layouts'))
-    .use(headingsidentifier())
     .use(require('metalsmith-less')())
     .use(timer('metalsmith-less'))
     .use(bower)

--- a/build.js
+++ b/build.js
@@ -1,7 +1,10 @@
 // Build with Metalsmith
 let metalsmith = require('metalsmith');
-let minimatch = require('minimatch');
 let slug = require("slug");
+let fs = require('fs');
+let path = require('path');
+let hb_partials = require("handlebars");
+let marked = require("marked");
 
 // Plugin for Bower support
 let bower = function(files, metalsmith, done) {
@@ -54,10 +57,6 @@ let set_metadata_defaults = function(files, metalsmith, done) {
     return done();
 };
 
-let fs = require('fs');
-let path = require('path');
-
-let hb_partials = require("handlebars");
 
 var partials_from_dir = (source, dir) =>
     (() => {
@@ -158,7 +157,6 @@ let subs = function(files, metalsmith, done) {
 
 // Extend `marked.Renderer` to increase all heading levels by 1 since we reserve
 // h1 for the page title. Will be passed to `metalsmith-markdown` plugin.
-let marked = require("marked");
 class Renderer extends marked.Renderer {
     heading( text, level, raw ) {
           return '<h'

--- a/build.js
+++ b/build.js
@@ -1,6 +1,5 @@
 // Build with Metalsmith
 let metalsmith = require('metalsmith');
-let slug = require("slug");
 let fs = require('fs');
 let path = require('path');
 let hb_partials = require("handlebars");
@@ -159,18 +158,13 @@ let subs = function(files, metalsmith, done) {
 // h1 for the page title. Will be passed to `metalsmith-markdown` plugin.
 class Renderer extends marked.Renderer {
     heading( text, level, raw ) {
-          return '<h'
-            + (level + 1)
-            + ' id="'
-            + this.options.headerPrefix
-            + raw.toLowerCase().replace(/[^\w]+/g, '-')
-            + '">'
-            + `<a class="heading-anchor" href="#${slug(text)}"><span></span></a>`
-            + text
-            + '</h'
-            + (level + 1)
-            + '>\n';
-    };
+        var slug = this.options.headerPrefix + raw.toLowerCase().replace(/[^\w]+/g, '-');
+        return `<h${level + 1} id="${slug}">
+            <a class="heading-anchor" href="#${slug}"><span></span></a>
+            ${text}
+            </h${level + 1}>
+`;
+    }
     table(header, body) {
         return `<table class="table table-striped">
 <thead>

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "metalsmith-uglify": "^1.0.1",
     "minimist": "^1.1.1",
     "moment": "^2.10.0",
-    "pug": "^2.0.0-beta6",
-    "slug": "^0.9.1"
+    "pug": "^2.0.0-beta6"
   },
   "scripts": {
     "build": "DEBUG=metalsmith-timer node build.js",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "metalsmith-uglify": "^1.0.1",
     "minimist": "^1.1.1",
     "moment": "^2.10.0",
-    "pug": "^2.0.0-beta6"
+    "pug": "^2.0.0-beta6",
+    "slug": "^0.9.1"
   },
   "scripts": {
     "build": "DEBUG=metalsmith-timer node build.js",


### PR DESCRIPTION
…endering of titles.

@tnabtaf This trims a very expensive step out of the build and rolls it into markdown rendering.  It'll also fix our problem with those mangled quotes.

( now that I think about it, we can probably do this easily enough without the extra elements at all, if I'd just approached this thinking about the goal instead of the problem in question -- it's a step in the right direction though, and it does fix the issues )