### PR TITLE
GCC2012: Delete duplicate Insert Markdown files, fix syntax in another.

### DIFF
--- a/content/events/gcc2012/ask-the-organizers.md
+++ b/content/events/gcc2012/ask-the-organizers.md
@@ -1,3 +1,4 @@
 <br /><br />
+
 ----
-Questions? [Ask the organizers](mailto:outreach@galaxyproject.org?subject=GCC 2012 Question).
+Questions? [Ask the organizers](mailto:outreach@galaxyproject.org?subject=GCC%202012%20Question).

--- a/content/events/gcc2012/askthe-organizers/index.md
+++ b/content/events/gcc2012/askthe-organizers/index.md
@@ -1,5 +1,0 @@
-<br /><br />
-<div class='center'>
-----
-Questions? [Ask the organizers](mailto:outreach@galaxyproject.org?subject=GCC 2012 Question).
-</div>

--- a/content/events/gcc2012/page-header/index.md
+++ b/content/events/gcc2012/page-header/index.md
@@ -1,4 +1,0 @@
-<div class='center'><div class='grey'>
-<a href='/events/gcc2012/'><img src="/events/gcc2012/GCC2012LogoWide800.png" alt="2012 Galaxy Community Conference (GCC2012), Chicago, Illinois, July 25-27, 2012" width="740" /></a>
-</div></div>
-<br /><br />


### PR DESCRIPTION
Just noticed some obvious errors in the slots/Inserts for the pages in /events/gcc2012/.