### PR TITLE
Re-implement `/use/feed.json` from old Hub

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -266,19 +266,31 @@ module.exports = function (api) {
           }`);
     })
 
+    api.configureServer(async (app) => {
+        // Serve /use/feed.json from develop server.
+        app.get("/use/feed.json", (request, response) => {
+            response.set("Content-Type", "application/json");
+            response.send(makePlatformsJson(platformsData));
+        });
+    });
+
     api.afterBuild(async () => {
         // Write all Platforms to /use/feed.json.
-        let platforms = platformsData.data.platforms.edges.map(edge => {
-            // Massage fields a little for backward compatibility.
-            let node = edge.node;
-            node.link = rmSuffix(node.path, "/");
-            node.path = path.join(rmPrefix(node.path, "/"), "index.md");
-            return node;
-        });
         let outDir = path.join(__dirname, "dist", "use");
         fs.mkdirSync(outDir, { recursive: true });
         let feedPath = path.join(outDir, "feed.json");
-        fs.writeFile(feedPath, JSON.stringify(platforms, null, '  '), error => {if (error) throw error});
+        fs.writeFile(feedPath, makePlatformsJson(platformsData), error => {if (error) throw error});
     });
 
 };
+
+function makePlatformsJson(platformsData) {
+    let platforms = platformsData.data.platforms.edges.map(edge => {
+        // Massage fields a little for backward compatibility.
+        let node = edge.node;
+        node.link = rmSuffix(node.path, "/");
+        node.path = path.join(rmPrefix(node.path, "/"), "index.md");
+        return node;
+    });
+    return JSON.stringify(platforms, null, '  ');
+}

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -10,7 +10,7 @@ const path = require("path");
 const { imageType } = require("gridsome/lib/graphql/types/image");
 const { repr, rmPrefix, rmSuffix, dateToStr, dateStrDiff, matchesPrefixes } = require("./src/utils");
 
-const CONFIG = JSON.parse(fs.readFileSync("config.json", "utf8"));
+const CONFIG = JSON.parse(fs.readFileSync(path.join(__dirname, "config.json"), "utf8"));
 const COMPILE_DATE = dateToStr(new Date());
 const IMAGE_REGISTRY = new Set();
 const IMAGE_PREFIX_WHITELIST = ["images/", "https://", "http://"];
@@ -192,6 +192,7 @@ class nodeModifier {
 }
 
 module.exports = function (api) {
+
     api.loadSource((actions) => {
         // Using the Data Store API: https://gridsome.org/docs/data-store-api/
         // Add derived `category` field.
@@ -202,13 +203,12 @@ module.exports = function (api) {
          *      This is supposed to be fixed by Gridsome 1.0.
          */
         actions.addSchemaTypes(`
-      type Article implements Node @infer {
-        category: String
-        has_date: Boolean
-        days_ago: Int
-        closed: Boolean
-      }
-    `);
+            type Article implements Node @infer {
+                category: String
+                has_date: Boolean
+                days_ago: Int
+                closed: Boolean
+            }`);
         let collections = ["Article", "VueArticle"].concat(Object.keys(CONFIG["collections"]));
         let schemas = {};
         for (let collection of collections) {
@@ -229,4 +229,56 @@ module.exports = function (api) {
         node.filename = node.fileInfo.name;
         return nodeModifier.processNewNode(node, collection, typeName);
     });
+
+    // Workaround for lack of access to GraphQL in `afterBuild()` hook.
+    // Taken from https://github.com/gridsome/gridsome/issues/1390#issuecomment-748792934
+    let platformsData;
+    api.createPages(async ({ graphql }) => {
+        platformsData = await graphql(`
+        query {
+            platforms: allPlatform(sortBy: "title", order: ASC) {
+              totalCount
+              edges {
+                node {
+                  id
+                  url
+                  path
+                  title
+                  image
+                  scope
+                  summary
+                  comments
+                  user_support
+                  quotas
+                  citations
+                  pub_libraries
+                  sponsors
+                  platforms {
+                    platform_group
+                    platform_url
+                    platform_text
+                    platform_location
+                    platform_purview
+                  }
+                }
+              }
+            }
+          }`);
+    })
+
+    api.afterBuild(async () => {
+        // Write all Platforms to /use/feed.json.
+        let platforms = platformsData.data.platforms.edges.map(edge => {
+            // Massage fields a little for backward compatibility.
+            let node = edge.node;
+            node.link = rmSuffix(node.path, "/");
+            node.path = path.join(rmPrefix(node.path, "/"), "index.md");
+            return node;
+        });
+        let outDir = path.join(__dirname, "dist", "use");
+        fs.mkdirSync(outDir, { recursive: true });
+        let feedPath = path.join(outDir, "feed.json");
+        fs.writeFile(feedPath, JSON.stringify(platforms, null, '  '), error => {if (error) throw error});
+    });
+
 };


### PR DESCRIPTION
The new file should match the old one, with the only exception being the addition of an `id` attribute for each platform.