### PR TITLE
Fix #758 for good (hopefully) by using <div>s to insert Markdown.

### DIFF
--- a/src/components/CardCareers.vue
+++ b/src/components/CardCareers.vue
@@ -18,7 +18,8 @@
                 Apply by: {{ article.closes }}
             </span>
         </p>
-        <p class="markdown" v-html="mdToHtml(article.summary)" />
+        <!-- The summary should be a single line. Inserting multiple lines or <div>s can result in bug #758. -->
+        <p class="markdown" v-html="mdToHtml(article.summary)"></p>
         <p v-if="article.contact" class="contact">Contact: {{ article.contact }}</p>
         <p v-if="article.image" class="logo">
             <a :href="article.external_url">

--- a/src/pages/Use.vue
+++ b/src/pages/Use.vue
@@ -17,12 +17,11 @@
                         </template>
                     </h2>
                     <!-- Table description. -->
-                    <p class="markdown" v-if="inserts[`tab-${tab.id}`]" v-html="inserts[`tab-${tab.id}`].content"></p>
-                    <!--
-                    The following <p> is a workaround for issue #758. Apparently the element produced by the following
-                    <b-row> is enough to trigger the bug.
-                -->
-                    <p class="d-none">dummy text</p>
+                    <div
+                        class="markdown"
+                        v-if="inserts[`tab-${tab.id}`]"
+                        v-html="inserts[`tab-${tab.id}`].content"
+                    ></div>
                     <!-- Table controls -->
                     <b-row class="table-controls">
                         <!-- Search -->
@@ -144,11 +143,11 @@
                         </template>
                     </b-table>
                     <!-- Post-table text (optional). -->
-                    <p
+                    <div
                         class="markdown"
                         v-if="inserts[`tab-${tab.id}-footer`]"
                         v-html="inserts[`tab-${tab.id}-footer`].content"
-                    ></p>
+                    ></div>
                 </b-tab>
             </b-tabs>
 

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -10,7 +10,7 @@
                     `insert.name` variable: https://vuejs.org/v2/guide/components-slots.html#Dynamic-Slot-Names
                 -->
                 <template v-for="insert of $page.article.inserts" #[insert.name]>
-                    <p class="markdown" :key="insert.name + ':md'" v-html="insert.content">&nbsp;</p>
+                    <div class="markdown" :key="insert.name + ':md'" v-html="insert.content">&nbsp;</div>
                 </template>
             </VueRemarkContent>
         </article>


### PR DESCRIPTION
This (hopefully) fixes the root cause of #758 by using `<div>`s to insert Markdown into Vue templates instead of `<p>`s.