### PR TITLE
Open links from /use/ to Galaxy servers in new tabs.

### DIFF
--- a/src/pages/Use.vue
+++ b/src/pages/Use.vue
@@ -105,6 +105,7 @@
                             v-for="link of getLinks(data.item, [tab.linkGroup || tab.id])"
                             :key="link.text"
                             :href="link.url"
+                            target="_blank"
                         >
                             {{ link.text }}
                         </a>
@@ -114,12 +115,18 @@
                             v-for="link of getLinks(data.item, ['academic-cloud', 'commercial-cloud'])"
                             :key="link.text"
                             :href="link.url"
+                            target="_blank"
                         >
                             {{ link.text }}
                         </a>
                     </template>
                     <template #cell(deployable)="data">
-                        <a v-for="link of getLinks(data.item, ['container', 'vm'])" :key="link.text" :href="link.url">
+                        <a
+                            v-for="link of getLinks(data.item, ['container', 'vm'])"
+                            :key="link.text"
+                            :href="link.url"
+                            target="_blank"
+                        >
                             {{ link.text }}
                         </a>
                     </template>


### PR DESCRIPTION
When you're looking at the Platform Directory and you click a link to a Galaxy server, it should probably open in a new tab.