### PR TITLE
Fix time links papercuts

### DIFF
--- a/content/events/2021-09-papercuts/index.md
+++ b/content/events/2021-09-papercuts/index.md
@@ -75,13 +75,13 @@ If you have time, and want to learn more about contributing you are encouraged t
 We will be on [Gitter](https://gitter.im/galaxyproject/Lobby) for chat all day long, and on 3 calls spread across the day. Please take advantage of both to communicate with your collaborators around the world.
 
 * **Call 1: Oceania, Australia, Asia**
-  * 14:00 Australia Eastern time.  [See your time](https://www.timeanddate.com/worldclock/fixedtime.html?msg=14%3A00+Melbourne+Galaxy+Papercuts+CoFest+Call&iso=20210916T14&p1=152&am=30).
+  * 14:00 Australia Eastern time.  <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg=14%3A00+Melbourne+Galaxy+Papercuts+CoFest+Call&iso=20210916T14&p1=152&am=30">See your time</a>.
   * [Zoom Link](https://zoom.us/j/98189403566?pwd=SWhueXkzNHlKSG1QMU0xUG1ESFFsUT09)
 * **Call 2: Middle East, Europe, Africa**
-  * 10:00 Central European Summer time.  [See your time](https://www.timeanddate.com/worldclock/fixedtime.html?msg=10%3A00+Freiburg+Galaxy+Papercuts+CoFest+Call&iso=20210916T10&p1=980&am=30).
+  * 10:00 Central European Summer time.  <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg=10%3A00+Freiburg+Galaxy+Papercuts+CoFest+Call&iso=20210916T10&p1=980&am=30">See your time</a>.
   * [Zoom Link](https://us02web.zoom.us/j/89108992104?pwd=eHhWdFFUQThnVVFwZ3RRall4WjBXQT09)
 * **Call 3: Americas**
-  * 12:00 US Eastern time.  [See your time](https://www.timeanddate.com/worldclock/fixedtime.html?msg=12%3A00+Penn+State+Galaxy+Papercuts+CoFest+Call&iso=20210916T12&p1=3705&am=30).
+  * 12:00 US Eastern time.  <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg=12%3A00+Penn+State+Galaxy+Papercuts+CoFest+Call&iso=20210916T12&p1=3705&am=30">See your time</a>.
   * [Zoom Link](https://zoom.us/j/98189403566?pwd=SWhueXkzNHlKSG1QMU0xUG1ESFFsUT09)
 
 ## After the event

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -192,7 +192,6 @@ class nodeModifier {
 }
 
 module.exports = function (api) {
-
     api.loadSource((actions) => {
         // Using the Data Store API: https://gridsome.org/docs/data-store-api/
         // Add derived `category` field.
@@ -235,36 +234,37 @@ module.exports = function (api) {
     let platformsData;
     api.createPages(async ({ graphql }) => {
         platformsData = await graphql(`
-        query {
-            platforms: allPlatform(sortBy: "title", order: ASC) {
-              totalCount
-              edges {
-                node {
-                  id
-                  url
-                  path
-                  title
-                  image
-                  scope
-                  summary
-                  comments
-                  user_support
-                  quotas
-                  citations
-                  pub_libraries
-                  sponsors
-                  platforms {
-                    platform_group
-                    platform_url
-                    platform_text
-                    platform_location
-                    platform_purview
-                  }
+            query {
+                platforms: allPlatform(sortBy: "title", order: ASC) {
+                    totalCount
+                    edges {
+                        node {
+                            id
+                            url
+                            path
+                            title
+                            image
+                            scope
+                            summary
+                            comments
+                            user_support
+                            quotas
+                            citations
+                            pub_libraries
+                            sponsors
+                            platforms {
+                                platform_group
+                                platform_url
+                                platform_text
+                                platform_location
+                                platform_purview
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }`);
-    })
+        `);
+    });
 
     api.configureServer(async (app) => {
         // Serve /use/feed.json from develop server.
@@ -279,18 +279,19 @@ module.exports = function (api) {
         let outDir = path.join(__dirname, "dist", "use");
         fs.mkdirSync(outDir, { recursive: true });
         let feedPath = path.join(outDir, "feed.json");
-        fs.writeFile(feedPath, makePlatformsJson(platformsData), error => {if (error) throw error});
+        fs.writeFile(feedPath, makePlatformsJson(platformsData), (error) => {
+            if (error) throw error;
+        });
     });
-
 };
 
 function makePlatformsJson(platformsData) {
-    let platforms = platformsData.data.platforms.edges.map(edge => {
+    let platforms = platformsData.data.platforms.edges.map((edge) => {
         // Massage fields a little for backward compatibility.
         let node = edge.node;
         node.link = rmSuffix(node.path, "/");
         node.path = path.join(rmPrefix(node.path, "/"), "index.md");
         return node;
     });
-    return JSON.stringify(platforms, null, '  ');
+    return JSON.stringify(platforms, null, "  ");
 }


### PR DESCRIPTION
Mentioned in the commit message, but we really need to track down what's mangling this stuff in a non-standard way.  Either & should just work, or &amp; should work, but currently an extra \ gets injected somewhere in markdown handling causing the links to break.

Also ran formatting.