### PR TITLE
Improve the NavBar Github "edit me!" link

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -10,6 +10,7 @@ const jiti = require("jiti")(__filename);
 const remarkToc = jiti("remark-toc").default;
 const tocRemodel = jiti("./src/build/toc-remodel.mjs").default;
 const { rmPrefix, rmSuffix, rmPathPrefix } = require("./src/utils.js");
+const CONFIG = require("./config.json");
 const REMARK_PLUGINS = [
     [remarkToc, { skip: "end-table-of-contents" }],
     [tocRemodel, { tocAttrs: { class: "toc-wrapper col-md-3" }, bodyAttrs: { class: "body-wrapper col-md-9" } }],
@@ -17,7 +18,6 @@ const REMARK_PLUGINS = [
 const REMARK_VUE_PLUGINS = REMARK_PLUGINS;
 const REMARK_MD_PLUGINS = REMARK_PLUGINS.concat("remark-attr");
 
-const CONFIG = JSON.parse(fs.readFileSync("config.json", "utf8"));
 const MD_CONTENT_DIR = CONFIG.build.dirs.md;
 const VUE_CONTENT_DIR = CONFIG.build.dirs.vue;
 const CONTENT_DIR_DEPTH = rmSuffix(MD_CONTENT_DIR, "/").split("/").length;
@@ -115,7 +115,6 @@ module.exports = {
     icon: "./src/favicon.png",
     templates: mkTemplates(CONFIG["collections"]),
     plugins: mkPlugins(CONFIG["collections"]),
-
     css: {
         loaderOptions: {
             scss: {

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -8,9 +8,9 @@
 const fs = require("fs");
 const path = require("path");
 const { imageType } = require("gridsome/lib/graphql/types/image");
-const { repr, rmPrefix, rmSuffix, dateToStr, dateStrDiff, matchesPrefixes } = require("./src/utils");
+const { repr, rmPrefix, rmSuffix, dateToStr, dateStrDiff, matchesPrefixes } = require("./src/utils.js");
+const CONFIG = require("./config.json");
 
-const CONFIG = JSON.parse(fs.readFileSync(path.join(__dirname, "config.json"), "utf8"));
 const COMPILE_DATE = dateToStr(new Date());
 const IMAGE_REGISTRY = new Set();
 const IMAGE_PREFIX_WHITELIST = ["images/", "https://", "http://"];

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -57,24 +57,30 @@
         </b-collapse>
     </b-navbar>
 </template>
+
 <script>
+import path from "path";
+import { rmPrefix } from "~/utils.js";
+import CONFIG from "~/../config.json";
 const REPO_URL = "https://github.com/galaxyproject/galaxy-hub/";
-const EDIT_URL = `${REPO_URL}tree/master/content/`;
+const EDIT_PATH = "tree/master/content";
 export default {
     computed: {
         editUrl() {
-            // TODO: a more robust way to do this, this only works on
-            // article-based pages and we probably don't want a hacky mess of
-            // exceptions.  For now, just default to root (which has a README,
-            // etc., so is not unreasonable) for 'special' pages.
-            let articlePath = this?.$page?.article?.fileInfo?.path;
-            if (articlePath) {
-                articlePath = articlePath.replace(/^build\//, "");
-                articlePath = articlePath.replace(/^content-md\//, "");
-                return `${EDIT_URL}${articlePath}`;
+            let sourcePath;
+            if (this.$page.main?.fileInfo?.path) {
+                // Each Collection should have a `$page.main`.
+                // `fileInfo.path` for VueArticles already omits the build directory: `"events/gcc2019/index.md"`.
+                // For Articles it looks like `"build/content-md/community/index.md"`.
+                sourcePath = rmPrefix(this.$page.main.fileInfo.path, CONFIG?.build?.dirs?.md);
             } else {
-                return REPO_URL;
+                // Otherwise, this must be a dynamic page.
+                // Almost every dynamic page has a `main.md` Insert.
+                //TODO: 404.vue doesn't have a `main.md`, so that Github link will (perhaps appropriately) 404.
+                //      Not sure what the best fix is.
+                sourcePath = path.join(this.$route.path, "main.md");
             }
+            return path.join(REPO_URL, EDIT_PATH, sourcePath);
         },
     },
 };

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -1,14 +1,14 @@
 <template>
     <Layout>
-        <ArticleHeader :article="$page.article" />
-        <div :class="['content', 'markdown', ...mdClasses]" v-html="$page.article.content" />
-        <ArticleFooter :article="$page.article" />
+        <ArticleHeader :article="$page.main" />
+        <div :class="['content', 'markdown', ...mdClasses]" v-html="$page.main.content" />
+        <ArticleFooter :article="$page.main" />
     </Layout>
 </template>
 
 <page-query>
 query Article ($path: String!) {
-   article: article (path: $path) {
+   main: article (path: $path) {
     id
     title
     tease
@@ -17,9 +17,6 @@ query Article ($path: String!) {
     days
     contact
     contact_url
-    fileInfo {
-        path
-    }
     authors
     location
     location_url
@@ -32,9 +29,12 @@ query Article ($path: String!) {
       url
       text
     }
+    external_url
     image
     images
-    external_url
+    fileInfo {
+        path
+    }
     content
   }
 }
@@ -50,15 +50,15 @@ export default {
     },
     metaInfo() {
         return {
-            title: this.$page.article.title,
+            title: this.$page.main.title,
         };
     },
     computed: {
         mdClasses() {
             let classes = [];
-            if (this.$page.article.autotoc === true) {
+            if (this.$page.main.autotoc === true) {
                 classes.push("toc");
-            } else if (this.$page.article.autotoc === false) {
+            } else if (this.$page.main.autotoc === false) {
                 classes.push("notoc");
             }
             return classes;

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -2,17 +2,17 @@
     <Layout>
         <g-link to="/use/" class="link"> &larr; Platform Directory</g-link>
         <header>
-            <h1 class="pageTitle">{{ $page.platform.title }}</h1>
+            <h1 class="pageTitle">{{ $page.main.title }}</h1>
         </header>
         <div class="float-right image-box">
-            <a :href="$page.platform.url">
-                <g-image v-if="$page.platform.image" class="img-responsive" :src="getImage($page.platform.image)" />
-                <template v-else>{{ $page.platform.title }}</template>
+            <a :href="$page.main.url">
+                <g-image v-if="$page.main.image" class="img-responsive" :src="getImage($page.main.image)" />
+                <template v-else>{{ $page.main.title }}</template>
             </a>
         </div>
         <table class="table table-striped summary">
             <tbody>
-                <tr v-for="platform of $page.platform.platforms">
+                <tr v-for="platform of $page.main.platforms">
                     <th>{{ groupNames.get(platform.platform_group) }}:</th>
                     <td>
                         <a :href="platform.platform_url">{{ platform.platform_text }}</a>
@@ -21,12 +21,12 @@
                 <tr>
                     <th>Scope:</th>
                     <td>
-                        <a :href="`/use/#${$page.platform.scope}`">{{ scopeNames.get($page.platform.scope) }}</a>
+                        <a :href="`/use/#${$page.main.scope}`">{{ scopeNames.get($page.main.scope) }}</a>
                     </td>
                 </tr>
                 <tr>
                     <th>Summary:</th>
-                    <td class="markdown" v-html="mdToHtml($page.platform.summary)" />
+                    <td class="markdown" v-html="mdToHtml($page.main.summary)" />
                 </tr>
             </tbody>
         </table>
@@ -35,7 +35,7 @@
             <ul :key="series.name + ':ul'">
                 <li class="markdown" v-for="item in series.values" :key="item" v-html="item" />
                 <template v-if="series.key === 'citations'">
-                    <li class="zotero" v-for="tag in $page.platform.pub_libraries" :key="tag">
+                    <li class="zotero" v-for="tag in $page.main.pub_libraries" :key="tag">
                         <a :href="'https://www.zotero.org/groups/1732893/galaxy/tags/%3E' + tag">
                             {{ tag }} tagged publications
                         </a>
@@ -50,7 +50,7 @@
 
 <page-query>
 query Platform($path: String!) {
-   platform(path: $path) {
+   main: platform(path: $path) {
     id
     title
     url
@@ -69,6 +69,9 @@ query Platform($path: String!) {
     quotas
     citations
     sponsors
+    fileInfo {
+        path
+    }
   }
 }
 </page-query>
@@ -78,13 +81,13 @@ import { mdToHtml, titlecase, getImage } from "~/utils.js";
 export default {
     metaInfo() {
         return {
-            title: this.$page.platform.title,
+            title: this.$page.main.title,
         };
     },
     methods: {
         mdToHtml,
         getImage(imagePath) {
-            return getImage(imagePath, this.$page.platform.images);
+            return getImage(imagePath, this.$page.main.images);
         },
     },
     data() {
@@ -110,7 +113,7 @@ export default {
             for (let key of ["comments", "user_support", "quotas", "citations", "sponsors"]) {
                 let series = {
                     key: key,
-                    values: this.$page.platform[key].map(mdToHtml),
+                    values: this.$page.main[key].map(mdToHtml),
                     name: key.split("_").map(titlecase).join(" "),
                 };
                 serieses.push(series);

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -1,6 +1,6 @@
 <template>
     <Layout>
-        <ArticleHeader :article="$page.article" />
+        <ArticleHeader :article="$page.main" />
         <article :class="['content', 'markdown', ...mdClasses]">
             <VueRemarkContent>
                 <!--
@@ -9,19 +9,19 @@
                     replaces. `[insert.name]` allows the slot name to be dynamic, based on the value of the
                     `insert.name` variable: https://vuejs.org/v2/guide/components-slots.html#Dynamic-Slot-Names
                 -->
-                <template v-for="insert of $page.article.inserts" #[insert.name]>
+                <template v-for="insert of $page.main.inserts" #[insert.name]>
                     <p class="markdown" :key="insert.name + ':md'" v-html="insert.content" />
                     <p class="d-none" :key="insert.name + ':p'">Issue #758 workaround</p>
                 </template>
             </VueRemarkContent>
         </article>
-        <ArticleFooter :article="$page.article" />
+        <ArticleFooter :article="$page.main" />
     </Layout>
 </template>
 
 <page-query>
 query VueArticle($path: String!) {
-   article: vueArticle(path: $path) {
+   main: vueArticle(path: $path) {
     id
     title
     tease
@@ -42,13 +42,16 @@ query VueArticle($path: String!) {
       url
       text
     }
+    external_url
     image
     images
+    fileInfo {
+        path
+    }
     inserts {
       name
       content
     }
-    external_url
     content
   }
 }
@@ -64,15 +67,15 @@ export default {
     },
     metaInfo() {
         return {
-            title: this.$page.article.title,
+            title: this.$page.main.title,
         };
     },
     computed: {
         mdClasses() {
             let classes = [];
-            if (this.$page.article.autotoc === true) {
+            if (this.$page.main.autotoc === true) {
                 classes.push("toc");
-            } else if (this.$page.article.autotoc === false) {
+            } else if (this.$page.main.autotoc === false) {
                 classes.push("notoc");
             }
             return classes;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ const util = require("util");
 const remark = require("remark");
 const remarkHtml = require("remark-html");
 const slugify = require("@sindresorhus/slugify");
+const CONFIG = require("../config.json");
 
 /* Using a kludge here to allow:
  * 1) importing this as a module with the `import` statement
@@ -11,11 +12,6 @@ const slugify = require("@sindresorhus/slugify");
  * 3) easily referencing these functions from other functions in the same file
  * That's the `module.exports.repr = repr` pattern.
  */
-
-let CONFIG;
-if (fs && fs.existsSync && fs.existsSync("config.json")) {
-    CONFIG = JSON.parse(fs.readFileSync("config.json", "utf8"));
-}
 
 /** Template literal tag that converts all embedded values to their literal representations.
  *  Uses `util.inspect()` for the conversions.

--- a/src/utils.js
+++ b/src/utils.js
@@ -222,7 +222,7 @@ function ensurePrefix(string, char) {
 module.exports.ensurePrefix = ensurePrefix;
 
 function rmPrefix(rawString, prefix) {
-    if (rawString.indexOf(prefix) === 0) {
+    if (prefix && rawString.indexOf(prefix) === 0) {
         return rawString.slice(prefix.length);
     } else {
         return rawString;
@@ -231,6 +231,9 @@ function rmPrefix(rawString, prefix) {
 module.exports.rmPrefix = rmPrefix;
 
 function rmSuffix(rawString, suffix) {
+    if (! suffix) {
+        return rawString;
+    }
     let suffixIndex = rawString.length - suffix.length;
     if (rawString.slice(suffixIndex) === suffix) {
         return rawString.slice(0, suffixIndex);


### PR DESCRIPTION
This should handle almost every page:  
All Collections  
\- Article
\- VueArticle
\- Platform  
Dynamic pages  
\- src/pages/*.vue

For dynamic pages, I decided to just point to the `main.md` file instead of the `.vue` file since I'd imagine people who are interested in messing with the structure already know where the repo is. Those who need the link are more likely to be interested in fixing errors in the text.

One exception I know about is the 404.vue page, which has no `main.md`. The url will be broken on that page.

Perhaps in the future pages could define their own `sourcePath` that NavBar then uses.