### PR TITLE
Fix issue with first collapsible element in /tutorials/nt-rnaseq/.

### DIFF
--- a/content/tutorials/nt_rnaseq/index.md
+++ b/content/tutorials/nt_rnaseq/index.md
@@ -83,7 +83,7 @@ The data is structured in the following way:
       <h4 class="panel-title">
         <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
 
-Data upload from Galaxy Library (**recommended** if using http://usegalaxy.org)
+Data upload from Galaxy Library (**recommended** if using usegalaxy.org)
 
 </a>
       </h4>


### PR DESCRIPTION
The autogenerated link was causing a strange DOM issue.
- A copy of the <a> element was being added just before the original.
- Caused issues with testing.