### PR TITLE
Limit publish workflow concurrency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+concurrency:
+  group: publish-master
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
So we can't have two workflows trying to build and publish at the same time, which is likely to cause issues.

Additionally, unlike some of our other concurrently locked actions, we don't want to interrupt a currently running publish because if the interruption happens during the actual s3copy you could end up with a broken website, so the best thing to do here is to allow the build to finish before another one starts.

Thanks @beatrizserrano for noticing the issue that lead to discovering this problem.