### PR TITLE
Creat a blog for Galaxy Tool Generator

### DIFF
--- a/src/blog/2018-11-GTG/index.md
+++ b/src/blog/2018-11-GTG/index.md
@@ -1,0 +1,8 @@
+---
+date: '2018-11-13'
+title: "Galaxy Tool Generator (GTG)"
+tease: "A web application for developing Galaxy tools through web interfaces"
+authors: "Ming Chen"
+external_url: "https://github.com/MingChen0919/gtgdocker"
+source_blog: "Staton Lab"
+---


### PR DESCRIPTION
Added an `index.md` file for creating a blog for the [Galaxy Tool Generator](https://github.com/MingChen0919/gtgdocker).