### PR TITLE
/use/ Cypress test: Specify element to search for text.

### DIFF
--- a/cypress/integration/main.spec.js
+++ b/cypress/integration/main.spec.js
@@ -75,7 +75,9 @@ describe("Use Page Tests", () => {
         cy.wait(1000);
         cy.findByRole("button", { name: /Community/i }).click();
         cy.findByRole("menuitem", { name: /Stats/i }).click();
-        cy.get("h1").findByText(/Galaxy Project Stats/i).should("be.visible");
+        cy.get("h1")
+            .findByText(/Galaxy Project Stats/i)
+            .should("be.visible");
     });
 });
 

--- a/cypress/integration/main.spec.js
+++ b/cypress/integration/main.spec.js
@@ -75,7 +75,7 @@ describe("Use Page Tests", () => {
         cy.wait(1000);
         cy.findByRole("button", { name: /Community/i }).click();
         cy.findByRole("menuitem", { name: /Stats/i }).click();
-        cy.findByText(/Galaxy Project Stats/i).should("be.visible");
+        cy.get("h1").findByText(/Galaxy Project Stats/i).should("be.visible");
     });
 });
 


### PR DESCRIPTION
I've been getting failures for the Cypress test "Tries to visit another page after /use/, via the masthead" test because `.findByText(/Galaxy Project Stats/i)` matches multiple elements: the `<title>` element in the `<head>` and the intended page title in an `<h1>`.

This tells it to look only in `<h1>` elements.