### PR TITLE
Fix invalid boolean value in 2017-10-04-gvl-intro.

### DIFF
--- a/src/events/2017-10-04-gvl-intro/index.md
+++ b/src/events/2017-10-04-gvl-intro/index.md
@@ -9,5 +9,5 @@ location_url: https://www.melbournebioinformatics.org.au/
 image: /images/logos/melbourne-bioinformatics.png
 external_url: https://www.eventbrite.com.au/e/introduction-to-galaxy-the-genomics-virtual-laboratory-4-oct-registration-37299824780
 contact: 'enquiries @ melbourne bio informatics . org . au'
-gtn: truees
+gtn: true
 ---


### PR DESCRIPTION
`truees` isn't a valid bool, it appears.