### PR TITLE
Build and publish action -- migrating from Jenkins

### DIFF
--- a/.github/workflows/links-external.yml
+++ b/.github/workflows/links-external.yml
@@ -3,7 +3,7 @@ name: Check External Links
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 23 * * *'
+    - cron: "30 23 * * *"
 
 jobs:
   check_links:

--- a/.github/workflows/links-internal.yml
+++ b/.github/workflows/links-internal.yml
@@ -3,7 +3,7 @@ name: Check Internal Links
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 23 * * *'
+    - cron: "30 23 * * *"
 
 jobs:
   check_links_internal:

--- a/.github/workflows/links-internal.yml
+++ b/.github/workflows/links-internal.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   check_links_internal:
-    name: Check Internal Links
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Code Quality Checks
 on: pull_request
-concurrency: 
+concurrency:
   group: lint-${{ github.head_ref }}
   cancel-in-progress: true
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Cypress Tests
 on: pull_request
-concurrency: 
+concurrency:
   group: cypress-${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
@@ -26,7 +26,7 @@ jobs:
         with:
           build: yarn build
           start: yarn serve
-          wait-on: 'http://localhost:8080'
+          wait-on: "http://localhost:8080"
       - uses: actions/upload-artifact@v1
         if: failure()
         with:

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -9,21 +9,21 @@ name: Compress images
 on:
   pull_request:
     paths:
-      - '**.jpg'
-      - '**.jpeg'
-      - '**.png'
-      - '**.webp'
+      - "**.jpg"
+      - "**.jpeg"
+      - "**.png"
+      - "**.webp"
   push:
     branches:
       - master
     paths:
-      - '**.jpg'
-      - '**.jpeg'
-      - '**.png'
-      - '**.webp'
+      - "**.jpg"
+      - "**.jpeg"
+      - "**.png"
+      - "**.webp"
   workflow_dispatch:
   schedule:
-    - cron: '00 23 * * 0'
+    - cron: "00 23 * * 0"
 jobs:
   build:
     name: calibreapp/image-actions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish Hub
 
 on:
+  workflow_dispatch:
   push:
     branches:
     - master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - master
+      - master
 
 jobs:
   publish:
@@ -32,5 +32,5 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
-          SOURCE_DIR: 'dist'      # optional: defaults to entire repository
+          AWS_REGION: "us-east-2" # optional: defaults to us-east-1
+          SOURCE_DIR: "dist" # optional: defaults to entire repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,16 +6,30 @@ on:
     - master
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl public-read --follow-symlinks --delete
-      env:
-        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
-        SOURCE_DIR: 'dist'      # optional: defaults to entire repository
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install project dependencies
+        run: yarn --prefer-offline
+      - name: Build static site
+        run: yarn build
+      - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
+          SOURCE_DIR: 'dist'      # optional: defaults to entire repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish Hub
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
+        SOURCE_DIR: 'dist'      # optional: defaults to entire repository


### PR DESCRIPTION
Jenkins is being retired; this will swap building/publishing to a github action that will replace it.  Also has the added benefit of providing more visibility to the build/publish infra, and can eventually be used to build and serve PR previews, both good things.