### PR TITLE
Fixed mistake in duration format

### DIFF
--- a/layouts/events_index.pug
+++ b/layouts/events_index.pug
@@ -39,7 +39,7 @@ mixin renderEventJSONLD(item)
         else
             | "url": "#{item.link}",
         if item.days
-            |  "duration": "#{item.days}D",
+            |  "duration": "P#{item.days}D",
         if item.location
             |  "location": {
             |    "@type": "Place",


### PR DESCRIPTION
Duration format must start with P for __period__.
See Duration ISO Standard https://en.wikipedia.org/wiki/ISO_8601#Durations