### PR TITLE
[WIP] gcc2019 registration is open

### DIFF
--- a/partials/Events/GCC2019/Header.html
+++ b/partials/Events/GCC2019/Header.html
@@ -4,7 +4,6 @@
   </a>
   <div class="linkbox-horizontal">
       [Program](https://gcc2019.sched.com/) |
-      [Register](/src/events/gcc2019/registration/index.md) |
       [Training](/src/events/gcc2019/training/index.md) |
       [CoFest](/src/events/gcc2019/cofest/index.md) |
       [Venue](/src/events/gcc2019/venue/index.md) |
@@ -20,7 +19,9 @@
   </div>
   <div style="font-size: large;">
     Freiburg, Germany, 1-6 July 2019
+    <br />
+    [Register](/src/events/gcc2019/registration/index.md) &nbsp;/&nbsp; [Submit an abstract](/src/events/gcc2019/abstracts/index.md)
   </div>
-  [#usegalaxy](https://twitter.com/hashtag/usegalaxy) / [Chat](https://gitter.im/galaxyproject/gcc)
+  [#usegalaxy](https://twitter.com/hashtag/usegalaxy) / [chat](https://gitter.im/galaxyproject/gcc)
   <br /><br />
 </div>

--- a/src/events/gcc2019/abstracts/index.md
+++ b/src/events/gcc2019/abstracts/index.md
@@ -1,0 +1,25 @@
+{{> Events/GCC2019/Header }}
+
+Doing work in data-intensive science?  There is no better place than GCC2019 to present your work and to learn from others.
+
+There are several options for presentations at GCC2019:
+
+* **Oral presentations**
+  * 15 to 20 minutes long.
+  * Review starts on 22 April. Authors notified by 6 May
+* **Lightning talks**
+  * 5 to 10 minutes long 
+  * Review starts on 22 April. Authors notified by 6 May
+* **Poster presentations**
+  * Presented during one of three hour-long poster/demo sessions.
+  * Posters will remain up for the duration of the meeting.
+  * Reviewed on a rolling basis.  Authors notified within 2 weeks of submission.  Open until out of space.
+* **Software demos**
+  * Presented during one of three hour-long poster/demo sessions.
+  * Reviewed on a rolling basis.  Authors notified within 2 weeks of submission.  Open until out of space.
+
+You can submit the same abstract as a long talk, a lightning talk, a poster and a demo.  (You can also submit separate abstracts if you want the wording to be different.) If you check both "Oral Presentation" and "Lightning Talk" then your abstract will first be considered for a long talk, and then for a lightning talk only if it is not selected as a long talk. If you submit both "Poster Presentation" and "Software Demo" and both are accepted, then your poster and demo will be presented concurrently and adjacent to each other.
+
+<br />
+<a href="https://easychair.org/conferences/?conf=gcc2019"><button type="button" class="btn btn-success">**Submit an Abstract for GCC 2019 Now**</button></a>
+

--- a/src/events/gcc2019/registration/index.md
+++ b/src/events/gcc2019/registration/index.md
@@ -8,8 +8,11 @@ title: "GCC2019 Registration
 
 <a href="https://www.conftool.com/gcc2019/"><button type="button" class="btn btn-success">Register for GCC 2019 Now!</button></a>
    
-   
-GCC2019 features [several events](https://gcc2019.sched.com/), all of which can be registered for separately, or all at the same time.  Steep discounts are offered to students and postdocs, and for registering early.
+GCC2019 features [several events](https://gcc2019.sched.com/), which can be registered for separately or all at once.  Steep discounts are offered to students and postdocs, and for registering early.
+
+# Training
+
+If you are participating in training on Monday, you will need to decide [which track to participate in](https://gcc2019.sched.com/) when you register.  You do not need to register for individual traing sessions during the meeting (Tuesday through Thursday).  We will poll meeting participants about training interests in early June.
 
 # Rates
 

--- a/src/events/gcc2019/registration/index.md
+++ b/src/events/gcc2019/registration/index.md
@@ -4,8 +4,11 @@ title: "GCC2019 Registration
 
 {{> Events/GCC2019/Header }}
 
-**Registration for GCC2019 will open shortly.**
+**Registration for GCC2019 is open**
 
+<a href="https://www.conftool.com/gcc2019/"><button type="button" class="btn btn-success">Register for GCC 2019 Now!</button></a>
+   
+   
 GCC2019 features [several events](https://gcc2019.sched.com/), all of which can be registered for separately, or all at the same time.  Steep discounts are offered to students and postdocs, and for registering early.
 
 # Rates

--- a/src/news/2019-03-gcc2019/index.md
+++ b/src/news/2019-03-gcc2019/index.md
@@ -1,0 +1,34 @@
+---
+title: "GCC2019 Registration & Abstract Submission are Open"
+tease: "Early registration ends 17 May"
+date: "2019-03-19"
+---
+
+[<img class="float-right" style="max-width: 300px" src="/src/events/gcc2019/gcc2019-logo-big.png" alt="GCC2019" />](/src/events/gcc2019/index.md)
+
+**We are pleased to announce that [registration](/src/events/gcc2019/registration/index.md) and [abstract submission](/src/events/gcc2019/abstracts/index.md) for the [2019 Galaxy Community Conference (GCC2019)](/src/events/gcc2019/index.md) are now open.**
+
+GCC2019 will be held 1-8 July in Freiburg, Germany.  The *tenth* [GCC](/src/gcc/index.md) will have many familiar features from earlier years, including accepted and lightning talks, posters and demos, birds-of-a-feather gatherings (BoFs), training, and a CollaborationFest.  2019 also brings the [most significant conference program update](https://gcc2019.sched.com/) in several years:
+
+* some training will be integrated with the main conference,
+* three days of conference instead of two,
+* several parallel sessions,
+* and a strong emphasis on organizing content by domain.
+
+GCC2019, like every GCC before it, will be built around *community*.  Training topics are nominated, selected, and presented by the community.  Presentations will  feature the full spectrum of Galaxy applications, enhancements and deployments from the community as well.
+
+If you are working in data intensive life science research then there will not be a better place to share your work, learn from others, and find new collaborators.
+
+**Registration**
+
+[Early registration](/src/events/gcc2019/registration/index.md) starts at €49/day for students and postdocs, and €79 / day for other academics and non-profit researchers.  Early registration ends 17 May, *when rates go up by 60%. So, [register early](/src/events/gcc2019/registration/index.md).*
+
+**Present your work!**
+
+[Abstract submission](/src/events/gcc2019/abstracts/index.md) for talks, lightning talks, demos and posters is now open.  If you work in data-intensive life science (or in other fields using Galaxy) then please consider presenting your work at GCC2019.  This is an ideal chance to present to 200+ researchers, all addressing common challenges in data intensive science.  Review of oral presentations starts on 22 April, in a little over a month.
+
+**[Submit an abstract (or two) now](/src/events/gcc2019/abstracts/index.md)!**
+
+*We hope to see you in Freiburg!*
+
+[GCC2019 Organizers](/src/events/gcc2019/organizers/index.md)


### PR DESCRIPTION
Registration for GCC2019 is open. This adds a bigger button to the page.

@tnabtaf feel free to merge whenever you think we are ready.