### PR TITLE
A more conservative improvement to the editUrl NavBar link.

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -57,25 +57,38 @@
         </b-collapse>
     </b-navbar>
 </template>
+
 <script>
+import path from "path";
+import { rmPrefix } from "~/utils.js";
+import CONFIG from "~/../config.json";
 const REPO_URL = "https://github.com/galaxyproject/galaxy-hub/";
-const EDIT_URL = `${REPO_URL}tree/master/content/`;
+const EDIT_PATH = "tree/master/content";
 export default {
     computed: {
         editUrl() {
-            // TODO: a more robust way to do this, this only works on
-            // article-based pages and we probably don't want a hacky mess of
-            // exceptions.  For now, just default to root (which has a README,
-            // etc., so is not unreasonable) for 'special' pages.
-            let articlePath = this?.$page?.article?.fileInfo?.path;
-            if (articlePath) {
-                articlePath = articlePath.replace(/^build\//, "");
-                articlePath = articlePath.replace(/^content-md\//, "");
-                return `${EDIT_URL}${articlePath}`;
+            // This will only point to the exact Github source url for Collections which include a "fileInfo { path }"
+            // in their GraphQL query. Otherwise, (like for dynamic pages) it'll default to pointing to the repo home
+            // page (which has a README, etc., so is not unreasonable).
+            let sourcePath = getPath(this.$page);
+            if (sourcePath) {
+                sourcePath = rmPrefix(sourcePath, CONFIG.build.dirs.md);
+                return path.join(REPO_URL, EDIT_PATH, sourcePath);
             } else {
                 return REPO_URL;
             }
         },
     },
 };
+
+function getPath(page) {
+    if (page) {
+        for (let child of Object.values(page)) {
+            let path = child?.fileInfo?.path;
+            if (path) {
+                return path;
+            }
+        }
+    }
+}
 </script>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -59,10 +59,9 @@
 </template>
 
 <script>
-import path from "path";
 import { rmPrefix } from "~/utils.js";
 import CONFIG from "~/../config.json";
-const REPO_URL = "https://github.com/galaxyproject/galaxy-hub/";
+const REPO_URL = "https://github.com/galaxyproject/galaxy-hub";
 const EDIT_PATH = "tree/master/content";
 export default {
     computed: {
@@ -72,10 +71,14 @@ export default {
             // page (which has a README, etc., so is not unreasonable).
             let sourcePath = getPath(this.$page);
             if (sourcePath) {
+                // Remove build directory prefix (e.g. "build/content-md").
+                // `Article`s contain the prefix (e.g. "build/content-md/galaxy-project/statistics/index.md").
+                // `VueArticle`s lack it (e.g. "events/gcc2019/index.md").
                 sourcePath = rmPrefix(sourcePath, CONFIG.build.dirs.md);
-                return path.join(REPO_URL, EDIT_PATH, sourcePath);
+                sourcePath = rmPrefix(sourcePath, "/");
+                return `${REPO_URL}/${EDIT_PATH}/${sourcePath}`;
             } else {
-                return REPO_URL;
+                return REPO_URL+"/";
             }
         },
     },

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -32,6 +32,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
 }
 </page-query>

--- a/src/pages/Blog.vue
+++ b/src/pages/Blog.vue
@@ -38,6 +38,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/blog/footer/") {
     id

--- a/src/pages/Careers.vue
+++ b/src/pages/Careers.vue
@@ -34,6 +34,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/careers/footer/") {
     id

--- a/src/pages/Events.vue
+++ b/src/pages/Events.vue
@@ -55,6 +55,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/events/footer/") {
     id

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -124,6 +124,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   videos: insert(path: "/insert:/homepage-videos/") {
     id

--- a/src/pages/News.vue
+++ b/src/pages/News.vue
@@ -31,6 +31,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/news/footer/") {
     id

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -94,6 +94,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/search/footer/") {
     id

--- a/src/pages/Use.vue
+++ b/src/pages/Use.vue
@@ -340,6 +340,11 @@ export default {
 
 <page-query>
 query {
+  main: insert(path: "/insert:/use/main/") {
+    fileInfo {
+      path
+    }
+  }
   allInsert(filter: {path: {regex: "^/insert:/use/[^/]+/$"}}) {
     totalCount
     edges {

--- a/src/pages/events/Archive.vue
+++ b/src/pages/events/Archive.vue
@@ -41,6 +41,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/events/archive/footer/") {
     id

--- a/src/pages/events/Cofests.vue
+++ b/src/pages/events/Cofests.vue
@@ -55,6 +55,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/events/cofests/footer/") {
     id

--- a/src/pages/events/Webinars.vue
+++ b/src/pages/events/Webinars.vue
@@ -55,6 +55,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/events/webinars/footer/") {
     id

--- a/src/pages/events/cofests/Papercuts.vue
+++ b/src/pages/events/cofests/Papercuts.vue
@@ -55,6 +55,9 @@ query {
     id
     title
     content
+    fileInfo {
+      path
+    }
   }
   footer: insert(path: "/insert:/events/cofests/papercuts/footer/") {
     id

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -17,9 +17,6 @@ query Article ($path: String!) {
     days
     contact
     contact_url
-    fileInfo {
-        path
-    }
     authors
     location
     location_url
@@ -27,6 +24,7 @@ query Article ($path: String!) {
     source_blog_url
     skip_title_render
     redirect
+    external_url
     autotoc
     links {
       url
@@ -34,7 +32,9 @@ query Article ($path: String!) {
     }
     image
     images
-    external_url
+    fileInfo {
+        path
+    }
     content
   }
 }

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -69,6 +69,9 @@ query Platform($path: String!) {
     quotas
     citations
     sponsors
+    fileInfo {
+        path
+    }
   }
 }
 </page-query>

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -37,6 +37,7 @@ query VueArticle($path: String!) {
     source_blog_url
     skip_title_render
     redirect
+    external_url
     autotoc
     links {
       url
@@ -44,11 +45,13 @@ query VueArticle($path: String!) {
     }
     image
     images
+    fileInfo {
+        path
+    }
     inserts {
       name
       content
     }
-    external_url
     content
   }
 }


### PR DESCRIPTION
A less radical change than #810.

This provides a specific Github url for every current Collection (`Article`, `VueArticle`, `Platform`), and leaves dynamic (`.vue`) pages alone.

It accommodates the different naming of the main `$page` object by basically duck typing: it looks for anything with a `.fileInfo.path` property.

It also doesn't assume anything lacking that is a dynamic page, so for those cases it provides a general link to the repo.