### PR TITLE
Cancel metadata redirect if user has left the page.

### DIFF
--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -56,7 +56,6 @@ function main(rawArgv) {
     console.log(`$ ${cmd3}`);
     let gridsome = childProcess.spawn(gridsomeExe, [command], { stdio: "inherit" });
     gridsome.on('exit', (code, signal) => {
-        console.log(`${cmd3} received code ${code}, signal ${signal}`);
         if (signal) {
             console.error(`${cmd3} exited due to signal ${signal}`);
         }

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -79,7 +79,8 @@ export default {
         if (this.article.redirect) {
             let url = getRedirectUrl(this.article.redirect);
             console.log(repr`Redirecting to ${url} in 5 seconds..`);
-            setTimeout(() => doRedirect(url), 5000);
+            let currentPath = window.location.pathname;
+            setTimeout(() => doRedirect(currentPath, url), 5000);
         }
     },
 };

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -8,7 +8,7 @@
             <strong>Note</strong>
             This content has a new home at
             <a :href="article.redirect">{{ article.redirect }}</a>
-            , which you will be redirected to in 5 seconds.
+            , which you will be redirected to in {{ redirectDelay }} seconds.
         </p>
         <g-image v-if="article.image" class="img-fluid main-image" :src="getImage(article)" />
         <h1 class="title" v-if="!article.skip_title_render">{{ article.title }}</h1>
@@ -56,6 +56,11 @@ export default {
     props: {
         article: { type: Object, required: true },
     },
+    data() {
+        return {
+            redirectDelay: 5,
+        }
+    },
     computed: {
         dateSpan() {
             if (this.article?.days > 1) {
@@ -78,9 +83,9 @@ export default {
     mounted() {
         if (this.article.redirect) {
             let url = getRedirectUrl(this.article.redirect);
-            console.log(repr`Redirecting to ${url} in 5 seconds..`);
+            console.log(repr`Redirecting to ${url} in ${this.redirectDelay} seconds..`);
             let currentPath = window.location.pathname;
-            setTimeout(() => doRedirect(currentPath, url), 5000);
+            setTimeout(() => doRedirect(currentPath, url), this.redirectDelay*1000);
         }
     },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -258,8 +258,11 @@ function getFilesShallow(dirPath, excludeExt = null) {
 }
 module.exports.getFilesShallow = getFilesShallow;
 
-function doRedirect(url) {
-    window.location.href = url;
+function doRedirect(currentPath, destUrl) {
+    // Cancel redirect if the user has navigated away already.
+    if (window.location.pathname === currentPath) {
+        window.location.href = destUrl;
+    }
 }
 module.exports.doRedirect = doRedirect;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -259,9 +259,11 @@ function getFilesShallow(dirPath, excludeExt = null) {
 module.exports.getFilesShallow = getFilesShallow;
 
 function doRedirect(currentPath, destUrl) {
-    // Cancel redirect if the user has navigated away already.
     if (window.location.pathname === currentPath) {
         window.location.href = destUrl;
+    } else {
+        // Cancel redirect if the user has navigated away already.
+        console.log(`Skipping redirect: user navigated away from ${currentPath}`);
     }
 }
 module.exports.doRedirect = doRedirect;


### PR DESCRIPTION
The `redirect` metadata key triggers the "this page has moved to" message and a redirect after 5 seconds.

But the user could hit the back button or leave via a link in those 5 seconds. Previously, the `setTimeout` would still fire the redirect even if they were already on another page.