### PR TITLE
Build process: Handle unusual exits from child processes in `run.mjs`.

### DIFF
--- a/src/build/mdfixer.mjs
+++ b/src/build/mdfixer.mjs
@@ -4,6 +4,7 @@ import nodePath from "path";
 import process from "process";
 import { fileURLToPath } from "url";
 import { unified } from "unified";
+//TODO: Move away from unified-args. Merely importing it causes preprocess.mjs' exit code to be masked.
 import * as unifiedArgs from "unified-args";
 import remarkParse from "remark-parse";
 import remarkFrontmatter from "remark-frontmatter";

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -11,60 +11,73 @@ const PROJECT_ROOT = nodePath.dirname(nodePath.dirname(SCRIPT_DIR));
 const PREPROCESSOR_PATH = nodePath.join(SCRIPT_DIR, "preprocess.mjs");
 const PREPROCESSOR_RELPATH = nodePath.relative(process.cwd(), PREPROCESSOR_PATH);
 
-let command = process.argv[2];
-
-if (command !== "develop" && command !== "build") {
-    console.error(repr`Invalid command ${command}. Must give 'develop' or 'build'.`);
-    process.exit(1);
-}
-
-// Preprocess content.
-let argv = process.argv.slice();
-argv[2] = "preprocess";
-let cmd1 = [PREPROCESSOR_RELPATH, ...argv.slice(2)].join(" ");
-console.log(`$ ${cmd1}`);
-let { status: code, signal} = childProcess.spawnSync(PREPROCESSOR_RELPATH, argv.slice(2), { stdio: "inherit" });
+let code = main(process.argv);
 if (code) {
-    console.error(`${cmd1} exited with code ${code}`);
-}
-if (signal) {
-    console.error(`${cmd1} exited due to signal ${signal}`);
-}
-if (code !== 0) {
-    process.exit(code);
+    process.exitCode = code;
 }
 
-// Start hot reloader, if running developer server.
-if (command === "develop") {
-    let args = ["watch", ...process.argv.slice(3)];
-    let cmd2 = [PREPROCESSOR_RELPATH, ...args].join(" ");
-    console.log(`$ ${cmd2} &`);
-    let watcher = childProcess.spawn(PREPROCESSOR_PATH, args, { stdio: "inherit" });
-    watcher.on('exit', (code, signal) => {
-        if (code) {
-            console.error(`${cmd2} exited with code ${code}`);
-        }
-        if (signal) {
-            console.error(`${cmd2} exited due to signal ${signal}`);
-        }
-        process.exit(code);
-    });
-}
+function main(rawArgv) {
+    let argv = rawArgv.slice();
+    let command = argv[2];
+    if (command !== "develop" && command !== "build") {
+        console.error(repr`Invalid command ${command}. Must give 'develop' or 'build'.`);
+        return 1;
+    }
 
-// Start Gridsome.
-let gridsomeExe = findGridsome();
-let cmd3 = `${gridsomeExe} ${command}`;
-console.log(`$ ${cmd3}`);
-let gridsome = childProcess.spawn(gridsomeExe, [command], { stdio: "inherit" });
-gridsome.on('exit', (code, signal) => {
+    // Preprocess content.
+    argv[2] = "preprocess";
+    let cmd1 = [PREPROCESSOR_RELPATH, ...argv.slice(2)].join(" ");
+    console.log(`$ ${cmd1}`);
+    let { status: code, signal} = childProcess.spawnSync(PREPROCESSOR_RELPATH, argv.slice(2), { stdio: "inherit" });
+    if (code) {
+        console.error(`${cmd1} exited with code ${code}`);
+    }
     if (signal) {
-        console.error(`${cmd3} exited due to signal ${signal}`);
+        console.error(`${cmd1} exited due to signal ${signal}`);
     }
-    if (code !== null) {
-        process.exitCode = code;
+    if (code !== 0) {
+        return code;
     }
-});
-//TODO: Get Gridsome's colors working in stdout again.
+
+    // Start hot reloader, if running developer server.
+    let watcher, cmd2;
+    if (command === "develop") {
+        let args = ["watch", ...argv.slice(3)];
+        cmd2 = [PREPROCESSOR_RELPATH, ...args].join(" ");
+        console.log(`$ ${cmd2} &`);
+        watcher = childProcess.spawn(PREPROCESSOR_PATH, args, { stdio: "inherit" });
+    }
+
+    // Start Gridsome.
+    //TODO: Get Gridsome's colors working in stdout again.
+    let gridsomeExe = findGridsome();
+    let cmd3 = `${gridsomeExe} ${command}`;
+    console.log(`$ ${cmd3}`);
+    let gridsome = childProcess.spawn(gridsomeExe, [command], { stdio: "inherit" });
+    gridsome.on('exit', (code, signal) => {
+        console.log(`${cmd3} received code ${code}, signal ${signal}`);
+        if (signal) {
+            console.error(`${cmd3} exited due to signal ${signal}`);
+        }
+        if (code) {
+            process.exitCode = code;
+        }
+    });
+
+    // Die if there is a watcher and it dies.
+    if (watcher) {
+        watcher.on('exit', (code, signal) => {
+            if (code) {
+                console.error(`${cmd2} exited with code ${code}`);
+            }
+            if (signal) {
+                console.error(`${cmd2} exited due to signal ${signal}`);
+            }
+            gridsome.kill();
+            process.exitCode = code;
+        });
+    }
+}
 
 /** Find the correct command to execute Gridsome. */
 function findGridsome() {


### PR DESCRIPTION
Preserve exit codes from subprocesses that die.

Kill the gridsome server if the watcher (for the hot reloader) dies.

Note: this still doesn't return a proper exit code if the watcher dies. That seems to be an issue inherent to using the `unified-args` package.