### PR TITLE
Events update

### DIFF
--- a/src/events/2020-03-wir-vs-virus/index.md
+++ b/src/events/2020-03-wir-vs-virus/index.md
@@ -4,7 +4,7 @@ date: '2020-03-20'
 days: 3
 tease: "Looking for bold and innovative ideas that will help society to show solidarity now and emerge stronger"
 continent: EU
-location: "Online"
+location: "Online, Germany"
 location_url: 
 external_url: "https://galaxyproject.eu/posts/2020/03/19/wirvsvirus/"
 image: 

--- a/src/events/2020-04-biocompute/index.md
+++ b/src/events/2020-04-biocompute/index.md
@@ -4,11 +4,11 @@ Galaxy in a Cloud Computing Environment"
 date: '2020-04-01'
 days: 2
 tease: ""
-continent: GL
-location: "Exploring Clouds for Acceleration of Science (E-CAS), Online"
+continent: NA
+location: "Exploring Clouds for Acceleration of Science (E-CAS), Online, United States"
 location_url: 
-external_url: "https://www.internet2.edu/blogs/detail/17595"
+external_url: "https://www.youtube.com/watch?v=8pwss1SY8Tg"
 gtn: false
-contact: "Presenters"
+contact: "Raja Mazumder, Jonathon Keeney, Charles Hadley King, Janisha Patel"
 image: 
 ---

--- a/src/events/2020-04-elixir-covid-1/index.md
+++ b/src/events/2020-04-elixir-covid-1/index.md
@@ -3,12 +3,15 @@ title: "Introduction to Galaxy and the Galaxy workflows for SARS-CoV-2 data anal
 date: '2020-04-30'
 days: 1
 tease: "Part of the Galaxy-ELIXIR webinar series"
-continent: GL
-location: "Galaxy-ELIXIR webinar series, Online"
-external_url: "https://register.gotowebinar.com/register/2484378815187103504"
+continent: EU
+location: "Galaxy-ELIXIR webinar series, Online, Europe"
+external_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session1"
 location_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19"
 gtn: true
 contact: "Anton Nekrutenko, Frederik Coppens"
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session1" 
 image: 
 ---

--- a/src/events/2020-04-workflow/index.md
+++ b/src/events/2020-04-workflow/index.md
@@ -3,11 +3,11 @@ title: "Galaxy: much more than a workflow management system"
 date: '2020-04-02'
 days: 2
 tease: ""
-continent: GL
-location: "Workshop on Workflow Platforms, EOSC-Life, Online"
+continent: EU
+location: "Workshop on Workflow Platforms, Online, EOSC-Life, Florence, Italy"
 location_url: "https://www.eosc-life.eu/news/workshop-on-workflow-management-systems/"
 external_url: "https://drive.google.com/file/d/1j_AYy7Jn0WXL5BZxtVGVU1qMGVHxf954/preview"
 gtn: false
-contact: "Björn Grüning, Frederik Coppens"
+contact: "Beatriz Serrano-Solano, Björn Grüning, Frederik Coppens"
 image: 
 ---

--- a/src/events/2020-05-covid-byow/index.md
+++ b/src/events/2020-05-covid-byow/index.md
@@ -3,8 +3,8 @@ title: "COVID-19 Virtual Bring Your Own Workflow"
 date: "2020-05-27"
 days: 1
 tease: "Anyone who has a COVID-19 related workflow is invited to come along and we will work with you to register your workflow in the Workflow Hub and learn how to make the Hub better."
-continent: GL
-location: "University of Manchester, Online"
+continent: EU
+location: "University of Manchester, Online, Manchester, United Kingdom"
 image: 
 location_url: ""
 external_url: "https://apps.mhs.manchester.ac.uk/surveys/TakeSurvey.aspx?SurveyID=l4KMn871I"

--- a/src/events/2020-05-elixir-covid-2/index.md
+++ b/src/events/2020-05-elixir-covid-2/index.md
@@ -3,12 +3,15 @@ title: "Genomics/Variant Calling"
 date: '2020-05-07'
 days: 1
 tease: "Part of the Galaxy-ELIXIR webinar series"
-continent: GL
-location: "Galaxy-ELIXIR webinar series, Online"
-external_url: "https://attendee.gotowebinar.com/register/6993001011673446160"
+continent: EU
+location: "Galaxy-ELIXIR webinar series, Online, Europe"
+external_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session2"
 location_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19"
 gtn: true
 contact: "Anton Nekrutenko, Wolfgang Maier"
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session2" 
 image: 
 ---

--- a/src/events/2020-05-elixir-covid-3/index.md
+++ b/src/events/2020-05-elixir-covid-3/index.md
@@ -4,11 +4,14 @@ date: '2020-05-14'
 days: 1
 tease: "Part of the Galaxy-ELIXIR webinar series"
 continent: GL
-location: "Galaxy-ELIXIR webinar series, Online"
-external_url: "https://attendee.gotowebinar.com/register/4607898607259954448"
+location: "Galaxy-ELIXIR webinar series, Online, Europe"
+external_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session3"
 location_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19"
 gtn: true
 contact: "Tim Dudgeon, Simon Bray"
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session3"
 image: 
 ---

--- a/src/events/2020-05-elixir-covid-3/index.md
+++ b/src/events/2020-05-elixir-covid-3/index.md
@@ -3,7 +3,7 @@ title: "Cheminformatics: Screening of the main protease"
 date: '2020-05-14'
 days: 1
 tease: "Part of the Galaxy-ELIXIR webinar series"
-continent: GL
+continent: EU
 location: "Galaxy-ELIXIR webinar series, Online, Europe"
 external_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session3"
 location_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19"

--- a/src/events/2020-05-elixir-covid-4/index.md
+++ b/src/events/2020-05-elixir-covid-4/index.md
@@ -3,12 +3,15 @@ title: "Evolution of the Virus"
 date: '2020-05-20'
 days: 1
 tease: "Part of the Galaxy-ELIXIR webinar series"
-continent: GL
-location: "Galaxy-ELIXIR webinar series, Online"
-external_url: "https://attendee.gotowebinar.com/register/3263865489071323920"
+continent: EU
+location: "Galaxy-ELIXIR webinar series, Online, Europe"
+external_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session4"
 location_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19"
 gtn: true
 contact: "Sergei Pond"
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session4"
 image: 
 ---

--- a/src/events/2020-05-elixir-covid-5/index.md
+++ b/src/events/2020-05-elixir-covid-5/index.md
@@ -3,12 +3,15 @@ title: "Galaxy Deployment"
 date: '2020-05-28'
 days: 1
 tease: "Part of the Galaxy-ELIXIR webinar series"
-continent: GL
-location: "Galaxy-ELIXIR webinar series, Online"
-external_url: "https://attendee.gotowebinar.com/register/7607010086065649936"
+continent: EU
+location: "Galaxy-ELIXIR webinar series, Online, Europe"
+external_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session5"
 location_url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19"
 gtn: true
 contact: "TBD"
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19#session5"
 image: 
 ---

--- a/src/events/2020-05-gtn/index.md
+++ b/src/events/2020-05-gtn/index.md
@@ -4,7 +4,7 @@ date: '2020-05-28'
 days: 1
 tease: ""
 continent: GL
-location: "Online"
+location: "Online, Global"
 image:
 location_url:
 external_url:

--- a/src/events/2020-05-qcif-variant/index.md
+++ b/src/events/2020-05-qcif-variant/index.md
@@ -3,8 +3,8 @@ title: "Variant Detection Using Galaxy"
 date: "2020-05-19"
 days: 1
 tease: "Detection of small variants, including SNPs and small indels, from next-generation sequencing data."
-continent: GL
-location: "QCIF, Online"
+continent: AU
+location: "Online, QCIF, Brisbane, Queensland, Australia"
 image: 
 location_url: "https://www.qcif.edu.au/training/training-courses/"
 external_url: "https://www.qcif.edu.au/trainingcourses/variant-detection-using-galaxy/"

--- a/src/events/2020-05-sgci/index.md
+++ b/src/events/2020-05-sgci/index.md
@@ -3,12 +3,17 @@ title: "Galaxy Project: Enabling an active global research community"
 date: "2020-05-13"
 days: 1
 tease: "Find out about Galaxy's community emphasis"
-continent: GL
-location: "SGCI Webinar Series, Online"
+continent: NA
+location: "SGCI Webinar Series, Online, North America"
 image: 
 location_url: "https://sciencegateways.org/engage/webinars"
-external_url: "https://depot.galaxyproject.org/hub/attachments/events/2020-05-sgci/2020-05-sgci-community.pdf"
+external_url: "https://sciencegateways.org/-/galaxy-project-enabling-an-active-global-research-community"
 gtn: false
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://youtu.be/fxF4iljMB0E" 
+  - text: "Slides"
+    url:  "https://depot.galaxyproject.org/hub/attachments/events/2020-05-sgci/2020-05-sgci-community.pdf"
 contact: "Dave Clements"
 ---

--- a/src/events/2020-05-veupathdb/index.md
+++ b/src/events/2020-05-veupathdb/index.md
@@ -3,11 +3,14 @@ title: "Running a Galaxy workflow and integrating data into VEuPathDB"
 date: "2020-05-14"
 days: 1
 tease: "Run a workflow in galaxy and exporting the results to your VEuPathDB workspace."
-continent: GL
-location: "Online"
+continent: NA
+location: "Online, University of Georgia, Athens, Georgia, United States"
 image: 
 location_url: ""
-external_url: "https://register.gotowebinar.com/register/2911235617248014349"
+external_url: "https://calendar.uga.edu/event/veupathdb_webinar_-_running_a_galaxy_workflow_and_integrating_data_into_veupathdb#.X68c-dt7nUI"
 gtn: false
-contact: "Instrucotrs"
+links:
+  - text: "Video"
+    url: "https://youtu.be/k15AJlZpNH8"
+contact: "Instructors"
 ---

--- a/src/events/2020-06-ebi-single-cell/index.md
+++ b/src/events/2020-06-ebi-single-cell/index.md
@@ -1,10 +1,10 @@
 ---
 title: "Starting Single Cell RNA-Seq Analysis"
-date: '2020-05-11'
+date: '2020-06-01'
 days: 5
 tease: "Utilising Galaxy throughout."
-continent: GL
-location: "EMBL-EBI, Online"
+continent: EU
+location: "Online, EMBL-EBI, Hinxton, United Kingdom"
 location_url: "https://www.ebi.ac.uk/training"
 external_url: "https://www.ebi.ac.uk/training/events/2020/starting-single-cell-rna-seq-analysis"
 gtn: false

--- a/src/events/2020-06-elixir/index.md
+++ b/src/events/2020-06-elixir/index.md
@@ -3,8 +3,8 @@ title: "ELIXIR Galaxy Community Meeting"
 date: '2020-06-08'
 days: 3
 tease: ""
-continent: GL
-location: "ELIXIR All Hands 2020, Online"
+continent: EU
+location: "ELIXIR All Hands 2020, Online, Europe"
 location_url: "https://elixir-europe.org/events/elixir-all-hands-2020"
 external_url: "https://docs.google.com/document/d/1Y1Etfprc9FJaYxc02Xml8b4fbBxHVnLXiMXD1Y0KoS4/edit#heading=h.rpm2xffxtlgg"
 gtn: false

--- a/src/events/2020-06-ml/index.md
+++ b/src/events/2020-06-ml/index.md
@@ -3,11 +3,14 @@ title: "Machine Learning using Galaxy"
 date: "2020-06-22"
 days: 5
 tease: "Register by 16 June"
-continent: GL
-location: "University of Freiburg, Online"
+continent: EU
+location: "University of Freiburg, Online, Freiburg, Germany"
 image: 
 location_url: ""
 external_url: "https://galaxyproject.eu/event/2020-05-27-Machine-Learning-Elixir/"
 gtn: true
+links:
+  - text: "Slides"
+    url: "https://docs.google.com/document/d/1Ug93xz-ogrn8bhjKUsOQQSxNtWZoR3gFOfOHXs4F1nc/preview"
 contact: "Alireza Khanteymoori"
 ---

--- a/src/events/2020-06-qcif-assembly/index.md
+++ b/src/events/2020-06-qcif-assembly/index.md
@@ -3,8 +3,8 @@ title: "Genome Assembly Using Galaxy"
 date: "2020-06-09"
 days: 1
 tease: "de novo assembly and initial annotation of a genome from short-read NGS data"
-continent: GL
-location: "QCIF, Online"
+continent: AU
+location: "QCIF, Online, Brisbane, Queensland, Australia"
 image: 
 location_url: "https://www.qcif.edu.au/training/training-courses/"
 external_url: "https://www.qcif.edu.au/trainingcourses/genome-assembly-using-galaxy/"

--- a/src/events/2020-06-rsg-turkey/index.md
+++ b/src/events/2020-06-rsg-turkey/index.md
@@ -3,8 +3,8 @@ title: "INSaFLU ve galaxyproject ile SARS-CoV-2 varyantlarının karşılaştır
 date: '2020-06-21'
 days: 1
 tease: "comparison of SARS-CoV-2 variants with INSaFLU and Galaxu"
-continent: GL
-location: "RSG Turkey, Online"
+continent: AS
+location: "RSG Turkey, Online, Turkey"
 location_url: ""
 external_url: "http://rsgturkey.com/en/insaflu-ve-galaxyproject-ile-sarscov2-varyantlarinin-karsilastirilmasi/"
 gtn: false

--- a/src/events/2020-06-sgci-jumpstart/index.md
+++ b/src/events/2020-06-sgci-jumpstart/index.md
@@ -3,8 +3,8 @@ title: "Jumpstart Your Sustainability Plan"
 date: '2020-06-16'
 days: 3
 tease: "Make your gateway sustainable"
-continent: GL
-location: "Scientific Gateways Community Institue, Online"
+continent: NA
+location: "Scientific Gateways Community Institue, Online, United States"
 location_url: ""
 external_url: "https://sciencegateways.org/engage/focus-week/jumpstart"
 gtn: false

--- a/src/events/2020-06-sgci/index.md
+++ b/src/events/2020-06-sgci/index.md
@@ -3,12 +3,17 @@ title: "Galaxy: Powering Science from the Desktop to Global Cyberinfrastructure"
 date: "2020-06-24"
 days: 1
 tease: "The ins and outs of the Galaxy platform"
-continent: GL
-location: "SGCI Webinar Series, Online"
+continent: NA
+location: "SGCI Webinar Series, Online, United States"
 image: 
 location_url: "https://sciencegateways.org/engage/webinars"
-external_url: "https://sciencegateways.org/engage/webinars"
+external_url: "https://sciencegateways.org/-/galaxy-powering-science-from-the-desktop-to-global-cyberinfrastructure"
 gtn: false
 tags: [ webinar ]
+links:
+  - text: "Video"
+    url: "https://youtu.be/MVWN4yl1yig"
+  - text: "Slides"
+    url: "https://sciencegateways.org/documents/20182/25103/Galaxy_Cyberinfrastructure_Webinar_Slides.pdf"
 contact: "Nate Coraor"
 ---

--- a/src/events/2020-06-sib-introduction/index.md
+++ b/src/events/2020-06-sib-introduction/index.md
@@ -4,7 +4,7 @@ date: '2020-06-17'
 days: 1
 tease: ""
 continent: GL
-location: "EFPL, Lausanne, Online"
+location: "EFPL, Online, Lausanne, Switzerland"
 location_url: "https://www.sib.swiss/training"
 external_url: "https://www.sib.swiss/training/course/2020-06-galaxy"
 gtn: true

--- a/src/events/2020-06-sra/index.md
+++ b/src/events/2020-06-sra/index.md
@@ -3,13 +3,18 @@ title: "Webinar: Using the new Galaxy-SRA Connection"
 date: '2020-06-24'
 days: 1
 tease: ""
-continent: GL
-location: "Online"
+continent: NA
+location: "Online, United States"
 location_url: "https://docs.google.com/forms/d/e/1FAIpQLSfeAjnJSEfG11ngNn_sS3imPiXuHhdUcDSaBO6u__88xRnMbA/viewform"
 external_url: ""
 gtn: true
 contact: "Dan Blankenberg, Marius van den Beek, Dave Clements"
 tags: [ webinar ]
+links:
+  - text: "Slides"
+    url: "https://depot.galaxyproject.org/hub/attachments/events/2020-06-sra/sra-galaxy-slides.pdf"
+  - text: "Video"
+    url: "https://depot.galaxyproject.org/hub/attachments/events/2020-06-sra/sra-galaxy-webinar.mp4"
 image: "galaxy-sra.png"
 ---
 

--- a/src/events/2020-07-09-dev-roundtable/index.md
+++ b/src/events/2020-07-09-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2020-07-09'
 days: 1
 tease: ""
 continent: GL
-location: "Galaxy Developer Roundtable, Online"
+location: "Galaxy Developer Roundtable, Online, Global"
 image: 
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2020-07-bhki/index.md
+++ b/src/events/2020-07-bhki/index.md
@@ -3,8 +3,8 @@ title: "End user open source bioinformatics tools"
 date: "2020-07-30"
 days: 1
 tease: "Get your hands dirty with the Galaxy workflow and tools"
-continent: GL
-location: "Bioinformatics Hub of Kenya, Online"
+continent: AF
+location: "Bioinformatics Hub of Kenya, Online, Kenya"
 image: 
 location_url: "https://bioinformaticshubofkenya.wordpress.com/upcoming-event/"
 external_url: "https://docs.google.com/forms/d/e/1FAIpQLSdzdwCDd3wg--RfGJff54sz1hEV-r5Kuzj-5YIEbrHStJjpew/viewform"

--- a/src/events/2020-07-mpds/index.md
+++ b/src/events/2020-07-mpds/index.md
@@ -3,7 +3,7 @@ title: "MPDS and Open Source Tools for Computer Aided Drug Discovery"
 date: '2020-07-23'
 days: 1
 tease: ''
-continent: GL
+continent: AS
 location: 'DDH2020 Training Program, Online, India'
 image: 
 location_url: "http://www.neist.res.in/ddh2020/"

--- a/src/events/2020-07-nci-data-science/index.md
+++ b/src/events/2020-07-nci-data-science/index.md
@@ -3,8 +3,8 @@ title: "Data Science for Science Teachers Bootcamp"
 date: "2020-07-06"
 days: 5
 tease: "learn data science techniques and how to communicate this highly desired, cutting-edge skill set with your students’ coursework."
-continent: GL
-location: "US National Cancer Institute, Online"
+continent: NA
+location: "US National Cancer Institute, Online, United States"
 image: 
 location_url: ""
 external_url: "https://events.cancer.gov/sbmab/ds-bootcamp"

--- a/src/events/2020-07-pawsey/index.md
+++ b/src/events/2020-07-pawsey/index.md
@@ -3,8 +3,8 @@ title: "Galaxy Australia COVID-19 Dedicated Pulsar"
 date: "2020-07-31"
 days: 1
 tease: ""
-continent: GL
-location: "HPC COVID-19 Australian Response Showcase, Online"
+continent: AU
+location: "HPC COVID-19 Australian Response Showcase, Online, Australia"
 image: 
 location_url: ""
 external_url: "https://pawsey.org.au/event/pawsey-friday-covid19/"

--- a/src/events/2020-07-qcif-rna-seq/index.md
+++ b/src/events/2020-07-qcif-rna-seq/index.md
@@ -3,8 +3,8 @@ title: "RNA-Seq Analysis Using Galaxy"
 date: "2020-07-14"
 days: 1
 tease: "RNA-Seq analysis, from data preparation through to statistical testing for differential gene expression, along with more advanced topics such as identification of novel transcription features and pathway and functional enrichment analysis."
-continent: GL
-location: "QCIF, Online"
+continent: AU
+location: "QCIF, Online, Brisbane, Queensland, Australia"
 image: 
 location_url: "https://www.qcif.edu.au/training/training-courses/"
 external_url: "https://www.qcif.edu.au/trainingcourses/rna-seq-analysis-using-galaxy/"

--- a/src/events/2020-08-qcif-metagenomics/index.md
+++ b/src/events/2020-08-qcif-metagenomics/index.md
@@ -3,8 +3,8 @@ title: "Metagenomics Analysis Using Galaxy"
 date: "2020-08-11"
 days: 1
 tease: "16S bacterial metagenomics analysis."
-continent: GL
-location: "QCIF, Online"
+continent: AU
+location: "QCIF, Online, Brisbane, Queensland, Australia"
 image: 
 location_url: "https://www.qcif.edu.au/training/training-courses/"
 external_url: "https://www.qcif.edu.au/trainingcourses/rna-seq-analysis-using-galaxy/"

--- a/src/events/2020-08-wgs/index.md
+++ b/src/events/2020-08-wgs/index.md
@@ -3,8 +3,8 @@ title: "Whole Genome Sequencing, Bioinformatics​"
 date: "2020-08-10"
 days: 3
 tease: "Online, hands on workshop"
-continent: GL
-location: " Sarvasumana Association, India, Online"
+continent: AS
+location: " Sarvasumana Association, Online, India"
 image: 
 location_url: "http://sarvasumana.in/"
 external_url: "https://docs.google.com/forms/d/e/1FAIpQLSdc1vZi6ryZ1lVsuv3IB8nxeBvd1MgEJoXhSgu2MJU9lwGs1A/viewform"

--- a/src/events/2020-09-03-dev-roundtable/index.md
+++ b/src/events/2020-09-03-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2020-09-03'
 days: 1
 tease: ""
 continent: GL
-location: "Galaxy Developer Roundtable, Online"
+location: "Galaxy Developer Roundtable, Online, Global"
 image: 
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2020-09-biocompute-isb/index.md
+++ b/src/events/2020-09-biocompute-isb/index.md
@@ -4,7 +4,7 @@ date: "2020-09-24"
 days: 1
 tease: ""
 continent: GL
-location: "ISB Workshop, Online"
+location: "ISB Workshop, Online, Global"
 image: "/src/use/biocompute-object/biocompute-objects-logo.png"
 location_url: "https://www.biocuration.org/biocuration-2020-online-workshops/"
 external_url: ""

--- a/src/events/2020-09-goblet/index.md
+++ b/src/events/2020-09-goblet/index.md
@@ -3,8 +3,8 @@ title: "Galaxy @ GOBLET 2020 AGM"
 tease: "Galaxy for learning, education, and training"
 date: '2020-09-14'
 days: 3
-continent: GL
-location: "Online"
+continent: EU
+location: "Online, Sweden"
 location_url: "https://mygoblet.org/goblet-agm2020/"
 external_url: ""
 contact: "Fotis Psomopoulos, Gareth Price"

--- a/src/events/2020-09-melb-assembly/index.md
+++ b/src/events/2020-09-melb-assembly/index.md
@@ -3,8 +3,8 @@ title: "Hybrid de novo genome assembly - Nanopore and Illumina"
 date: "2020-09-29"
 days: 1
 tease: "Learn how to create high-quality genome assemblies using the powerful combination of Nanopore and Illumina reads"
-continent: GL
-location: "Melbourne Bioinformatics, Online"
+continent: AU
+location: "Melbourne Bioinformatics, Online, Melbourne, Victoria, Australia"
 image: 
 location_url: "https://www.melbournebioinformatics.org.au/training-and-events/"
 external_url: "https://www.eventbrite.com.au/e/hybrid-de-novo-genome-assembly-nanopore-and-illumina-online-tickets-118408967409"

--- a/src/events/2020-09-melb-intro/index.md
+++ b/src/events/2020-09-melb-intro/index.md
@@ -3,8 +3,8 @@ title: "Introduction to Galaxy & Galaxy Workflows"
 date: "2020-09-23"
 days: 1
 tease: "Don't like the command line? Use Galaxy."
-continent: GL
-location: "Melbourne Bioinformatics, Online"
+continent: AU
+location: "Melbourne Bioinformatics, Online, Melbourne, Victoria, Australia"
 image: 
 location_url: "https://www.melbournebioinformatics.org.au/training-and-events/"
 external_url: "https://www.eventbrite.com.au/e/introduction-to-galaxy-galaxy-workflows-online-tickets-118405573257"

--- a/src/events/2020-09-niaid/index.md
+++ b/src/events/2020-09-niaid/index.md
@@ -4,7 +4,7 @@ date: '2020-09-04'
 days: 1
 tease: ''
 continent: NA
-location: 'Online, NIAID, United States'
+location: 'NIAID, Online, United States'
 image: /src/images/logos/niaid-logo.png
 location_url: ""
 external_url: ""

--- a/src/events/2020-09-qcif-ngs/index.md
+++ b/src/events/2020-09-qcif-ngs/index.md
@@ -3,8 +3,8 @@ title: "An Introduction to NGS Platforms and Bioinformatics Analysis"
 date: "2020-09-08"
 days: 1
 tease: "Hands-on practical workshop: an introduction to next generation sequencing technologies and how they work, providers, common bioinformatics workflows, standardised file types, quality control and an introduction to Galaxy Australia."
-continent: GL
-location: "QCIF, Online"
+continent: AU
+location: "QCIF, Online, Brisbane, Queensland, Australia"
 image: 
 location_url: "https://www.qcif.edu.au/training/training-courses/"
 external_url: "https://www.qcif.edu.au/trainingcourses/ngs-platforms-how-data-generation-impacts-bioinformatics-analysis/"

--- a/src/events/2020-10-01-dev-roundtable/index.md
+++ b/src/events/2020-10-01-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2020-10-01'
 days: 1
 tease: ""
 continent: GL
-location: "Galaxy Developer Roundtable, Online"
+location: "Galaxy Developer Roundtable, Online, Global"
 image: 
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2020-10-15-dev-roundtable/index.md
+++ b/src/events/2020-10-15-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2020-10-15'
 days: 1
 tease: ""
 continent: GL
-location: "Online"
+location: "Online, Global"
 image: "/images/galaxy-logos/galaxy-developer-roundtable-300.png"
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2020-10-29-dev-roundtable/index.md
+++ b/src/events/2020-10-29-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2020-10-29'
 days: 1
 tease: "Tool testing and tool deployment discussion"
 continent: GL
-location: "Online"
+location: "Online, Global"
 image: "/images/galaxy-logos/galaxy-developer-roundtable-300.png"
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2020-10-elixir-tools/index.md
+++ b/src/events/2020-10-elixir-tools/index.md
@@ -3,8 +3,8 @@ title: "Ask the ELIXIR-Tools Working Group - Anything!"
 date: '2020-10-15'
 days: 1
 tease: 'Answers to questions about Bio.tools, OpenEbench, BioContainers, and Galaxy workflows'
-continent: GL
-location: 'Europe, Online'
+continent: EU
+location: 'Online, Europe'
 image: 
 location_url: ""
 external_url: "https://www.eventbrite.co.uk/e/elixir-tools-platform-ask-us-anything-registration-124523221307/"

--- a/src/events/2020-10-eresearch-australasia/index.md
+++ b/src/events/2020-10-eresearch-australasia/index.md
@@ -3,8 +3,8 @@ title: "Galaxy @ eResearch Australasia 2020"
 date: '2020-10-19'
 days: 5
 tease: "a whole lot of Galaxy Australia"
-continent: GL
-location: "Australia, Online"
+continent: AU
+location: "Online, Australia"
 location_url: "https://conference.eresearch.edu.au/"
 external_url:
 gtn: true

--- a/src/events/2020-10-fates/index.md
+++ b/src/events/2020-10-fates/index.md
@@ -3,8 +3,8 @@ title: "Functionally Assembled Terrestrial Ecosystem Simulator (FATES)"
 date: '2020-10-26'
 days: 2
 tease: 'Learn to compose and execute repeatable and reproducible modelling workflow with FATES for improving climate models.'
-continent: GL
-location: 'Norway, Online'
+continent: EU
+location: 'EOSC-Life, Online, Oslo, Norway'
 image: 
 location_url: ""
 external_url: "https://nordicesmhub.github.io/2020-10-26-galaxy-fates/"

--- a/src/events/2020-10-gateways/index.md
+++ b/src/events/2020-10-gateways/index.md
@@ -3,8 +3,8 @@ title: "Gateways 2020"
 date: '2020-10-19'
 days: 3
 tease: "an opportunity for gateway creators and enthusiasts to learn, share, connect, and shape the future of gateways"
-continent: GL
-location: "Online"
+continent: NA
+location: "SGCI, Online, Maryland, United States"
 location_url: ""
 external_url: "https://sciencegateways.org/web/gateways2020/welcome"
 gtn: false

--- a/src/events/2020-10-jupytercon/index.md
+++ b/src/events/2020-10-jupytercon/index.md
@@ -3,8 +3,8 @@ title: "Climate JupyterLab as an interactive tool in Galaxy"
 date: '2020-10-12'
 days: 5
 tease: 'Bridging the gap between climate scientists and non-climate specialists'
-continent: GL
-location: 'JupyterCon, Online'
+continent: EU
+location: 'JupyterCon, Online, Europe'
 image: 
 location_url: "https://jupytercon.com/"
 external_url: "https://cfp.jupytercon.com/2020/schedule/presentation/184/climate-jupyterlab-as-an-interactive-tool-in-galaxy/"

--- a/src/events/2020-10-ml-iscb-la/index.md
+++ b/src/events/2020-10-ml-iscb-la/index.md
@@ -3,8 +3,8 @@ title: "Machine Learning in Bioinformatics using Galaxy"
 date: '2020-10-26'
 days: 1
 tease: ""
-continent: GL
-location: "ISCB-LA SoIBio BioNetMX 2020, Mexico, Online"
+continent: NA
+location: "ISCB-LA SoIBio BioNetMX 2020, Online, Mexico"
 location_url: "https://www.iscb.org/iscb-latinamerica2020-p-s/iscb-latinamerica2020-worktut"
 external_url: "https://galaxyproject.eu/event/2020-10-22-Machine-Learning-ISCB2020/"
 gtn: true

--- a/src/events/2020-10-papercuts/index.md
+++ b/src/events/2020-10-papercuts/index.md
@@ -4,7 +4,7 @@ date: '2020-10-21'
 days: 1
 tease: 'A community contribution day'
 continent: GL
-location: 'Global, online'
+location: 'Online, Global'
 image: "papercuts-2020-10-21.png"
 location_url: ""
 external_url:

--- a/src/events/2020-11-12-dev-roundtable/index.md
+++ b/src/events/2020-11-12-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2020-11-12'
 days: 1
 tease: "Galaxy Training Network"
 continent: GL
-location: "Online"
+location: "Online, Global"
 image: "/images/galaxy-logos/galaxy-developer-roundtable-300.png"
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2020-11-abc-intro/index.md
+++ b/src/events/2020-11-abc-intro/index.md
@@ -3,8 +3,8 @@ title: "Online data analysis for biologists"
 date: '2020-11-12'
 days: 1
 tease: "Get a hands-on introduction to Galaxy, an online platform for data analysis"
-continent: GL
-location: "Australian BioCommons, Australia, Online"
+continent: AU
+location: "Australian BioCommons, Online, Melbourne, Victoria, Australia"
 location_url: ""
 external_url: "https://www.eventbrite.com.au/e/online-data-analysis-for-biologists-november-2020-tickets-123259172503"
 gtn: true

--- a/src/events/2020-11-abc-webinar/index.md
+++ b/src/events/2020-11-abc-webinar/index.md
@@ -4,7 +4,7 @@ date: '2020-11-04'
 days: 1
 tease: "Webinar: Data analysis without the need for programming experience"
 continent: GL
-location: "Australian BioCommons, Australia, Online"
+location: "Australian BioCommons, Online, Melbourne, Victoria, Australia"
 location_url: ""
 external_url: "https://www.biocommons.org.au/events/galaxy-aust-mass-spec"
 gtn: false

--- a/src/events/2020-11-du-novo/index.md
+++ b/src/events/2020-11-du-novo/index.md
@@ -4,7 +4,7 @@ date: '2020-11-10'
 days: 1
 tease: "A GalaxyPro Webinar"
 continent: NA
-location: "Online, GalaxyWorks, United States"
+location: "GalaxyWorks, Online, United States"
 location_url: "https://galaxyworks.io/webinars/"
 external_url: "https://depot.galaxyproject.org/hub/attachments/events/2020-11-du-novo/du-novo-webinar.pdf"
 gtn: false

--- a/src/events/2020-11-du-novo/index.md
+++ b/src/events/2020-11-du-novo/index.md
@@ -3,8 +3,8 @@ title: "Ultra-Low Variant Detection: Du Novo Sequencing"
 date: '2020-11-10'
 days: 1
 tease: "A GalaxyPro Webinar"
-continent: GL
-location: "GalaxyWorks, United States, Online"
+continent: NA
+location: "Online, GalaxyWorks, United States"
 location_url: "https://galaxyworks.io/webinars/"
 external_url: "https://depot.galaxyproject.org/hub/attachments/events/2020-11-du-novo/du-novo-webinar.pdf"
 gtn: false

--- a/src/events/2020-11-egi/index.md
+++ b/src/events/2020-11-egi/index.md
@@ -3,8 +3,8 @@ title: "Diving into the Galaxy: an accessible and reproducible workbench with an
 date: '2020-11-02'
 days: 4
 tease: "Best-practices, tools, workflow development, transparent and reproducible research"
-continent: GL
-location: "EGI Conference 2020, Netherlands, Online"
+continent: EU
+location: "EGI Conference 2020, Online, Netherlands"
 location_url: "https://indico.egi.eu/event/5000/"
 external_url: "https://indico.egi.eu/event/5000/timetable/?view=standard_inline_minutes#b-5085-keynote-diving-into-the"
 gtn: false

--- a/src/events/2020-11-gateways-focus/index.md
+++ b/src/events/2020-11-gateways-focus/index.md
@@ -3,8 +3,8 @@ title: "Gateways Focus Week"
 date: '2020-11-30'
 days: 11
 tease: "Make your gateway sustainable"
-continent: GL
-location: "SDSC, La Jolla, California, United States, Online"
+continent: NA
+location: "SDSC, Online, La Jolla, California, United States"
 location_url: ""
 external_url: "https://sciencegateways.org/engage/focus-week"
 gtn: false

--- a/src/events/2020-11-gtn/index.md
+++ b/src/events/2020-11-gtn/index.md
@@ -4,7 +4,7 @@ date: '2020-11-19'
 days: 1
 tease: ""
 continent: GL
-location: "Online"
+location: "Online, Global"
 image:
 location_url:
 external_url:

--- a/src/events/2020-11-papercuts/index.md
+++ b/src/events/2020-11-papercuts/index.md
@@ -4,7 +4,7 @@ date: '2020-11-18'
 days: 1
 tease: 'A community contribution day'
 continent: GL
-location: 'Global, online'
+location: 'Online, Global'
 image: "papercuts-2020-11-18.png"
 location_url: ""
 external_url:

--- a/src/events/2020-12-10-dev-roundtable/index.md
+++ b/src/events/2020-12-10-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2020-12-10'
 days: 1
 tease: "What should be covered in Galaxy Developer Training?"
 continent: GL
-location: "Online"
+location: "Online, Global"
 image: "/images/galaxy-logos/galaxy-developer-roundtable-300.png"
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2020-12-abc-intro/index.md
+++ b/src/events/2020-12-abc-intro/index.md
@@ -3,8 +3,8 @@ title: "Online data analysis for biologists"
 date: '2020-12-09'
 days: 1
 tease: "Get a hands-on introduction to Galaxy, an online platform for data analysis"
-continent: GL
-location: "Australian BioCommons, Australia, Online"
+continent: AU
+location: "Australian BioCommons, Online, Melbourne, Victoria, Australia"
 location_url: ""
 external_url: "https://www.eventbrite.com.au/e/online-data-analysis-for-biologists-december-2020-tickets-123610812267"
 gtn: true

--- a/src/events/2020-12-chloroplast/index.md
+++ b/src/events/2020-12-chloroplast/index.md
@@ -4,7 +4,7 @@ date: '2020-12-10'
 days: 1
 tease: "Webinar"
 continent: AU
-location: "Online"
+location: "Australian BioCommons, Online, Melbourne, Victoria, Australia"
 location_url: "https://unimelb.zoom.us/webinar/register/WN_N7o065f8QG60ZRFw2_JxYg"
 external_url: "https://www.biocommons.org.au/events/chloroplastgenomeassembly"
 gtn: true

--- a/src/events/2020-12-tools-hack/index.md
+++ b/src/events/2020-12-tools-hack/index.md
@@ -3,8 +3,8 @@ title: "Hackathon sur les outils interactifs de Galaxy (GxIT)"
 date: '2020-12-07'
 days: 4
 tease: "Un Hackathon pour partager des compétences en terme du développement logiciel et d'administration système des Interactive Tools de Galaxy."
-continent: GL
-location: "France, Online"
+continent: EU
+location: "Online, France"
 location_url: ""
 external_url: "https://forgemia.inra.fr/geoc/hackaton2020"
 gtn: false

--- a/src/events/2020-12-vib-proteomics/index.md
+++ b/src/events/2020-12-vib-proteomics/index.md
@@ -3,8 +3,8 @@ title: "DDA and DIA proteomic analysis in Galaxy"
 date: '2020-12-03'
 days: 2
 tease: "Label-free Proteomics data analysis in Galaxy "
-continent: GL
-location: "Ghent, Belgium, Online"
+continent: EU
+location: "VIB, Online, Ghent, Belgium"
 location_url: ""
 external_url: "https://training.vib.be/all-trainings/dda-and-dia-proteomic-analysis-galaxy"
 gtn: true

--- a/src/events/2020-12-webinar-where/index.md
+++ b/src/events/2020-12-webinar-where/index.md
@@ -4,7 +4,7 @@ date: '2020-12-09'
 days: 1
 tease: "Options for using Galaxy: everywhere and right now"
 continent: GL
-location: "United States, Online"
+location: "Online, Global"
 location_url: ""
 external_url: ""
 gtn: false

--- a/src/events/2020-ashg/index.md
+++ b/src/events/2020-ashg/index.md
@@ -3,8 +3,8 @@ title: "GWAS Analysis with Galaxy on the Analysis Visualization Integrated Lab-s
 tease: ""
 date: '2020-10-27'
 days: 5
-continent: GL
-location: "ASHG 2020, Online"
+continent: NA
+location: "ASHG 2020, Online, San Diego, California, United States"
 external_url: "https://www.abstractsonline.com/pp8/#!/9070/session/146"
 location_url: "https://www.ashg.org/meetings/2020meeting/"
 contact: 'Dave Clements, Alex Ostrovsky'

--- a/src/events/2020-asms/index.md
+++ b/src/events/2020-asms/index.md
@@ -3,8 +3,8 @@ title:  "Galaxy @ ASMS 2020"
 date: '2020-06-01'
 days: 12
 tease: 
-continent: GL
-location: "ASMS 2020, Online"
+continent: NA
+location: "ASMS 2020, Online, San Antonio, Texas, United States"
 image: /images/logos/ASMSLogo.png
 location_url: "https://www.asms.org/conferences/asms-2020-reboot"
 external_url: 

--- a/src/events/2020-eshg/index.md
+++ b/src/events/2020-eshg/index.md
@@ -3,8 +3,8 @@ title: "Reproducible and Transparent Analysis of SARS/Cov-2 intra-host variants 
 date: '2020-06-06'
 days: 4
 tease: ""
-continent: GL
-location: "ESHG 2020, Online"
+continent: EU
+location: "ESHG 2020, Online, Berlin, Germany"
 location_url: "https://2020.eshg.org/"
 external_url: "https://2020.eshg.org/index.php/programme/monday/#accordion-3224-5"
 gtn: true

--- a/src/events/2020-ismb/index.md
+++ b/src/events/2020-ismb/index.md
@@ -3,8 +3,8 @@ title: 'Galaxy @ ISMB 2020'
 date: '2020-07-12'
 days: 5
 tease: ""
-continent: GL
-location: "ISMB 2020, Online"
+continent: NA
+location: "ISMB 2020, Online, Montreal, Quebec, Canada"
 image: "ismb-2020-logo-wide.jpg"
 location_url: "https://www.iscb.org/ismb2020/"
 external_url:

--- a/src/events/2021-01-07-dev-roundtable/index.md
+++ b/src/events/2021-01-07-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2021-01-07'
 days: 1
 tease: "TBD"
 continent: GL
-location: "Online"
+location: "Online, Global"
 image: "/images/galaxy-logos/galaxy-developer-roundtable-300.png"
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/2021-01-21-dev-roundtable/index.md
+++ b/src/events/2021-01-21-dev-roundtable/index.md
@@ -4,7 +4,7 @@ date: '2021-01-21'
 days: 1
 tease: "TBD"
 continent: GL
-location: "Online"
+location: "Online, Global"
 image: "/images/galaxy-logos/galaxy-developer-roundtable-300.png"
 location_url: "/community/devroundtable/"
 external_url:

--- a/src/events/bcc2020/index.md
+++ b/src/events/bcc2020/index.md
@@ -4,7 +4,7 @@ date: '2020-07-18'
 days: 8
 tease: "Galaxy & BOSC join forces again for 8 days of training, meeting, networking and collaborative work"
 continent: GL
-location: "Online"
+location: "Online, Global"
 location_url: ""
 external_url: "https://bcc2020.github.io/"
 image: 


### PR DESCRIPTION
Changed how online events are listed.  They had been listed as Global, but everything is online now, and listing everything as Global communicates nothing about time zones.  So, events are still listed as online, but if they have a clear home, then that is listed now instead of "Global."