### PR TITLE
Pause before redirecting from 404 and explain in an alert.

### DIFF
--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -85,7 +85,7 @@ export default {
             let url = getRedirectUrl(this.article.redirect);
             console.log(repr`Redirecting to ${url} in ${this.redirectDelay} seconds..`);
             let currentPath = window.location.pathname;
-            setTimeout(() => doRedirect(currentPath, url), this.redirectDelay * 1000);
+            setTimeout(() => doRedirect(url, currentPath), this.redirectDelay * 1000);
         }
     },
 };

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -6,9 +6,7 @@
                 <a :href="this.redirectUrl">{{ this.redirectUrl }}</a>
                 ?
             </p>
-            <p>
-                You will be redirected in {{ redirectDelay }} seconds.
-            </p>
+            <p>You will be redirected in {{ redirectDelay }} seconds.</p>
         </div>
         <h1 class="page-title">{{ $page.main.title }}</h1>
         <div class="markdown" v-html="$page.main.content" />

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -1,5 +1,15 @@
 <template>
     <Layout>
+        <div v-if="this.redirectUrl" class="redirect alert alert-warning trim-p">
+            <p>
+                This url is no longer valid. Perhaps you meant
+                <a :href="this.redirectUrl">{{ this.redirectUrl }}</a>
+                ?
+            </p>
+            <p>
+                You will be redirected in {{ redirectDelay }} seconds.
+            </p>
+        </div>
         <h1 class="page-title">{{ $page.main.title }}</h1>
         <div class="markdown" v-html="$page.main.content" />
     </Layout>
@@ -13,14 +23,22 @@ export default {
             title: this.$page.main.title,
         };
     },
+    data() {
+        return {
+            redirectDelay: 5,
+            redirectUrl: undefined,
+        };
+    },
     mounted() {
-        // Try seeing if the url is different under Gridsome's slugification rules.
-        // If so, try redirecting to that.
-        let url = new URL(window.location.href);
+        // If the url is different under Gridsome's slugification rules, redirect to that.
+        let currentUrl = window.location.href;
+        let url = new URL(currentUrl);
         url.pathname = gridifyPath(url.pathname);
-        if (window.location.href !== url.href) {
-            console.log(repr`Redirecting to slugified url ${url.href}`);
-            doRedirect(url.href);
+        if (url.href !== currentUrl) {
+            this.redirectUrl = url.href;
+            console.log(repr`Redirecting to slugified url ${this.redirectUrl} in ${this.redirectDelay} seconds.`);
+            let currentPath = window.location.pathname;
+            setTimeout(() => doRedirect(this.redirectUrl, currentPath), this.redirectDelay * 1000);
         }
     },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -253,8 +253,8 @@ function getFilesShallow(dirPath, excludeExt = null) {
 }
 module.exports.getFilesShallow = getFilesShallow;
 
-function doRedirect(currentPath, destUrl) {
-    if (window.location.pathname === currentPath) {
+function doRedirect(destUrl, currentPath) {
+    if (currentPath === undefined || window.location.pathname === currentPath) {
         window.location.href = destUrl;
     } else {
         // Cancel redirect if the user has navigated away already.


### PR DESCRIPTION
Make the redirect from the 404 page like a normal redirect from a content page: show an alert to the user, then wait 5 seconds.