### PR TITLE
Fix remark being overly picky about slot parsing

### DIFF
--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -10,7 +10,7 @@
                     `insert.name` variable: https://vuejs.org/v2/guide/components-slots.html#Dynamic-Slot-Names
                 -->
                 <template v-for="insert of $page.article.inserts" #[insert.name]>
-                    <p class="markdown" :key="insert.name + ':md'" v-html="mdToHtml(insert.content)" />
+                    <p class="markdown" :key="insert.name + ':md'" v-html="insert.content" />
                     <p class="d-none" :key="insert.name + ':p'">Issue #758 workaround</p>
                 </template>
             </VueRemarkContent>
@@ -57,7 +57,6 @@ query VueArticle($path: String!) {
 <script>
 import ArticleHeader from "@/components/ArticleHeader";
 import ArticleFooter from "@/components/ArticleFooter";
-import { mdToHtml } from "~/utils.js";
 export default {
     components: {
         ArticleHeader,
@@ -67,9 +66,6 @@ export default {
         return {
             title: this.$page.article.title,
         };
-    },
-    methods: {
-        mdToHtml,
     },
     computed: {
         mdClasses() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -182,7 +182,7 @@ function mdToHtml(md) {
     //TODO: Fix links (E.g. `/src/main/index.md` -> `/main/`)
     let rawHtml;
     remark()
-        .use(remarkHtml)
+        .use(remarkHtml, { sanitize: false })
         .process(md, (err, file) => {
             if (err) {
                 console.error(err);
@@ -190,8 +190,6 @@ function mdToHtml(md) {
                 rawHtml = String(file);
             }
         });
-    // Real dumb, but works.
-    rawHtml = rawHtml.trim() || md;
     return rmPrefix(rmSuffix(rawHtml.trim(), "</p>"), "<p>");
 }
 module.exports.mdToHtml = mdToHtml;

--- a/src/utils.js
+++ b/src/utils.js
@@ -190,6 +190,8 @@ function mdToHtml(md) {
                 rawHtml = String(file);
             }
         });
+    // Real dumb, but works.
+    rawHtml = rawHtml.trim() || md;
     return rmPrefix(rmSuffix(rawHtml.trim(), "</p>"), "<p>");
 }
 module.exports.mdToHtml = mdToHtml;


### PR DESCRIPTION
This works around https://github.com/remarkjs/remark-html/releases/tag/13.0.2 changing the default sanitization in a patch release.

It additionally cuts out redundant parsing that we discovered when this broke.