### PR TITLE
Add local link testing all-in-one command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "cypress:run": "cypress run",
     "build-and-serve": "yarn build && yarn serve",
     "test": "start-server-and-test build-and-serve http://localhost:8080 cypress:run",
-    "test:interactive": "start-server-and-test develop http://localhost:8080 cypress:open"
+    "test:interactive": "start-server-and-test develop http://localhost:8080 cypress:open",
+    "test:links": "start-server-and-test build-and-serve http://localhost:8080 links:internal"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",

--- a/src/build/check-links.mjs
+++ b/src/build/check-links.mjs
@@ -131,8 +131,8 @@ const siteChecker = new blc.SiteChecker(options, {
             outTemplate(customData.summary.pages, customData.summary.total, customData.summary.broken) +
             customData.markdownReport;
         fs.writeFileSync(outputFile, output);
+        console.log(output);
         if (customData.summary.broken > 0) {
-            console.log(output);
             process.exitCode = 1;
         }
     },


### PR DESCRIPTION
Slightly streamlines local link testing -- with this you can just do a `yarn run test:links` and test links locally.

Also changes check-links to *always* print the output report to the console -- not just on failure.