### PR TITLE
updating usegalaxy-be initial content

### DIFF
--- a/src/use/usegalaxy-be/index.md
+++ b/src/use/usegalaxy-be/index.md
@@ -5,25 +5,28 @@ scope: "general"
 platforms:
   - platform_group: "public-server"
     platform_url: "https://usegalaxy.be/"
-    platform_text: "Belgium Galaxy Server"
+    platform_text: "ELIXIR Belgium Galaxy Server"
     platform_location: BE
 summary: "General purpose genomics Galaxy server"
 image: "/src/use/usegalaxy-be/usegalaxy-be-logo.png"
 comments:
-  - "A public Galaxy server with an emphasis on serving researchers in Belgium." 
+  - "A public Galaxy server with an emphasis on serving researchers in Belgium."
   - "[Real time status](https://usegalaxy.be/stats/)"
-  - "Plant genomes provided by ELIXIR Belgium"
+  - "Provides reference data for plant species from the [PLAZA data warehouse](https://usegalaxy-be.github.io/posts/2019/07/01/PLAZA-reference-data/plain.html)."
 user_support:
   - "Email: galaxy@elixir-belgium.org"
 quotas:
   - "Free to use"
   - "50 GB for any registered users (5GB for unregistered users)"
-  - "On demand training capacity"
   - "Special requests contact galaxy@elixir-belgium.org"
 citations:
   - "[UseGalaxy.be
 platform for data-intensive research](https://frederikcoppens.github.io/slidedecks/ELIXIR_Belgium_usegalaxy_20190916/), Frederik Coppens, ELIXIR Belgium All Hands 2019"
 pub_libraries:
 sponsors:
-  - "[ELIXIR Belgium](https://www.elixir-belgium.org/), [VLAAMS Supercomputer Centrum](https://www.vscentrum.be/), [Research Foundation - Flanders (FWO)](https://www.fwo.be/en/), [Flemish Department of Economy, Science and Innovation](https://www.ewi-vlaanderen.be/en)"
+  - "[ELIXIR Belgium](https://www.elixir-belgium.org/)"
+  - "[Flemish Supercomputer Center](https://www.vscentrum.be/)"
+  - "[VIB](http://www.vib.be)"
+  - "[Research Foundation - Flanders (FWO)](https://www.fwo.be/en/)"
+  - "[Flemish Department of Economy, Science and Innovation](https://www.ewi-vlaanderen.be/en)"
 ---


### PR DESCRIPTION
Some adaptations to the usegalaxy-be page for the hub. While training is installed, we did not yet test it, so I prefer to add it publicly later