### PR TITLE
Solve overlapping heading issue with a z-index instead of inline-block.

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -161,7 +161,7 @@ p.trim-p,
 .markdown h4,
 .markdown h5,
 .markdown h6 {
-    display: inline-block;
+    z-index: -10;
 }
 /* Replacement for .table and .table-striped on Markdown tables.
  * Until we can get those classes inserted into the table elements themselves.


### PR DESCRIPTION
fd50bef9ef attempted to solve the issue of when a heading element expands to the entire width of its container, which could occlude other elements that may have floated up alongside it. If there's, say, a linkbox floated right, the heading can end up on top of it, preventing the user from clicking some of the links.

fd50bef9ef solved this by shrinking the heading elements by making them `inline-blocks`. But sometimes that can cause weird layout. Specifically, when there's multiple headings in a row, they'll all end up on the same line (see [/events/gcc2013/program/](https://galaxyproject.org/events/gcc2013/program/#program)).

Instead, this attempts to solve it by lowering the z-index of headings.