### PR TITLE
fix-links.mjs: Check for necessary values before invoking `getDirPath()`.

### DIFF
--- a/src/build/fix-links.mjs
+++ b/src/build/fix-links.mjs
@@ -31,7 +31,7 @@ export default function attacher(options) {
     // https://github.com/unifiedjs/unified#function-transformernode-file-next
     function transformer(tree, file) {
         globals.filePathRaw = file.path;
-        if (options.bases && options.bases.reduce((a, b) => a || b)) {
+        if (globals.filePathRaw && file.cwd && options.bases && options.bases.reduce((a, b) => a || b)) {
             globals.dirPath = getDirPath(options.bases, file.cwd, globals.filePathRaw);
         } else {
             console.error("No `bases` option received. Will not be able to convert image src paths to relative paths.");


### PR DESCRIPTION
Adding some checks to prevent `getDirPath()` from failing (with a confusing error message).