### PR TITLE
404 page: Handle redirecting urls with spaces.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -138,14 +138,15 @@ function mdToHtml(md) {
 module.exports.mdToHtml = mdToHtml;
 
 function gridifyPath(rawPath) {
-    let rawParts = rawPath.split(path.sep);
+    let decodedPath = decodeURI(rawPath);
+    let rawParts = decodedPath.split("/");
     let lastPart = rawParts[rawParts.length - 1];
     if (lastPart.endsWith(".html")) {
         rawParts[rawParts.length - 1] = rmSuffix(lastPart, ".html");
         rawParts.push("");
     }
     let sluggedParts = rawParts.map(slugify);
-    return sluggedParts.join(path.sep);
+    return sluggedParts.join("/");
 }
 module.exports.gridifyPath = gridifyPath;
 


### PR DESCRIPTION
This adds a `decodeURI()` call to handle urls with spaces (represented internally as `%20`) when redirecting from the 404 page.

With this, all types of urls identified in #760 are handled.