### PR TITLE
Only run checks on PR, not push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Code Quality Checks
-on: [push, pull_request]
+on: pull_request
 concurrency: 
   group: lint-${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: Cypress Tests
-on: [push, pull_request]
+on: pull_request
 concurrency: 
   group: cypress-${{ github.head_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This will cut down on excess CI runs and will only run checks against PRs.