### PR TITLE
Change headings back to blocks, not inline-blocks.

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -152,17 +152,6 @@ p.trim-p,
     padding-bottom: 0.4em;
     line-height: 1.3em;
 }
-/* Keep headings from expanding to the entire width of the line (and occluding
- * other elements that might have floated up to the right of it).
- */
-.markdown h1,
-.markdown h2,
-.markdown h3,
-.markdown h4,
-.markdown h5,
-.markdown h6 {
-    display: inline-block;
-}
 /* Replacement for .table and .table-striped on Markdown tables.
  * Until we can get those classes inserted into the table elements themselves.
  */


### PR DESCRIPTION
fd50bef tried to fix #1033 by changing headings to inline-blocks. But then when there's several headings in a row, they end up getting bunched up on the same line.

#1024 is another failed fix.

This PR proposes reverting to the old behavior until we find a solution that doesn't just introduce other problems.