### PR TITLE
Convert link checking to run nightly at 11:30

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,8 +1,9 @@
 name: Check Links
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron: '*/3 * * * *'
+    - cron: '30 23 * * *'
 
 jobs:
   check_links:
@@ -35,6 +36,6 @@ jobs:
         uses: peter-evans/create-issue-from-file@v3
         with:
           issue-number: 851
-          title: Link Checker Report
+          title: Link Checker Report (updated daily)
           content-filepath: ./lychee/out.md
           labels: report, automated issue


### PR DESCRIPTION
It worked, so I can back this off.  It can be manually triggered, or it will run nightly at 11:30.

Once we get the report looking good, we can expand coverage to more frequented pages.