### PR TITLE
Fix detecting autolinks in unescape-links.mjs.

### DIFF
--- a/src/build/mdfixer.mjs
+++ b/src/build/mdfixer.mjs
@@ -13,7 +13,7 @@ import keepNewlineBeforeHtml from "./keep-newline-before-html.mjs";
 import htmlImgToMd from "./html-img-to-md.mjs";
 import fixLinks from "./fix-links.mjs";
 import tocAdd from "./toc-add.mjs";
-import unescapeLink from "./unescape-links.mjs";
+import { unescapeLink } from "./unescape-links.mjs";
 import { repr, rmPrefix } from "../utils.js";
 import { PathInfo } from "../paths.js";
 

--- a/src/build/unescape-links.mjs
+++ b/src/build/unescape-links.mjs
@@ -66,7 +66,7 @@ export function isAutolink(node) {
     }
     // The url must be absolute (containing a scheme).
     let parts = node.url.split(":");
-    if (parts.length < 2 || ! parts[1]) {
+    if (parts.length < 2 || !parts[1]) {
         return false;
     }
     // But the scheme can't contain a slash. This excludes urls which are actually relative paths with a colon in them.

--- a/src/build/unescape-links.mjs
+++ b/src/build/unescape-links.mjs
@@ -5,7 +5,7 @@ import remarkStringify from "remark-stringify";
 const QUOTE_MAP = { '"': "'", "'": '"' };
 const remarkCompiler = unified().use(remarkStringify);
 
-export default function unescapeLink(node, parent, context) {
+export function unescapeLink(node, parent, context) {
     /** Custom handler for Link mdast nodes. This prevents special characters like `&` and `_` from being escaped in
      * link urls.
      */
@@ -54,10 +54,25 @@ export default function unescapeLink(node, parent, context) {
     return `[${childrenStr}](${node.url}${titleStr})`;
 }
 
-function isAutolink(node) {
+export function isAutolink(node) {
+    // Autolinks have only a simple text node as their only child.
     if (!(node.children.length === 1 && node.children[0].type === "text")) {
         return false;
     }
     let text = node.children[0].value;
-    return text === node.url;
+    // Their `url` field is the same as the value of their child text node.
+    if (text !== node.url) {
+        return false;
+    }
+    // The url must be absolute (containing a scheme).
+    let parts = node.url.split(":");
+    if (parts.length < 2 || ! parts[1]) {
+        return false;
+    }
+    // But the scheme can't contain a slash. This excludes urls which are actually relative paths with a colon in them.
+    let scheme = parts[0];
+    if (scheme.includes("/")) {
+        return false;
+    }
+    return true;
 }

--- a/src/build/unescape-links.test.mjs
+++ b/src/build/unescape-links.test.mjs
@@ -3,7 +3,6 @@ import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import { unescapeLink, isAutolink } from "./unescape-links.mjs";
 
-
 // unescapeLink()
 
 const UNALTERED_LINKS = [
@@ -39,7 +38,6 @@ test("Unescape links", () => {
     }
 });
 
-
 // isAutolink()
 
 const POSSIBLE_AUTOLINKS = {
@@ -56,8 +54,8 @@ const POSSIBLE_AUTOLINKS = {
 test("Autolink detection", () => {
     let link = {
         type: "link",
-        children: [ { type: "text" } ]
-    }
+        children: [{ type: "text" }],
+    };
     for (let [url, expectedResult] of Object.entries(POSSIBLE_AUTOLINKS)) {
         link.url = url;
         link.children[0].value = url;

--- a/src/build/unescape-links.test.mjs
+++ b/src/build/unescape-links.test.mjs
@@ -1,7 +1,10 @@
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
-import unescapeLink from "./unescape-links.mjs";
+import { unescapeLink, isAutolink } from "./unescape-links.mjs";
+
+
+// unescapeLink()
 
 const UNALTERED_LINKS = [
     "[Google](https://google.com/search?channel=fs&q=query)",
@@ -33,5 +36,31 @@ test("Unescape links", () => {
         let tree = processor.parse(input);
         let result = processor.stringify(tree);
         expect(result).toBe(expectedValue + "\n");
+    }
+});
+
+
+// isAutolink()
+
+const POSSIBLE_AUTOLINKS = {
+    "https://google.com": true,
+    "http://google.org/full/path/with:colon": true,
+    "mailto:person@email.com": true,
+    "ftp:server.com": true,
+    "localhost:8080/path?query=string&lang=en": true,
+    "made-up-scheme://foo,bar": true,
+    "relative/path": false,
+    "/absolute/path": false,
+    "path/with:colon": false,
+};
+test("Autolink detection", () => {
+    let link = {
+        type: "link",
+        children: [ { type: "text" } ]
+    }
+    for (let [url, expectedResult] of Object.entries(POSSIBLE_AUTOLINKS)) {
+        link.url = url;
+        link.children[0].value = url;
+        expect(isAutolink(link)).toBe(expectedResult);
     }
 });


### PR DESCRIPTION
`unescape-links.mjs` was mistakenly transforming any link where the text was identical to the url into an autolink, resulting in links like `[/admin/get-galaxy/](/admin/get-galaxy/)` getting turned into `</admin/get-galaxy/>`, which doesn't work.

This should fix that by using rules from the CommonMark spec about what urls work as an autolink.