### PR TITLE
Omit empty jumbotron.

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -4,7 +4,7 @@
             <h1 class="display-4">{{ $page.main.title }}</h1>
         </header>
 
-        <section class="section-content jumbotron" v-if="$page.jumbotron">
+        <section class="section-content jumbotron" v-if="$page.jumbotron && $page.jumbotron.content.trim()">
             <div class="row text-center markdown" v-html="$page.jumbotron.content" />
         </section>
 

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -8,7 +8,7 @@
             <div class="row text-center markdown" v-html="$page.jumbotron.content" />
         </section>
 
-        <section class="section-content">
+        <section class="section-content main-content">
             <div id="splash-row">
                 <div class="col-sm-12 lead markdown" v-html="$page.main.content" />
             </div>
@@ -213,6 +213,9 @@ query {
     background-color: lightyellow;
     padding-top: 100px;
     border: 4px solid black;
+}
+.header + .main-content {
+    margin-top: 40px;
 }
 .pseudo-card {
     background-color: #e0eaf2;


### PR DESCRIPTION
If `jumbotron.md` is present but empty, it would create a big, blank space on the homepage under the title.

This fixes that.