### PR TITLE
Add git fetch to updating galaxy instruction

### DIFF
--- a/src/admin/get-galaxy/index.md
+++ b/src/admin/get-galaxy/index.md
@@ -26,7 +26,7 @@ $ git clone -b release_18.01 https://github.com/galaxyproject/galaxy.git
 If you have an existing Galaxy repository and want to update it, run:
 
 ```
-$ git checkout release_18.01 && git pull --ff-only origin release_18.01
+$ git fetch origin && git checkout release_18.01 && git pull --ff-only origin release_18.01
 ```
 
 


### PR DESCRIPTION
Otherwise if the release branch doesn't exist the checkout fails with:
```
$ git checkout bla
error: pathspec 'bla' did not match any file(s) known to git.
```