### PR TITLE
Don't redirect urls that look like filenames.

### DIFF
--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -29,17 +29,37 @@ export default {
     },
     mounted() {
         // If the url is different under Gridsome's slugification rules, redirect to that.
-        let currentUrl = window.location.href;
-        let url = new URL(currentUrl);
-        url.pathname = gridifyPath(url.pathname);
-        if (url.href !== currentUrl) {
-            this.redirectUrl = url.href;
-            console.log(repr`Redirecting to slugified url ${this.redirectUrl} in ${this.redirectDelay} seconds.`);
-            let currentPath = window.location.pathname;
-            setTimeout(() => doRedirect(this.redirectUrl, currentPath), this.redirectDelay * 1000);
-        }
+        this.redirectUrl = doRedirectIfNeeded(window.location.href, window.location.pathname, this.redirectDelay);
     },
 };
+function doRedirectIfNeeded(currentUrl, currentPath, redirectDelay) {
+    let redirectUrl = currentUrl;
+    let url = new URL(currentUrl);
+    if (isFilenamePath(url.pathname)) {
+        return;
+    }
+    url.pathname = gridifyPath(url.pathname);
+    if (url.href !== currentUrl) {
+        redirectUrl = url.href;
+        console.log(repr`Redirecting to slugified url ${redirectUrl} in ${redirectDelay} seconds.`);
+        setTimeout(() => doRedirect(redirectUrl, currentPath), redirectDelay * 1000);
+        return redirectUrl;
+    }
+}
+/** Does the path look like it ends with a filename?
+ * Returns `true` if the filename at the end of the path has a file extension no longer than `maxExtLen`.
+ * Note: Paths that end in "/" or that have no "." after the last "/" will return `false`.
+ */
+function isFilenamePath(path, maxExtLen = 6) {
+    let pathParts = path.split("/");
+    let filename = pathParts[pathParts.length - 1];
+    let fileParts = filename.split(".");
+    let ext = fileParts[fileParts.length - 1];
+    if (ext && ext.length <= maxExtLen) {
+        return true;
+    }
+    return false;
+}
 </script>
 
 <page-query>

--- a/src/utils.js
+++ b/src/utils.js
@@ -141,7 +141,8 @@ function gridifyPath(rawPath) {
         rawParts.push("");
     }
     let sluggedParts = rawParts.map(slugify);
-    return sluggedParts.join("/");
+    let fixedPath = sluggedParts.join("/");
+    return ensureSuffix(fixedPath, "/");
 }
 module.exports.gridifyPath = gridifyPath;
 
@@ -160,14 +161,23 @@ function matchesPrefixes(string, prefixes) {
 }
 module.exports.matchesPrefixes = matchesPrefixes;
 
-function ensurePrefix(string, char) {
-    if (string.startsWith(char)) {
+function ensurePrefix(string, prefix) {
+    if (string.startsWith(prefix)) {
         return string;
     } else {
-        return char + string;
+        return prefix + string;
     }
 }
 module.exports.ensurePrefix = ensurePrefix;
+
+function ensureSuffix(string, suffix) {
+    if (string.endsWith(suffix)) {
+        return string;
+    } else {
+        return string + suffix;
+    }
+}
+module.exports.ensureSuffix = ensureSuffix;
 
 function rmPrefix(rawString, prefix) {
     if (rawString.startsWith(prefix)) {


### PR DESCRIPTION
Previously we'd redirect people who went to a url like `/path/to/file.pdf` and ended up on the 404 page. In that case, they'd end up on `/path/to/file-pdf/`. That's pretty unlikely to be right.

So this tries to recognize that situation and skip the redirect.