### PR TITLE
Devroundtable page to collect presentations with links, etc.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.pdf filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.m4a filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.pdf filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
+*.m4a filter=lfs diff=lfs merge=lfs -text

--- a/src/community/devroundtable/devroundtable001.mp4
+++ b/src/community/devroundtable/devroundtable001.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c12441291d86be34c9a9d9ea946efbed0d0880cbe558a853439804271b8120ae
-size 165994943

--- a/src/community/devroundtable/devroundtable001.mp4
+++ b/src/community/devroundtable/devroundtable001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c12441291d86be34c9a9d9ea946efbed0d0880cbe558a853439804271b8120ae
+size 165994943

--- a/src/community/devroundtable/index.md
+++ b/src/community/devroundtable/index.md
@@ -25,4 +25,4 @@ These meetings are intended to be lightweight and informal, these sessions will 
 
 | Date | Presentations | Recording Link |
 | --- | --- | --- |
-| 6-11-2020 | Mason - New History | Link |
+| 6-11-2020 | Mason - New History | [Recording Link](devroundtable001.mp4)|

--- a/src/community/devroundtable/index.md
+++ b/src/community/devroundtable/index.md
@@ -1,0 +1,28 @@
+---
+title: Galaxy Developer Roundtable
+---
+
+## When
+Every other Thursday at Noon ET (4pm UTC) as long as there are one or more presenters for that week.
+
+## Who
+Anyone is welcome to attend. If you would like to present, please fill out this form https://bit.ly/gxdevroundtablepresent by midday Wednesday of that week.
+
+## What
+
+This is an opportunity for presenters (Galaxy users, developers, admins) to engage with the Galaxy developer community interactively. Some example presentation slots might include:
+
+Small sized slots (~5 min) presenting particular Galaxy issues, well developed questions, or focused advocacy.
+Medium sized slots (~10min) presenting big pull requests benefiting from a lot of discussion (from recent examples interactive tools, Galaxy markdown, history rewrite, etc..) or presentations of user or admin stories to advocate to a developer audience.
+Longer slots (20min+) to practice conference style-presentations about larger bodies of work.
+
+These are just some initial ideas and time allocation doesn’t need to map cleanly to these ideas. One can easily imagine very long discussions or presentations being relevant to this audience. We only ask presenters to have publicly available slides. If you wish to start a discussion on a particular point, please be ready to lead the discussion and have at least one slide available.
+
+These meetings are intended to be lightweight and informal, these sessions will be cancelled if no one volunteers to present. We expect some weeks no one will have anything to present and this is fine. We won’t track down people to present for the sake of consistency - this is an opportunity for presenters not an obligation for developers generally - the Galaxy committers group may however encourage presentations for large, disruptive PRs to facilitate interactive pull request reviews by more committers.
+
+
+## Past Meetings
+
+| Date | Presentations | Recording Link |
+| --- | --- | --- |
+| 6-11-2020 | Mason - New History | Link |

--- a/src/community/devroundtable/index.md
+++ b/src/community/devroundtable/index.md
@@ -23,6 +23,5 @@ These meetings are intended to be lightweight and informal, these sessions will 
 
 ## Past Meetings
 
-| Date | Presentations | Recording Link |
-| --- | --- | --- |
-| 6-11-2020 | Mason - New History | [Recording Link](devroundtable001.mp4)|
+### 6-11-2020:  The New History by Mason
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/yR67bFB6W38" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
@tnabtaf Look good as a start?

(URL would be  `galaxyproject.org/community/devroundtable/`)
We'll probably want to collect slide links and make this a little more automatic in the future, but I'm not building a new automated index page right now :)