### PR TITLE
Replace `unified-args` with `unified-engine` in `mdfixer.mjs`, clean up some build code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "sass": "^1.39.2",
     "sharp": "^0.29.1",
     "unified": "^10.1.0",
-    "unified-args": "^9.0.2",
+    "unified-engine": "^9.0.4",
     "unist-util-visit": "^4.0.0",
     "which": "^2.0.2"
   },

--- a/src/build/fix-links.mjs
+++ b/src/build/fix-links.mjs
@@ -47,11 +47,11 @@ export default function attacher(options) {
     return transformer;
 }
 
+/** Get the relative path of this file from the base directory.
+ *  Multiple bases can be given and this will chose the one which results in the shortest
+ *  relative path.
+ */
 function getDirPath(bases, cwd, filePathRaw) {
-    /** Get the relative path of this file from the base directory.
-     *  Multiple bases can be given and this will chose the one which results in the shortest
-     *  relative path.
-     */
     let dirPaths = [];
     for (let base of bases.filter((b) => b)) {
         let filePath = getRelFilePath(cwd, filePathRaw, base);
@@ -108,12 +108,12 @@ function fixHtmlLinks(node) {
     node.value = html;
 }
 
+/** Replace the value of HTML property `propName` in `elem` with the value `value` by directly
+ *  editing `htmlStr`.
+ *  Note: This requires `elem` to be parsed from `htmlStr` using `rehype-parse` with `verbose` set
+ *  to `true`.
+ */
 function editProperty(htmlStr, elem, propName, value) {
-    /** Replace the value of HTML property `propName` in `elem` with the value `value` by directly
-     *  editing `htmlStr`.
-     *  Note: This requires `elem` to be parsed from `htmlStr` using `rehype-parse` with `verbose` set
-     *  to `true`.
-     */
     // Note: This does not check if there are double-quotes in `value`.
     // That would result in invalid HTML.
     let propData = elem.data.position.properties[propName];
@@ -123,12 +123,12 @@ function editProperty(htmlStr, elem, propName, value) {
     return prefix + replacement + suffix;
 }
 
+/** Find all the elements of a given type in a `hast` tree rooted at `elem`.
+ * NOTE: `elem` should be of type `element` or `root`. This does not check that.
+ */
 function getElementsByTagNames(elem, tagNames) {
-    /** Find all the elements of a given type in a `hast` tree rooted at `elem`.
-     * NOTE: `elem` should be of type `element` or `root`. This does not check that.
-     */
     let results = [];
-    if (tagNames.indexOf(elem.tagName) >= 0) {
+    if (tagNames.includes(elem.tagName)) {
         results.push(elem);
     }
     for (let child of elem.children) {
@@ -139,8 +139,8 @@ function getElementsByTagNames(elem, tagNames) {
     return results;
 }
 
+/** Perform all the editing appropriate for a hyperlink url (whether in HTML or Markdown). */
 function fixHyperLink(rawUrl) {
-    /** Perform all the editing appropriate for a hyperlink url (whether in HTML or Markdown). */
     // Full parsing is needed to take care of situations like a trailing url #fragment.
     if (matchesPrefixes(rawUrl, PREFIX_WHITELIST)) {
         return rawUrl;
@@ -158,8 +158,8 @@ function fixHyperLink(rawUrl) {
     return url;
 }
 
+/** Perform all the editing appropriate for an image src url (whether in HTML or Markdown). */
 function fixImageLink(rawPath) {
-    /** Perform all the editing appropriate for an image src url (whether in HTML or Markdown). */
     let path = rmPrefix(rawPath, "/src");
     if (globals.dirPath) {
         path = toRelImagePath(globals.dirPath, path, PREFIX_WHITELIST);

--- a/src/build/html-img-to-md.mjs
+++ b/src/build/html-img-to-md.mjs
@@ -55,12 +55,12 @@ function replaceImgs(rootNode, index, parent) {
     parent.children.splice(index, 1, ...replacements);
 }
 
+/** Does this HTML fragment contain only `<img>` elements?
+ * `imgElems`: The `<img>` elements parsed from the HTML using `rehype-parse`
+ *   (the output of `findImgElems()`).
+ * `htmlLength`: The length of the HTML string parsed by `rehype-parse`.
+ */
 function containsOnlyImgs(imgElems, htmlLength) {
-    /** Does this HTML fragment contain only `<img>` elements?
-     * `imgElems`: The `<img>` elements parsed from the HTML using `rehype-parse`
-     *   (the output of `findImgElems()`).
-     * `htmlLength`: The length of the HTML string parsed by `rehype-parse`.
-     */
     let lastImgEnd = 0;
     for (let imgElem of imgElems) {
         if (imgElem.position.start.offset !== lastImgEnd) {

--- a/src/build/keep-newline-before-html.mjs
+++ b/src/build/keep-newline-before-html.mjs
@@ -26,12 +26,7 @@ function fixer(node, index, parent) {
     let newChildren = [];
     let lastChild;
     for (let child of parent.children) {
-        if (
-            child.type == "html" &&
-            lastChild &&
-            !lastChild.keepNewlineKludge &&
-            EXCLUDED.indexOf(lastChild.type) === -1
-        ) {
+        if (child.type == "html" && lastChild && !lastChild.keepNewlineKludge && !EXCLUDED.includes(lastChild.type)) {
             newChildren.push({ type: "text", value: "", keepNewlineKludge: true });
         }
         newChildren.push(child);

--- a/src/build/mdfixer.mjs
+++ b/src/build/mdfixer.mjs
@@ -4,8 +4,7 @@ import nodePath from "path";
 import process from "process";
 import { fileURLToPath } from "url";
 import { unified } from "unified";
-//TODO: Move away from unified-args. Merely importing it causes preprocess.mjs' exit code to be masked.
-import * as unifiedArgs from "unified-args";
+import * as unifiedEngine from "unified-engine";
 import remarkParse from "remark-parse";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkStringify from "remark-stringify";
@@ -29,8 +28,8 @@ const REMARK_STRINGIFY_OPTIONS = {
 const program = new Command();
 program
     .arguments("<input>")
-    .option("-q, --quiet", "Output only warnings and errors.")
-    .option("-o, --output [path]", "Specify output location. Give without a path to overwrite the original file(s).")
+    .option("-o, --output <path>", "Specify output location.")
+    .option("-O, --overwrite", "Edit the input files in-place. The input path must be a directory.")
     .option(
         "-w, --watch",
         "Watch the given directory for changes in Markdown files and update the output. Only works if " +
@@ -42,6 +41,7 @@ program
         "The root content directory for this input file. Only needed when working on a single input " +
             "file, not a directory."
     )
+    .option("-q, --quiet", "Output only warnings and errors.")
     .option("--inspect", "Output formatted syntax tree.")
     .option("-l, --limit <limit>", "Only process this many html nodes in the <img> replacer.", (l) => parseInt(l))
     .option("--debug")
@@ -62,23 +62,33 @@ export function main(inputPath, opts) {
             opts[key] = value;
         }
     }
+    // Validate arguments.
+    if (opts.overwrite && PathInfo.type(inputPath) !== "dir") {
+        throw repr`--overwrite given but input path is not a directory: ${inputPath}`;
+    }
+    if (opts.output && opts.overwrite) {
+        throw "Must give --output OR --overwrite, not both.";
+    }
+    // Get the base path to pass to fix-links.mjs.
     let bases;
     if (opts.base) {
         bases = [opts.base];
-    } else if (opts.output === true) {
+    } else if (opts.overwrite) {
         bases = [inputPath];
     } else if (opts.output && PathInfo.type(opts.output) === "dir") {
         bases = [opts.output];
     } else if (opts.quiet !== true) {
         console.error(`No base identified. Can't fix relative img src paths unless a --base is given.`);
     }
-    // Fix up process.argv so `unified-args` will be happy.
-    let originalArgv = process.argv.slice();
-    process.argv = fixArgv(process.argv, [inputPath], opts);
-
+    // Get the value to pass to the `output` option of unified-engine.
+    let output = false;
+    if (opts.output) {
+        output = opts.output;
+    } else if (opts.overwrite) {
+        output = true;
+    }
     // Parse Markdown with remark-parse, parse the frontmatter, modify it with our plugins, then
     // serialize it right back to Markdown with remark-stringify.
-    //TODO: Use unified-engine directly. Could avoid the argv munging.
     //TODO: Both htmlImgToMd and fixLinks parse the HTML of each `html` node. If it's a performance
     //      issue, we could cache the parsed `hast` tree in a property on the node. Then maybe a
     //      separate plugin at the end could handle stringifying it back into HTML.
@@ -91,20 +101,26 @@ export function main(inputPath, opts) {
         .use(remarkFrontmatter, { type: "yaml", marker: "-" })
         .use(remarkStringify, REMARK_STRINGIFY_OPTIONS);
 
-    unifiedArgs.args({
-        processor: processor,
-        name: "mdfixer",
-        description: "Fix Markdown.",
-        version: 0.1,
-        extensions: [opts.ext],
-        ignoreName: ".mdfixer.ignore",
-        rcName: ".mdfixerc",
-        packageField: "none",
-        pluginPrefix: "none",
-    });
+    unifiedEngine.engine(
+        {
+            processor: processor,
+            files: [inputPath],
+            output: output,
+            extensions: [opts.ext],
+            quiet: opts.quiet,
+        },
+        handleExit
+    );
+}
 
-    // Restore original argv to avoid affecting other modules/scripts.
-    process.argv = originalArgv;
+function handleExit(error, code) {
+    if (error) {
+        throw error;
+    }
+    if (code) {
+        console.error(repr`unified-engine in mdfixer.mjs returned exit code ${code}.`);
+        process.exitCode = code;
+    }
 }
 
 /** Fix all Markdown files that are direct children of `dirPath`, but do not recurse into
@@ -126,62 +142,6 @@ export function shallowPass(dirPath, opts = {}) {
             main(mdPath, { ...opts, output: mdPath });
         }
     }
-}
-
-// `unified-args` does its own inspection of `process.argv`.
-// We need to make sure those arguments are how it likes it, otherwise it'll throw a fit.
-function fixArgv(currentArgv, positionals, opts) {
-    if (process.argv[1] === fileURLToPath(import.meta.url)) {
-        // If this is being executed directly as a script, all we have to do is remove arguments that
-        // `unified-args` doesn't recognize.
-        return removeExtraArgs(currentArgv.slice());
-    } else {
-        // If this is being used as a module, the current process.argv is irrelevant: it's the arguments
-        // to the calling executable, not this script. We have to construct an artificial argv.
-        return constructArgv(positionals, opts);
-    }
-}
-
-function removeExtraArgs(argv) {
-    // Options that take arguments.
-    for (let arg of ["-b", "--base", "-l", "--limit"]) {
-        let i = argv.indexOf(arg);
-        if (i >= 0) {
-            argv.splice(i, 2);
-        }
-    }
-    // Flags.
-    for (let arg of ["--debug"]) {
-        let i = argv.indexOf(arg);
-        if (i >= 0) {
-            argv.splice(i, 1);
-        }
-    }
-    return argv;
-}
-
-function constructArgv(positionals, opts) {
-    let argv = [process.argv[0], process.argv[1]];
-    // Flags.
-    for (let arg of ["quiet", "inspect"]) {
-        if (opts[arg]) {
-            argv.push(`--${arg}`);
-        }
-    }
-    // Positionals.
-    if (positionals.length !== 1) {
-        throw repr`Invalid arguments: Must give one positional; instead found ${positionals}`;
-    }
-    let inputPath = positionals[0];
-    argv.push(inputPath);
-    // Special cases.
-    if (opts.output) {
-        argv.push("--output");
-        if (opts.output !== true) {
-            argv.push(opts.output);
-        }
-    }
-    return argv;
 }
 
 function getDefaults(options) {

--- a/src/build/partition-content.mjs
+++ b/src/build/partition-content.mjs
@@ -348,7 +348,7 @@ function fileContainsTags(fileContents, tags) {
     let queryStrings = tags.map((tag) => `<${tag} `);
     for (let line of splitlines(fileContents)) {
         for (let query of queryStrings) {
-            if (line.indexOf(query) >= 0) {
+            if (line.includes(query)) {
                 return true;
             }
         }
@@ -358,7 +358,7 @@ function fileContainsTags(fileContents, tags) {
 
 function fileContainsSubstr(filePath, substr) {
     let fileContents = fs.readFileSync(filePath, { encoding: "utf8" });
-    return fileContents.indexOf(substr) >= 0;
+    return fileContents.includes(substr);
 }
 
 /** Delete any empty directories in the tree rooted at `dirPath`, including `dirPath`. */
@@ -405,7 +405,7 @@ function assignPlacers(placerOpt, placersOpt, contentTypes) {
     }
     if (placersOpt) {
         for (let [name, value] of Object.entries(placersOpt)) {
-            if (contentTypes.indexOf(name) === -1) {
+            if (!contentTypes.includes(name)) {
                 let typesList = contentTypes.join("', '");
                 throw repr`Invalid content type ${name}. Must be one of '` + typesList + "'";
             }

--- a/src/build/preprocess.mjs
+++ b/src/build/preprocess.mjs
@@ -125,7 +125,6 @@ function main(command, opts) {
                 setTimeout(fixMdOnEvent, 250, eventType, path, partitioner, partitioner.verbose, partitioner.simulate);
             }
         });
-        //TODO: Wait for a gridsome develop process to appear, then exit once it dies.
     } else if (command === "preprocess") {
         process.stdout.write("Placing files into build directories.. ");
         start = Date.now();
@@ -137,7 +136,7 @@ function main(command, opts) {
             process.stdout.write("Fixing Markdown files..                ");
             start = Date.now();
             for (let buildDir of Object.values(partitioner.buildDirs)) {
-                mdfixer.main(buildDir, { quiet: !partitioner.verbose, output: true });
+                mdfixer.main(buildDir, { quiet: !partitioner.verbose, overwrite: true });
             }
         }
     }

--- a/src/build/preprocess.mjs
+++ b/src/build/preprocess.mjs
@@ -70,7 +70,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 
 function main(command, opts) {
     // Check if command is valid.
-    if (["preprocess", "watch"].indexOf(command) === -1) {
+    if (!(command === "preprocess" || command === "watch")) {
         let preamble;
         if (command) {
             preamble = repr`Invalid command ${command}. `;

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -50,7 +50,6 @@ function main(rawArgv) {
     }
 
     // Start Gridsome.
-    //TODO: Get Gridsome's colors working in stdout again.
     let gridsomeExe = findGridsome();
     let cmd3 = `${gridsomeExe} ${command}`;
     console.log(`$ ${cmd3}`);

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -29,7 +29,7 @@ function main(rawArgv) {
     argv[2] = "preprocess";
     let cmd1 = [PREPROCESSOR_RELPATH, ...argv.slice(2)].join(" ");
     console.log(`$ ${cmd1}`);
-    let { status: code, signal} = childProcess.spawnSync(PREPROCESSOR_RELPATH, argv.slice(2), { stdio: "inherit" });
+    let { status: code, signal } = childProcess.spawnSync(PREPROCESSOR_RELPATH, argv.slice(2), { stdio: "inherit" });
     if (code) {
         console.error(`${cmd1} exited with code ${code}`);
     }
@@ -55,7 +55,7 @@ function main(rawArgv) {
     let cmd3 = `${gridsomeExe} ${command}`;
     console.log(`$ ${cmd3}`);
     let gridsome = childProcess.spawn(gridsomeExe, [command], { stdio: "inherit" });
-    gridsome.on('exit', (code, signal) => {
+    gridsome.on("exit", (code, signal) => {
         console.log(`${cmd3} received code ${code}, signal ${signal}`);
         if (signal) {
             console.error(`${cmd3} exited due to signal ${signal}`);
@@ -67,7 +67,7 @@ function main(rawArgv) {
 
     // Die if there is a watcher and it dies.
     if (watcher) {
-        watcher.on('exit', (code, signal) => {
+        watcher.on("exit", (code, signal) => {
             if (code) {
                 console.error(`${cmd2} exited with code ${code}`);
             }

--- a/src/pages/Use.vue
+++ b/src/pages/Use.vue
@@ -151,7 +151,7 @@
 </template>
 
 <script>
-import { rmPrefix, rmSuffix, mdToHtml, contains } from "~/utils.js";
+import { rmPrefix, rmSuffix, mdToHtml } from "~/utils.js";
 const LINK_DISP_NAMES = {
     "academic-cloud": "Academic",
     "commercial-cloud": "Commercial",
@@ -278,7 +278,7 @@ export default {
         getLinks(platform, groups) {
             let links = [];
             for (let platformData of platform.platforms) {
-                if (contains(groups, platformData.platform_group)) {
+                if (groups.includes(platformData.platform_group)) {
                     links.push({ url: platformData.platform_url, text: LINK_DISP_NAMES[platformData.platform_group] });
                 }
             }

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,112 +1,112 @@
 const fs = require("fs");
 
 class PathInfo {
-  constructor(path) {
-      //TODO: `cache` option to tell it to cache results of system calls.
-      //      This will prevent it from updating as the filesystem state changes, though.
-      this.path = path;
-  }
-  /** Does the path exist?
-   *  Note: This returns `true` for broken symlinks (the link exists, but its targets does not).
-   */
-  exists() {
-      if (fs.existsSync(this.path)) {
-          return true;
-      } else {
-          try {
-              fs.lstatSync(this.path);
-              return true;
-          } catch (error) {
-              return false;
-          }
-      }
-  }
-  static exists(path) {
-      let pathInfo = new this(path);
-      return pathInfo.exists();
-  }
-  /** Get the type of filesystem object this path points to.
-   *  If the path does not exist, return `'nonexistent'`.
-   *  If the path is a symbolic link, return the type of its target. If the target is missing,
-   *  return `'brokenlink'`.
-   */
-  type() {
-      if (!this.exists()) {
-          return "nonexistent";
-      }
-      let stats;
-      try {
-          stats = fs.statSync(this.path);
-      } catch (error) {
-          if (error.code === "ENOENT") {
-              // fs.statSync() will throw an error on a broken link.
-              // We defined those as "existing" in this.exists(), but fs.statSync() does not agree.
-              if (this.isLink()) {
-                  return "brokenlink";
-              } else {
-                  console.error(`Unexpected filesystem entry ${this.path}`);
-                  throw error;
-              }
-          } else {
-              throw error;
-          }
-      }
-      if (stats.isFile()) {
-          return "file";
-      } else if (stats.isDirectory()) {
-          return "dir";
-      } else if (stats.isSocket()) {
-          return "socket";
-      } else if (stats.isBlockDevice()) {
-          return "block";
-      } else if (stats.isCharacterDevice()) {
-          return "char";
-      } else if (stats.isFIFO()) {
-          return "fifo";
-      } else {
-          throw `Unexpected path type: ${this.path}`;
-      }
-  }
-  static type(path) {
-      let pathInfo = new this(path);
-      return pathInfo.type();
-  }
-  isLink() {
-      if (this.exists()) {
-          let stats = fs.lstatSync(this.path);
-          if (stats.isSymbolicLink()) {
-              return true;
-          }
-      }
-      return false;
-  }
-  static isLink(path) {
-      let pathInfo = new this(path);
-      return pathInfo.isLink();
-  }
-  mtime() {
-      if (this.exists()) {
-          let stats = fs.lstatSync(this.path);
-          return stats.mtimeMs;
-      } else {
-          return null;
-      }
-  }
-  static mtime(path) {
-      let pathInfo = new this(path);
-      return pathInfo.mtime();
-  }
-  size() {
-      if (this.exists()) {
-          let stats = fs.lstatSync(this.path);
-          return stats.size;
-      } else {
-          return null;
-      }
-  }
-  static size(path) {
-      let pathInfo = new this(path);
-      return pathInfo.size();
-  }
+    constructor(path) {
+        //TODO: `cache` option to tell it to cache results of system calls.
+        //      This will prevent it from updating as the filesystem state changes, though.
+        this.path = path;
+    }
+    /** Does the path exist?
+     *  Note: This returns `true` for broken symlinks (the link exists, but its targets does not).
+     */
+    exists() {
+        if (fs.existsSync(this.path)) {
+            return true;
+        } else {
+            try {
+                fs.lstatSync(this.path);
+                return true;
+            } catch (error) {
+                return false;
+            }
+        }
+    }
+    static exists(path) {
+        let pathInfo = new this(path);
+        return pathInfo.exists();
+    }
+    /** Get the type of filesystem object this path points to.
+     *  If the path does not exist, return `'nonexistent'`.
+     *  If the path is a symbolic link, return the type of its target. If the target is missing,
+     *  return `'brokenlink'`.
+     */
+    type() {
+        if (!this.exists()) {
+            return "nonexistent";
+        }
+        let stats;
+        try {
+            stats = fs.statSync(this.path);
+        } catch (error) {
+            if (error.code === "ENOENT") {
+                // fs.statSync() will throw an error on a broken link.
+                // We defined those as "existing" in this.exists(), but fs.statSync() does not agree.
+                if (this.isLink()) {
+                    return "brokenlink";
+                } else {
+                    console.error(`Unexpected filesystem entry ${this.path}`);
+                    throw error;
+                }
+            } else {
+                throw error;
+            }
+        }
+        if (stats.isFile()) {
+            return "file";
+        } else if (stats.isDirectory()) {
+            return "dir";
+        } else if (stats.isSocket()) {
+            return "socket";
+        } else if (stats.isBlockDevice()) {
+            return "block";
+        } else if (stats.isCharacterDevice()) {
+            return "char";
+        } else if (stats.isFIFO()) {
+            return "fifo";
+        } else {
+            throw `Unexpected path type: ${this.path}`;
+        }
+    }
+    static type(path) {
+        let pathInfo = new this(path);
+        return pathInfo.type();
+    }
+    isLink() {
+        if (this.exists()) {
+            let stats = fs.lstatSync(this.path);
+            if (stats.isSymbolicLink()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    static isLink(path) {
+        let pathInfo = new this(path);
+        return pathInfo.isLink();
+    }
+    mtime() {
+        if (this.exists()) {
+            let stats = fs.lstatSync(this.path);
+            return stats.mtimeMs;
+        } else {
+            return null;
+        }
+    }
+    static mtime(path) {
+        let pathInfo = new this(path);
+        return pathInfo.mtime();
+    }
+    size() {
+        if (this.exists()) {
+            let stats = fs.lstatSync(this.path);
+            return stats.size;
+        } else {
+            return null;
+        }
+    }
+    static size(path) {
+        let pathInfo = new this(path);
+        return pathInfo.size();
+    }
 }
 module.exports.PathInfo = PathInfo;

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,11 +36,6 @@ function repr(strParts, ...values) {
 }
 module.exports.repr = repr;
 
-function contains(iterable, element) {
-    return !!(iterable.indexOf(element) > -1);
-}
-module.exports.contains = contains;
-
 // Set operations from https://exploringjs.com/impatient-js/ch_sets.html#missing-set-operations
 
 /** Get the union of two arrays (or any other spreadable iterable).

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,14 +1272,14 @@
     "@types/unist" "*"
 
 "@types/is-empty@^1.0.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/is-empty/-/is-empty-1.2.0.tgz#16bc578060c9b0b6953339eea906c255a375bf86"
-  integrity sha512-brJKf2boFhUxTDxlpI7cstwiUtA2ovm38UzFTi9aZI6//ARncaV+Q5ALjCaJqXaMtdZk/oPTJnSutugsZR6h8A==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/is-empty/-/is-empty-1.2.1.tgz#18d7256a73e43ec51f8b75c25fbdc31350be52a6"
+  integrity sha512-a3xgqnFTuNJDm1fjsTjHocYJ40Cz3t8utYpi5GNaxzrJC2HSD08ym+whIL7fNqiqBCdM9bcqD1H/tORWAFXoZw==
 
 "@types/js-yaml@^4.0.0":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.2.tgz#4117a7a378593a218e9d6f0ef44ce6d5d9edf7fa"
-  integrity sha512-KbeHS/Y4R+k+5sWXEYzAZKuB1yQlZtEghuhRxrVRLaqhtoG5+26JwQsa4HyS3AWX8v1Uwukma5HheduUDskasA==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.3.tgz#9f33cd6fbf0d5ec575dc8c8fc69c7fec1b4eb200"
+  integrity sha512-5t9BhoORasuF5uCPr+d5/hdB++zRFUTMIZOzbNkr+jZh3yQht4HYbRDyj9fY8n2TZT30iW9huzav73x4NikqWg==
 
 "@types/json-schema@^7.0.6":
   version "7.0.7"
@@ -1309,9 +1309,9 @@
   integrity sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
 
 "@types/node@^16.0.0":
-  version "16.4.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.13.tgz#7dfd9c14661edc65cccd43a29eb454174642370d"
-  integrity sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==
+  version "16.9.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
+  integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
 
 "@types/parse5@^6.0.0":
   version "6.0.1"
@@ -1336,20 +1336,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/repeat-string@^1.0.0":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@types/repeat-string/-/repeat-string-1.6.1.tgz#8bb5686e662ce1d962271b0b043623bf51404cdc"
-  integrity sha512-vdna8kjLGljgtPnYN6MBD2UwX62QE0EFLj9QlLXvg6dEu66NksXB900BNguBCMZZY2D9SSqncUskM23vT3uvWQ==
-
 "@types/supports-color@^8.0.0":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-8.1.1.tgz#1b44b1b096479273adf7f93c75fc4ecc40a61ee4"
   integrity sha512-dPWnWsf+kzIG140B8z2w3fr5D03TLWbOAFQl45xUpI3vcizeXriNR5VYkWZ+WTMsUHqZ9Xlt3hrxGNANFyNQfw==
-
-"@types/text-table@^0.2.0":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@types/text-table/-/text-table-0.2.2.tgz#774c90cfcfbc8b4b0ebb00fecbe861dc8b1e8e26"
-  integrity sha512-dGoI5Af7To0R2XE8wJuc6vwlavWARsCh3UKJPjWs1YEqGUqfgBI/j/4GX0yf19/DsDPPf0YAXWAp8psNeIehLg==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -1790,10 +1780,10 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-regex@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.0.tgz#ecc7f5933cbe5ac7b33e209a5ff409ab1669c6b2"
-  integrity sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2682,7 +2672,7 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.0.0:
+"chokidar@>=3.0.0 <4.0.0":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -4819,7 +4809,19 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -6272,7 +6274,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.0.0, json5@^2.1.2:
+json5@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
@@ -7008,7 +7010,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.0.0, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -9679,13 +9681,13 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     strip-ansi "^6.0.0"
 
 string-width@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.0.0.tgz#19191f152f937b96f4ec54ba0986a5656660c5a2"
-  integrity sha512-zwXcRmLUdiWhMPrHz6EXITuyTgcEnUqDzspTkCLhQovxywWz6NP9VHgqfVg20V/1mUg0B95AKbXxNT+ALRmqCw==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.0.1.tgz#0d8158335a6cfd8eb95da9b6b262ce314a036ffd"
+  integrity sha512-5ohWO/M4//8lErlUUtrFy3b11GtNOuMOU0ysKCDXFcfXuuvUXu95akgj/i8ofmaGdN0hCqyl6uu9i8dS/mQp5g==
   dependencies:
     emoji-regex "^9.2.2"
     is-fullwidth-code-point "^4.0.0"
-    strip-ansi "^7.0.0"
+    strip-ansi "^7.0.1"
 
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
@@ -9764,12 +9766,12 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-strip-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.0.tgz#1dc49b980c3a4100366617adac59327eefdefcb0"
-  integrity sha512-UhDTSnGF1dc0DRbUqr1aXwNoY3RgVkSWG8BrpnuFIxhP57IqbS7IRta2Gfiavds4yCxc5+fEAVVOgBZWnYkvzg==
+strip-ansi@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
   dependencies:
-    ansi-regex "^6.0.0"
+    ansi-regex "^6.0.1"
 
 strip-bom-string@^1.0.0:
   version "1.0.0"
@@ -10083,12 +10085,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     safe-regex "^1.1.0"
 
 to-vfile@^7.0.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-7.2.1.tgz#fe42892024f724177ba81076f98ee74b0888c293"
-  integrity sha512-biljADNq2n+AZn/zX+/87zStnIqctKr/q5OaOD8+qSKINokUGPbWBShvxa1iLUgHz6dGGjVnQPNoFRtVBzMkVg==
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-7.2.2.tgz#5976568397ef664bc8df210676d082478822afbf"
+  integrity sha512-7WL+coet3qyaYb5vrVrfLtOUHgNv9E1D5SIsyVKmHKcgZefy77WMQRk7FByqGKNInoHOlY6xkTGymo29AwjUKg==
   dependencies:
     is-buffer "^2.0.0"
-    vfile "^5.0.0"
+    vfile "^5.1.0"
 
 toidentifier@1.0.0:
   version "1.0.0"
@@ -10266,25 +10268,10 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
 
-unified-args@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/unified-args/-/unified-args-9.0.2.tgz#0c14f555e73ee29c23f9a567942e29069f56e5a2"
-  integrity sha512-qSqryjoqfJSII4E4Z2Jx7MhXX2MuUIn6DsrlmL8UnWFdGtrWvEtvm7Rx5fKT5TPUz7q/Fb4oxwIHLCttvAuRLQ==
-  dependencies:
-    "@types/text-table" "^0.2.0"
-    camelcase "^6.0.0"
-    chalk "^4.0.0"
-    chokidar "^3.0.0"
-    fault "^2.0.0"
-    json5 "^2.0.0"
-    minimist "^1.0.0"
-    text-table "^0.2.0"
-    unified-engine "^9.0.0"
-
-unified-engine@^9.0.0:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-9.0.3.tgz#c1d57e67d94f234296cbfa9364f43e0696dae016"
-  integrity sha512-SgzREcCM2IpUy3JMFUcPRZQ2Py6IwvJ2KIrg2AiI7LnGge6E6OPFWpcabHrEXG0IvO2OI3afiD9DOcQvvZfXDQ==
+unified-engine@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-9.0.4.tgz#ee02b6a7f11e69a56f79cb8595065b8c3f02bda8"
+  integrity sha512-NFI+jC3DWZ23eBsWkOW2havz47DPG/DSyJEvBH+qA5cQHF6zlgiJYev7ksb/naOypZZ+cfhaCxCRo2BqrysYEw==
   dependencies:
     "@types/concat-stream" "^1.0.0"
     "@types/debug" "^4.0.0"
@@ -10782,13 +10769,11 @@ vfile-message@^3.0.0:
     unist-util-stringify-position "^3.0.0"
 
 vfile-reporter@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-7.0.1.tgz#759bfebb995f3dc8c644284cb88ac4b310ebd168"
-  integrity sha512-pof+cQSJCUNmHG6zoBOJfErb6syIWHWM14CwKjsugCixxl4CZdrgzgxwLBW8lIB6czkzX0Agnnhj33YpKyLvmA==
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-7.0.2.tgz#2b3bfafb428581e72073c4337acdf82912385356"
+  integrity sha512-1bYxpyhl8vhAICiKR59vYyZHIOWsF7P1nV6xjaz3ZWAyOQDQhR4DjlOZo14+PiV9oLEWIrolvGHs0/2Bnaw5Vw==
   dependencies:
-    "@types/repeat-string" "^1.0.0"
     "@types/supports-color" "^8.0.0"
-    repeat-string "^1.0.0"
     string-width "^5.0.0"
     supports-color "^9.0.0"
     unist-util-stringify-position "^3.0.0"
@@ -10833,6 +10818,16 @@ vfile@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.0.2.tgz#57773d1d91478b027632c23afab58ec3590344f0"
   integrity sha512-5cV+K7tX83MT3bievROc+7AvHv0GXDB0zqbrTjbOe+HRbkzvY4EP+wS3IR77kUBCoWFMdG9py18t0sesPtQ1Rw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
+
+vfile@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.1.0.tgz#18e78016f0f71e98d737d40f0fca921dc264a600"
+  integrity sha512-4o7/DJjEaFPYSh0ckv5kcYkJTHQgCKdL8ozMM1jLAxO9ox95IzveDPXCZp08HamdWq8JXTkClDvfAKaeLQeKtg==
   dependencies:
     "@types/unist" "^2.0.0"
     is-buffer "^2.0.0"


### PR DESCRIPTION
As mentioned in #838, `unified-args` was causing problems in the build system. Also, `mdfixer.mjs` contained a lot of ugly workarounds for its peculiarities. A lot of this was because `unified-args` was being used in ways it wasn't intended.

This replaces it with `unified-engine`, which is what `unified-args` uses under the hood. It greatly simplifies the code.

This branch also includes some cleanups of style issues left in the build code.