### PR TITLE
Fix mistake in `/events/archive/`: Filter for events older than 1 year, not 0 years.

### DIFF
--- a/src/pages/events/Archive.vue
+++ b/src/pages/events/Archive.vue
@@ -52,7 +52,7 @@ query {
   }
   events: allArticle(
       sortBy: "date", order: DESC, filter: {
-        category: {eq: "events"}, has_date: {eq: true}, days_ago: {gt: 0}, draft: {ne: true}
+        category: {eq: "events"}, has_date: {eq: true}, days_ago: {gt: 364}, draft: {ne: true}
       }
     ) {
     totalCount


### PR DESCRIPTION
Oops, used the wrong value!

Fixes #893.