### PR TITLE
link to Freiburg Galaxy Team changed

### DIFF
--- a/src/events/gcc2019/index.md
+++ b/src/events/gcc2019/index.md
@@ -16,9 +16,9 @@ GCC2019 will be held at [Konzerthaus Freiburg](http://www.konzerthaus.freiburg.d
 ## Hosts
 
 <div class="center">
-[<img src="/src/images/logos/FreiburgGalaxyTeam.png" alt="Galaxy Freiburg Project" height="120" />](http://www.bioinf.uni-freiburg.de/Galaxy/) &nbsp;&nbsp; [<img src="/src/images/logos/UniFreiburg.png" alt="University of Freiburg" height="120" />](http://www.uni-freiburg.de/) &nbsp;&nbsp;&nbsp;&nbsp; [<img src="/src/images/logos/deNBILogo.png" alt="de.NBI :the German Network for Bioinformatics Infrastructure" height="60" />](https://www.denbi.de/)
+[<img src="/src/images/logos/FreiburgGalaxyTeam.png" alt="Galaxy Freiburg Project" height="120" />](https://galaxyproject.eu/freiburg) &nbsp;&nbsp; [<img src="/src/images/logos/UniFreiburg.png" alt="University of Freiburg" height="120" />](http://www.uni-freiburg.de/) &nbsp;&nbsp;&nbsp;&nbsp; [<img src="/src/images/logos/deNBILogo.png" alt="de.NBI :the German Network for Bioinformatics Infrastructure" height="60" />](https://www.denbi.de/)
 </div>
 
 <br />
 
-GCC2019 is hosted by the [Freiburg Galaxy Project](https://usegalaxy.eu/freiburg), the [University of Freiburg](http://www.uni-freiburg.de/), and [de.NBI (the German Network for Bioinformatics Infrastructure)](https://www.denbi.de/).
+GCC2019 is hosted by the [Freiburg Galaxy Project](https://galaxyproject.eu/freiburg), the [University of Freiburg](http://www.uni-freiburg.de/), and [de.NBI (the German Network for Bioinformatics Infrastructure)](https://www.denbi.de/).


### PR DESCRIPTION
from http://www.bioinf.uni-freiburg.de/Galaxy/index.html to https://galaxyproject.eu/freiburg
and the link https://usegalaxy.eu/freiburg was broken, exchanged by https://galaxyproject.eu/freiburg