### PR TITLE
Fixes for stricter yaml frontmatter parsing

### DIFF
--- a/src/cite-u-like/index.md
+++ b/src/cite-u-like/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Galaxy's CiteULike library has moved to Zotero
+title: "Galaxy's CiteULike library has moved to Zotero"
 ---
 
 ![Zotero](/src/images/logos/zotero-logo-small-trans.png)

--- a/src/community/deployment/deep-tools/index.md
+++ b/src/community/deployment/deep-tools/index.md
@@ -1,5 +1,5 @@
 ---
-title: [deepTools](http://deeptools.ie-freiburg.mpg.de/)
+title: deepTools
 ---
 <div class='center'>
 <a href='http://deeptools.ie-freiburg.mpg.de/'><img src="/src/use/deeptools/deeptools.png" alt="deepTools" height="200" /></a>

--- a/src/community/deployment/galax-east/index.md
+++ b/src/community/deployment/galax-east/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GalaxyEast](http://www.galaxeast.fr)
+title: GalaxyEast
 ---
 <div class='center'>
 <a href='http://www.galaxeast.fr'><img src="/src/use/galaxeast/galaxeast.png" alt="GalaxEast" height="200" /></a>

--- a/src/community/deployment/galaxy-at-u-iowa/index.md
+++ b/src/community/deployment/galaxy-at-u-iowa/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GalaxyAt](/src/GalaxyAt/index.md)UIowa
+title: Galaxy at UIowa
 ---
 <div class='center'>
 <a href='http://medicine.uiowa.edu/humangenetics/'><img src="/src/images/logos/UIowaLogo.jpg" alt="GalaxyAtUIowa" width=200 /></a>

--- a/src/community/deployment/kmer-svm/index.md
+++ b/src/community/deployment/kmer-svm/index.md
@@ -1,5 +1,5 @@
 ---
-title: [kmer-SVM](http://kmersvm.beerlab.org/)
+title: "kmer-SVM"
 ---
 <div class='center'>
 <a href='http://kmersvm.beerlab.org/'><img src="/src/use/kmer-svm/kmer-svm.png" alt="kmer-SVM"  /></a>

--- a/src/community/galaxy-admins/future/index.md
+++ b/src/community/galaxy-admins/future/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GalaxyAdmins](/src/GalaxyAdmins/index.md) Future Directions
+title: GalaxyAdmins Future Directions
 ---
 <div class='center'>
 ![GalaxyAdmins](/src/images/logos/GalaxyAdmins.png)

--- a/src/community/galaxy-admins/index.md
+++ b/src/community/galaxy-admins/index.md
@@ -1,5 +1,5 @@
 ---
-title: Galaxy-Admins
+title: "Galaxy-Admins"
 ---
 <div class='center'><img src="/src/images/galaxy-logos/GalaxyAdmins.png" alt="" width="240" /></div>
 

--- a/src/community/galaxy-admins/meetups/2012-07-27/index.md
+++ b/src/community/galaxy-admins/meetups/2012-07-27/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GalaxyCzars](/src/community/galaxy-admins/index.md) [GCC2012 Breakout Session](/src/events/gcc2012/index.md)
+title: GalaxyCzars GCC2012 Breakout Session
 ---
 <div class='center'>
 <a href='/src/community/galaxy-admins/index.md'><img src="/src/images/logos/GalaxyAdmins.png" /></a> &nbsp;&nbsp;&nbsp;

--- a/src/data-providers/cookbook/index.md
+++ b/src/data-providers/cookbook/index.md
@@ -1,5 +1,5 @@
 ---
-title: [DataProviders](/src/dataProvider/index.md) Cookbook
+title: DataProviders Cookbook
 ---
 <div class='left'></div>
 

--- a/src/events/admin-training2016/advanced-session/index.md
+++ b/src/events/admin-training2016/advanced-session/index.md
@@ -1,5 +1,5 @@
 ---
-title: Galaxy Admin Training: Advanced Topics
+title: "Galaxy Admin Training: Advanced Topics"
 ---
 {{> Events/AdminTraining2016/Header }}
 

--- a/src/events/admin-training2016/basics-session/index.md
+++ b/src/events/admin-training2016/basics-session/index.md
@@ -1,5 +1,5 @@
 ---
-title: Galaxy Admin Training: Basic Topics
+title: "Galaxy Admin Training: Basic Topics"
 ---
 {{> Events/AdminTraining2016/Header }}
 

--- a/src/events/admin-training2016/publicity/index.md
+++ b/src/events/admin-training2016/publicity/index.md
@@ -1,5 +1,5 @@
 ---
-title: Galaxy Admin Training: Help spread the word
+title: "Galaxy Admin Training: Help spread the word"
 ---
 {{> Events/AdminTraining2016/Header }}
 

--- a/src/events/bio-it-world2014/w14/index.md
+++ b/src/events/bio-it-world2014/w14/index.md
@@ -1,5 +1,5 @@
 ---
-title: Workshop 14: Running a Local Galaxy Instance
+title: "Workshop 14: Running a Local Galaxy Instance"
 ---
 [Adam Kraut](http://bioteam.net/company-leadership/), [Nate Coraor](/src/people/nate/index.md), [Anushka Brownley](http://bioteam.net/company-leadership/), Tristan Lubinski, [James Reaney](http://www.sgi.com/solutions/genomics)
 

--- a/src/events/gcc2012/organizing-committee/index.md
+++ b/src/events/gcc2012/organizing-committee/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GCC2012](/src/events/gcc2012/index.md) Organizing Committee
+title: GCC2012 Organizing Committee
 ---
 {{> Events/GCC2012/PageHeader }}
 

--- a/src/events/gcc2012/photos/index.md
+++ b/src/events/gcc2012/photos/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GCC2012](/src/events/gcc2012/index.md) Photos
+title: GCC2012 Photos
 ---
 {{> Events/GCC2012/PageHeader }}
 

--- a/src/events/gcc2014/training-day/admin-walkthrough/index.md
+++ b/src/events/gcc2014/training-day/admin-walkthrough/index.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorial: Galaxy Installation and Administration
+title: "Tutorial: Galaxy Installation and Administration"
 ---
 {{> Events/GCC2014/Header }}
 <br /><br />

--- a/src/events/gcc2014/training-day/api/index.md
+++ b/src/events/gcc2014/training-day/api/index.md
@@ -1,5 +1,5 @@
 ---
-title: Galaxy Automation: Using the API
+title: "Galaxy Automation: Using the API"
 ---
 {{> Events/GCC2014/Header }}
 <br /><br />

--- a/src/events/gcc2015/bofs/cwl/index.md
+++ b/src/events/gcc2015/bofs/cwl/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Common Workflow Language](http://common-workflow-language.github.io)
+title: "Common Workflow Language"
 ---
 {{> Events/GCC2015/Header }}
 

--- a/src/events/gcc2015/bofs/elixir/index.md
+++ b/src/events/gcc2015/bofs/elixir/index.md
@@ -1,5 +1,5 @@
 ---
-title: [ELIXIR-Galaxy Workshop](https://docs.google.com/document/d/1k_d9A4HDTcmjEhYW3FbVeEjcAkembhxupZZN3KQn0NA/edit#heading=h.8fvjaj9oq5oi)
+title: ELIXIR-Galaxy Workshop
 ---
 {{> Events/GCC2015/Header }}
 

--- a/src/events/gcc2015/bofs/galaxy-admins/index.md
+++ b/src/events/gcc2015/bofs/galaxy-admins/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GalaxyAdmins](/src/community/galaxy-admins/index.md) GCC2015 Meetup
+title: GalaxyAdmins GCC2015 Meetup
 ---
 {{> Events/GCC2015/Header }}
 

--- a/src/events/gcc2015/bofs/galaxy-community-uk/index.md
+++ b/src/events/gcc2015/bofs/galaxy-community-uk/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Galaxy Community UK (GCUK)](http://galaxy-community.org.uk/)
+title: "Galaxy Community UK (GCUK)"
 ---
 {{> Events/GCC2015/Header }}
 

--- a/src/events/gcc2015/bofs/galaxy-scientists/index.md
+++ b/src/events/gcc2015/bofs/galaxy-scientists/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GalaxyScientists](/src/galaxy-scientists/index.md)
+title: GalaxyScientists
 ---
 {{> Events/GCC2015/Header }}
 

--- a/src/events/gcc2019/cofest/index.md
+++ b/src/events/gcc2019/cofest/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GCC2019 CollaborationFest: Core and Encore
+title: "GCC2019 CollaborationFest: Core and Encore"
 ---
 
 {{> Events/GCC2019/Header }}

--- a/src/events/gcc2019/registration/index.md
+++ b/src/events/gcc2019/registration/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GCC2019 Registration
+title: "GCC2019 Registration"
 ---
 
 {{> Events/GCC2019/Header }}

--- a/src/events/gcc2019/venue/index.md
+++ b/src/events/gcc2019/venue/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GCC2019 Venue: Freiburg Germany
+title: "GCC2019 Venue: Freiburg Germany"
 ---
 
 {{> Events/GCC2019/Header }}

--- a/src/events/gccbosc2018/register/index.md
+++ b/src/events/gccbosc2018/register/index.md
@@ -1,5 +1,5 @@
 ---
-title: 2018 GCCBOSC2018 Conferences: Register
+title: "2018 GCCBOSC2018 Conferences: Register"
 ---
 
 {{> Events/GCCBOSC2018/Header }}

--- a/src/events/gccbosc2018/training/index.md
+++ b/src/events/gccbosc2018/training/index.md
@@ -1,5 +1,5 @@
 ---
-title: 2018 GCCBOSC2018 Conferences: Training
+title: "2018 GCCBOSC2018 Conferences: Training"
 ---
 
 {{> Events/GCCBOSC2018/Header }}

--- a/src/learn/faq/index.md
+++ b/src/learn/faq/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Frequently Asked Questions](/src/faqs/index.md) for Using Galaxy
+title: Frequently Asked Questions for Using Galaxy
 ---
 {{> Learn/LinkBox }}
 {{> FAQs/LinkBox }}

--- a/src/people/carrie-ganote/index.md
+++ b/src/people/carrie-ganote/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Carrie Ganote](http://www.researchgate.net/profile/Carrie_Ganote)
+title: Carrie Ganote
 ---
 <div class='right'><img src="/src/events/gcc2014/abstracts/CarrieGanote.jpg" alt="Carrie Ganote" width="120" /></div>
 

--- a/src/teach/materials/index.md
+++ b/src/teach/materials/index.md
@@ -1,5 +1,5 @@
 ---
-title: Teaching with Galaxy: Materials
+title: "Teaching with Galaxy: Materials"
 ---
 {{> Teach/Header }}
 

--- a/src/teach/resource/bio-trac-ngs-course-syllabus/index.md
+++ b/src/teach/resource/bio-trac-ngs-course-syllabus/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Biotrac Next Generation Sequencing Course Syllabus](http://www.biotrac.com/pages/Tracs/Trac45.html)
+title: Biotrac Next Generation Sequencing Course Syllabus
 ---
 <div class='center'>
 <a href='http://www.biotrac.com/'><img src="/src/teach/resource/bio-trac-ngs-course-syllabus/BioTracLogo.gif" alt="Bio-Trac"  /></a>

--- a/src/teach/resource/chb-harvard-chip-seq/index.md
+++ b/src/teach/resource/chb-harvard-chip-seq/index.md
@@ -1,5 +1,5 @@
 ---
-title: [CHB Harvard ChIP-Seq Workshop](http://hbc.github.io/ngs-workshops/courses/introduction-to-chip-seq/)
+title: "CHB Harvard ChIP-Seq Workshop"
 ---
 <div class='center'><a href='http://hbc.github.io/ngs-workshops/about/'><img src="/src/images/logos/CHBHarvard.png" alt="Center for Health Bioinformatics Galaxy Tutorials"  /></a></div>
 

--- a/src/teach/resource/chb-harvard-cloudman/index.md
+++ b/src/teach/resource/chb-harvard-cloudman/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Running your own Galaxy instance (in the cloud)](http://hbc.github.io/ngs-workshops/courses/running-your-own-galaxy-instance/)
+title: "Running your own Galaxy instance (in the cloud)"
 ---
 <div class='center'><a href='http://hbc.github.io/ngs-workshops/about/'><img src="/src/images/logos/CHBHarvard.png" alt="Center for Health Bioinformatics Galaxy Tutorials"  /></a></div>
 

--- a/src/teach/resource/chb-harvard-exome-seq/index.md
+++ b/src/teach/resource/chb-harvard-exome-seq/index.md
@@ -1,5 +1,5 @@
 ---
-title: [CHB Harvard Exome-Seq Workshop](http://scriptogr.am/ohofmann/exome-seq)
+title: "CHB Harvard Exome-Seq Workshop"
 ---
 <div class='center'><a href='http://scriptogr.am/ohofmann/about'><img src="/src/images/logos/CHBHarvard.png" alt="Center for Health Bioinformatics Galaxy Tutorials"  /></a></div>
 

--- a/src/teach/resource/chb-harvard-intro/index.md
+++ b/src/teach/resource/chb-harvard-intro/index.md
@@ -1,5 +1,5 @@
 ---
-title: [CHB Harvard Introduction to Galaxy](http://hbc.github.io/ngs-workshops/courses/introduction-to-galaxy/)
+title: CHB Harvard Introduction to Galaxy
 ---
 <div class='center'><a href='http://hbc.github.io/ngs-workshops/about/'><img src="/src/images/logos/CHBHarvard.png" alt="Center for Health Bioinformatics Galaxy Tutorials"  /></a></div>
 

--- a/src/teach/resource/chb-harvard-rna-seq/index.md
+++ b/src/teach/resource/chb-harvard-rna-seq/index.md
@@ -1,5 +1,5 @@
 ---
-title: [CHB Harvard RNA-Seq Workshop](http://hbc.github.io/ngs-workshops/courses/introduction-to-rna-seq/)
+title: "CHB Harvard RNA-Seq Workshop"
 ---
 <div class='center'><a href='http://hbc.github.io/ngs-workshops/about/'><img src="/src/images/logos/CHBHarvard.png" alt="Center for Health Bioinformatics Galaxy Tutorials"  /></a></div>
 

--- a/src/teach/resource/chip-seq-avec-galaxy/index.md
+++ b/src/teach/resource/chip-seq-avec-galaxy/index.md
@@ -1,5 +1,5 @@
 ---
-title: [ChIP-Seq avec Galaxy](https://youtu.be/qgiH4h52HYc)
+title: ChIP-Seq avec Galaxy
 ---
 <div class='center'>
 <a href='https://youtu.be/qgiH4h52HYc'><img src="/src/teach/resource/chip-seq-avec-galaxy/ChIP-SeqAvecGalaxyVideo.png" alt="ChIP-Seq avec Galaxy" height="200" /></a>

--- a/src/teach/resource/detection-de-variants-structuraux/index.md
+++ b/src/teach/resource/detection-de-variants-structuraux/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Détection de variants structuraux](https://youtu.be/aNPDObmX2ho)
+title: "Détection de variants structuraux"
 ---
 <div class='center'>
 <a href='https://youtu.be/aNPDObmX2ho'><img src="/src/teach/resource/detection-de-variants-structuraux/DétectionVariantsStructurauxVideo.png" alt="Détection de variants structuraux" height="200" /></a>

--- a/src/teach/resource/exome-seq-avec-galaxy/index.md
+++ b/src/teach/resource/exome-seq-avec-galaxy/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Analyse de données ExomeSeq avec Galaxy](https://youtu.be/HyQCUWmgx84)
+title: Analyse de données ExomeSeq avec Galaxy
 ---
 <div class='center'>
 <a href='http://linkToResourceOrOrg'><img src="/src/teach/resource/exome-seq-avec-galaxy/ExomeSeqVideo.png" alt="Analyse de données ExomeSeq avec Galaxy" height="200" /></a>

--- a/src/teach/resource/freiburg-hands-on-training/index.md
+++ b/src/teach/resource/freiburg-hands-on-training/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Galaxy Freiburg Hands-On Training](https://github.com/bgruening/training-material)
+title: Galaxy Freiburg Hands-On Training
 ---
 <div class='center'>
 <a href='https://github.com/bgruening/training-material'><img src="/src/teach/resource/freiburg-hands-on-training/Freiburg-Galaxy-Team.png" alt="Freiburg-Galaxy-Team" height="100" /></a>

--- a/src/teach/resource/galaxy-ngs101/index.md
+++ b/src/teach/resource/galaxy-ngs101/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Galaxy NGS 101](/src/learn/galaxy-ngs101/index.md)
+title: Galaxy NGS 101
 ---
 <div class='center'>
 <a href='https://vimeo.com/album/3456159'><img src="/src/images/ngs101/NGS101PlaySlide.png" alt="Galaxy NGS 101 Videos" width="180" /></a>

--- a/src/teach/resource/genomic-data-science-galaxy-coursera/index.md
+++ b/src/teach/resource/genomic-data-science-galaxy-coursera/index.md
@@ -1,5 +1,5 @@
 ---
-title: [Genomic Data Science with Galaxy on Coursera](https://www.coursera.org/course/gengalaxy)
+title: Genomic Data Science with Galaxy on Coursera
 ---
 <div class='center'><a href='https://www.coursera.org/course/gengalaxy'><img src="/src/images/logos/CourseraGBDS.png" alt="Genomic Data Science with Galaxy"  /></a>
 </div>

--- a/src/teach/resource/gvl-variant-detection-advanced-tutorial/index.md
+++ b/src/teach/resource/gvl-variant-detection-advanced-tutorial/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GVL Variant Detection Advanced Tutorial](https://docs.google.com/document/pub?id=1CuKkKylVDb03tnN7RSWl5EUzleetn0ctjmvaidPKLxM)
+title: "GVL Variant Detection Advanced Tutorial"
 ---
 <div class='center'>
 <a href='https://docs.google.com/document/pub?id=1CuKkKylVDb03tnN7RSWl5EUzleetn0ctjmvaidPKLxM'><img src="/src/images/logos/gvl-300.png" alt="Variant Detection Advanced Tutorial" height="200" /></a>

--- a/src/teach/resource/gvl-variant-detection-introductory-tutorial/index.md
+++ b/src/teach/resource/gvl-variant-detection-introductory-tutorial/index.md
@@ -1,5 +1,5 @@
 ---
-title: [GVL Variant Detection Introductory Tutorial](https://docs.google.com/document/pub?id=1ZRzrjjOCvtAu3m-IKL-rbJ1f4On60dDL_IEwG7oejdI)
+title: "GVL Variant Detection Introductory Tutorial"
 ---
 <div class='center'>
 <a href='https://docs.google.com/document/pub?id=1ZRzrjjOCvtAu3m-IKL-rbJ1f4On60dDL_IEwG7oejdI'><img src="/src/images/logos/gvl-300.png" alt="Variant Detection Introductory Tutorial" height="200" /></a>

--- a/src/teach/resource/uc-davis-core-ami/index.md
+++ b/src/teach/resource/uc-davis-core-ami/index.md
@@ -1,5 +1,5 @@
 ---
-title: [UC Davis Bioinformatics Core Galaxy AMI](http://bioinformatics.ucdavis.edu/software/)
+title: UC Davis Bioinformatics Core Galaxy AMI
 ---
 <div class='center'>
 <a href='http://bioinformatics.ucdavis.edu/'><img src="/src/images/logos/UCDavisGenomeCenter.png" alt="UC Davis Bioinformatics Core" height="100" /></a>

--- a/src/teach/resource/uc-davis-core-galaxy-course/index.md
+++ b/src/teach/resource/uc-davis-core-galaxy-course/index.md
@@ -1,5 +1,5 @@
 ---
-title: [UC Davis Using Galaxy for Analysis of High Throughput Sequence Data Workshop](http://training.bioinformatics.ucdavis.edu/docs/2014/06/june-2014-workshop/)
+title: "UC Davis Using Galaxy for Analysis of High Throughput Sequence Data Workshop"
 ---
 <div class='center'>
 <a href='http://bioinformatics.ucdavis.edu/'><img src="/src/images/logos/UCDavisGenomeCenter.png" alt="UC Davis Bioinformatics Core" height="100" /></a>

--- a/src/teach/resource/uc-davis-rna-chip-workshop/index.md
+++ b/src/teach/resource/uc-davis-rna-chip-workshop/index.md
@@ -1,5 +1,5 @@
 ---
-title: [UC Davis RNA-Seq and ChIP-Seq Analysis with Galaxy Workshop](http://training.bioinformatics.ucdavis.edu/docs/2014/12/december-2014-workshop/)
+title: UC Davis RNA-Seq and ChIP-Seq Analysis with Galaxy Workshop
 ---
 <div class='center'>
 <a href='http://bioinformatics.ucdavis.edu/'><img src="/src/images/logos/UCDavisGenomeCenter.png" alt="UC Davis Bioinformatics Core" height="100" /></a>

--- a/src/teach/resource/uc-riverside-ngs/index.md
+++ b/src/teach/resource/uc-riverside-ngs/index.md
@@ -1,5 +1,5 @@
 ---
-title: [UC Riverside NGS Tutorial](http://manuals.bioinformatics.ucr.edu/workshops/dec-12-16-2013)
+title: UC Riverside NGS Tutorial
 ---
 <div class='center'>
 [[<a href='http://manuals.bioinformatics.ucr.edu/workshops/dec-12-16-2013'><img src="/src/teach/resource/uc-riverside-ngs/UCR_IIGB_Logo.png" alt="UC Riverside Institute for Integrative Genome Biology"  /></a>

--- a/src/teach/resources/index.md
+++ b/src/teach/resources/index.md
@@ -1,5 +1,5 @@
 ---
-title: Galaxy Training: Resources
+title: "Galaxy Training: Resources"
 ---
 {{> Teach/Header }}
 

--- a/src/va/mega-mapper/index.md
+++ b/src/va/mega-mapper/index.md
@@ -1,5 +1,5 @@
 ---
-title: [MegaMapper](https://wiki.med.harvard.edu/SysBio/Megason/MegaMapper)
+title: MegaMapper
 ---
 <div class='center'>
 <a href='http://linkToVirtApplOrOrg'><img src="/src/va/mega-mapper/MegasonLabLogo.png" alt="MegaMapper"  /></a>


### PR DESCRIPTION
Primarily:

- Quoted strings need both quotes.
- Strings with separator characters need to be quoted
- We don't use markdown links inside yaml frontmatter fields
