### PR TITLE
Displaying tease and (new) links on events listing pages.

### DIFF
--- a/layouts/events.pug
+++ b/layouts/events.pug
@@ -33,6 +33,13 @@ mixin renderEvent()
                 li
                     strong Contact: 
                     | !{contact}
+            if links
+                li
+                    strong Links: 
+                    each link in links
+                        a( href=link.url )
+                            | #{link.text}
+                        | . 
         div: p !{ contents }
 
 block content

--- a/layouts/events_index.pug
+++ b/layouts/events_index.pug
@@ -24,6 +24,15 @@ mixin renderEventRow(item)
             else
                 a( href=item.link )
                     +renderEventTitle(item)
+            span( class="small")
+                if item.tease != ''
+                    | #{item.tease} 
+                if item.links
+                    | ( 
+                    each link in item.links
+                        a( href=link.url )
+                            | #{link.text}. 
+                    | )
         td
             if item.continent
                 img(style="float:right;" src='/images/icons/' + item.continent + '.png')

--- a/layouts/events_index_webinars.pug
+++ b/layouts/events_index_webinars.pug
@@ -24,6 +24,15 @@ mixin renderEventRow(item)
             else
                 a( href=item.link )
                     +renderEventTitle(item)
+            span( class="small")
+                if item.tease != ''
+                    | #{item.tease} 
+                if item.links
+                    | ( 
+                    each link in item.links
+                        a( href=link.url )
+                            | #{link.text}. 
+                    | )
         td
             if item.continent
                 img(style="float:right;" src='/images/icons/' + item.continent + '.png')

--- a/src/events/2020-09-niaid/index.md
+++ b/src/events/2020-09-niaid/index.md
@@ -3,17 +3,17 @@ title: "Galaxy for Immunological and Infectious Disease Research"
 date: '2020-09-04'
 days: 1
 tease: ''
-continent: GL
+continent: NA
 location: 'Online, NIAID, United States'
 image: /src/images/logos/niaid-logo.png
 location_url: ""
 external_url: ""
 gtn: false
 tags: [ webinar ]
+links:
+  - text: "Intro slides"
+    url: "https://depot.galaxyproject.org/hub/attachments/events/2020-09-niaid/galaxy-intro-niaid.pdf"
+  - text: "Evolution of SARS-CoV-2 slides"
+    url: "http://data.hyphy.org/web/galaxy-niaid.pdf"
 contact: "Dave Clements, Steven Weaver"
 ---
-
-This webinar was presented in two parts:
-
-* [Introduction to the Galaxy Ecosystem](https://depot.galaxyproject.org/hub/attachments/events/2020-09-niaid/galaxy-intro-niaid.pdf), Dave Clements
-* [Evolution of SARS-CoV-2](http://data.hyphy.org/web/galaxy-niaid.pdf), Steven Weaver

--- a/src/events/2020-11-du-novo/index.md
+++ b/src/events/2020-11-du-novo/index.md
@@ -10,5 +10,8 @@ external_url: "https://depot.galaxyproject.org/hub/attachments/events/2020-11-du
 gtn: false
 contact: "Barbara Arbeithuber, Nick Stoler "
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://www.youtube.com/watch?v=yP8noF2fyMs"
 image: 
 ---

--- a/src/events/2020-12-chloroplast/index.md
+++ b/src/events/2020-12-chloroplast/index.md
@@ -2,7 +2,7 @@
 title: "Plant genomics: chloroplast genome assembly using Galaxy Australia"
 date: '2020-12-10'
 days: 1
-tease: "Webinar&nbsp;"
+tease: "Webinar"
 continent: AU
 location: "Online"
 location_url: "https://unimelb.zoom.us/webinar/register/WN_N7o065f8QG60ZRFw2_JxYg"


### PR DESCRIPTION
Two things:

* now displaying tease with each event in events listing pages.
* added links to events. Displaying those in events listing pages too.

I'm not sure if updating the NIAID event page like this PR did is a best practice or not.  The du novo event page links outside the hub, so it seems like a good idea to list the video link on the events list (and it isn't listed at the external page).  However, the NIAID page is internal to the hub, and this info was already displayed in a better way on that page.  I dunno.