### PR TITLE
Show `links` metadata in event listings.

### DIFF
--- a/src/components/ArticleTableEvents.vue
+++ b/src/components/ArticleTableEvents.vue
@@ -4,7 +4,15 @@
         <td class="title">
             <a v-if="article.external_url" :href="article.external_url">{{ article.title }}</a>
             <g-link v-else :to="article.path" class="read">{{ article.title }}</g-link>
-            <p class="tease">{{ article.tease }}</p>
+            <p class="tease small">
+                {{ article.tease }}
+                <template v-if="article.links.length">
+                    (<template v-for="(link, i) of article.links">
+                        <a :href="link.url">{{ link.text }}</a>
+                        <template v-if="i < article.links.length-1">, </template>
+                    </template>)
+                </template>
+            </p>
         </td>
         <td class="location">
             <Continent :continent="article.continent" />

--- a/src/components/ArticleTableEvents.vue
+++ b/src/components/ArticleTableEvents.vue
@@ -7,9 +7,9 @@
             <p class="tease small">
                 {{ article.tease }}
                 <template v-if="article.links.length">
-                    (<template v-for="(link, i) of article.links">
-                        <a :href="link.url">{{ link.text }}</a>
-                        <template v-if="i < article.links.length - 1">, </template> </template
+                    (<template v-for="(link, index) of article.links">
+                        <a :href="link.url" :key="index">{{ link.text }}</a>
+                        <template v-if="index < article.links.length - 1">, </template> </template
                     >)
                 </template>
             </p>

--- a/src/components/ArticleTableEvents.vue
+++ b/src/components/ArticleTableEvents.vue
@@ -9,8 +9,8 @@
                 <template v-if="article.links.length">
                     (<template v-for="(link, i) of article.links">
                         <a :href="link.url">{{ link.text }}</a>
-                        <template v-if="i < article.links.length-1">, </template>
-                    </template>)
+                        <template v-if="i < article.links.length - 1">, </template> </template
+                    >)
                 </template>
             </p>
         </td>

--- a/src/pages/Events.vue
+++ b/src/pages/Events.vue
@@ -81,6 +81,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }
@@ -103,6 +107,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }

--- a/src/pages/events/Archive.vue
+++ b/src/pages/events/Archive.vue
@@ -67,6 +67,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }

--- a/src/pages/events/Cofests.vue
+++ b/src/pages/events/Cofests.vue
@@ -82,6 +82,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }
@@ -105,6 +109,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }

--- a/src/pages/events/Webinars.vue
+++ b/src/pages/events/Webinars.vue
@@ -82,6 +82,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }
@@ -105,6 +109,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }

--- a/src/pages/events/cofests/Papercuts.vue
+++ b/src/pages/events/cofests/Papercuts.vue
@@ -82,6 +82,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }
@@ -105,6 +109,10 @@ query {
         contact
         external_url
         gtn
+        links {
+          text
+          url
+        }
         date (format: "D MMMM YYYY")
         path
       }


### PR DESCRIPTION
Another feature from the old Hub: show links like slides, video, etc. in the tease of event listings on pages like `/events/` or `/events/webinars/`.

Also, shrink tease text size.