### PR TITLE
Fix article slots rendering (causing duplicates)

### DIFF
--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -10,8 +10,7 @@
                     `insert.name` variable: https://vuejs.org/v2/guide/components-slots.html#Dynamic-Slot-Names
                 -->
                 <template v-for="insert of $page.article.inserts" #[insert.name]>
-                    <p class="markdown" :key="insert.name + ':md'" v-html="insert.content" />
-                    <p class="d-none" :key="insert.name + ':p'">Issue #758 workaround</p>
+                    <p class="markdown" :key="insert.name + ':md'" v-html="insert.content">&nbsp;</p>
                 </template>
             </VueRemarkContent>
         </article>


### PR DESCRIPTION
xref https://html.spec.whatwg.org/multipage/parsing.html#parse-error-non-void-html-element-start-tag-with-trailing-solidus

xref #758

I think this may be what was going on all along.  I need to look at the use page again with this in mind; may well be the same issue and I'll follow up here.