### PR TITLE
Convert COVID-19 logos footer into Markdown.

### DIFF
--- a/content/covid19/footer.md
+++ b/content/covid19/footer.md
@@ -1,24 +1,28 @@
-<div class="center">
-  <a href="https://galaxyproject.org">   <img src="/images/covid19/logos/galaxy_logo.png" width= "22%" alt="Galaxy Project" /></a> &nbsp;
-  <a href="https://galaxyproject.eu">    <img src="https://raw.githubusercontent.com/usegalaxy-eu/branding/master/galaxy-eu/galaxy-eu.256.png" width= "20%" alt="European Galaxy Project" /></a> &nbsp;
-  <a href="https://usegalaxy-au.github.io/">    <img src="/images/covid19/logos/galaxy_australia.png" width="20%" alt="Australian Galaxy Project" /></a> &nbsp;
-  <a href="https://bioconda.org">        <img src="/images/covid19/logos/bioconda_logo.png" width="20%" alt="bioconda" /></a> &nbsp;
-  <a href="https://xsede.org">           <img src="/images/covid19/logos/xsede_logo.png" width="20%" alt="XSEDE" /></a> &nbsp;
-  <a href="https://www.tacc.utexas.edu"> <img src="/images/covid19/logos/tacc_logo.png" width="20%" alt="TACC" /></a> &nbsp;
-  <a href="https://www.denbi.de">        <img src="/images/covid19/logos/denbi-logo-color.svg" width="20%" alt="de.NBI" /></a> &nbsp;
-  <a href="https://elixir-europe.org">   <img src="/images/covid19/logos/elixir_logo.png" width="15%" alt="ELIXIR" /></a> &nbsp;
-  <a href="https://www.psc.edu">         <img src="/images/covid19/logos/psc_logo.jpg" width="20%" alt="PSC" /></a> &nbsp;
-  <a href="https://www.iu.edu">          <img src="/images/covid19/logos/iu_logo.jpg" width="20%" alt="Indiana University" /></a> &nbsp;
-  <a href="https://training.galaxyproject.org"> <img src="/images/covid19/logos/gtn_logo.png" width="20%" alt="Galaxy Training Network" /></a> &nbsp;
-  <a href="https://bioplatforms.com">    <img src="/images/covid19/logos/bpa_logo.png" width="20%" alt="Bio Platforms Australia" /></a> &nbsp;
-  <a href="https://ardc.ed.au">          <img src="/images/covid19/logos/ardc_logo.png" width="20%" alt="Australian Research Data Commons" /></a> &nbsp;
-  <a href="http://www.vib.be/">          <img src="/images/covid19/logos/vib_tagline_pos_rgb.png" width="15%" alt="VIB" /></a> &nbsp;
-  <a href="https://www.elixir-belgium.org">          <img src="/images/covid19/logos/ELIXIR_BELGIUM_white_background.png" width="15%" alt="ELIXIR Belgium" /></a> &nbsp;
-  <a href="https://www.vscentrum.be">          <img src="/images/covid19/logos/VSC-logo.png" width="25%" alt="Vlaams Supercomputer Center" /></a> &nbsp;
-  <a href="https://www.eosc-life.eu">          <img src="/images/covid19/logos/eosclife.png" width="10%" alt="EOSC-Life" /></a> &nbsp;
-  <a href="https://datamonkey.org">          <img src="/images/covid19/logos/datamonkey.svg" alt="Datamonkey" width = "150px" /></a> &nbsp;
-  <a href="https://www.france-bioinformatique.fr/en">          <img src="/images/covid19/logos/ifb.png" alt="IFB" width = "20%" /></a> &nbsp;
-  <a href="http://galaxyp.org/">          <img src="/images/covid19/logos/galaxyp.png" alt="GalaxyP" width = "10%" /></a> &nbsp;
-  <a href="https://www.niaid.nih.gov/"> <img src="/images/covid19/logos/niaid_logo.jpg" width="11%" alt="NIAID" /></a> &nbsp;
-  <a href="https://www.nhgri.nih.gov/"> <img src="/images/covid19/logos/nhgri_logo_vertical.jpg" width="9%" alt="NHGRI" /></a> &nbsp;
+<div style="height: 500px">
+  <div class="center img-sizer" style="height: 90px">
+
+[![Galaxy Project](/images/covid19/logos/galaxy_logo.png)](https://galaxyproject.org)
+[![European Galaxy Project](https://raw.githubusercontent.com/usegalaxy-eu/branding/master/galaxy-eu/galaxy-eu.256.png)](https://galaxyproject.eu)
+[![Australian Galaxy Project](/images/covid19/logos/galaxy_australia.png)](https://usegalaxy-au.github.io/)
+[![bioconda](/images/covid19/logos/bioconda_logo.png)](https://bioconda.org)
+[![XSEDE](/images/covid19/logos/xsede_logo.png)](https://xsede.org)
+[![TACC](/images/covid19/logos/tacc_logo.png)](https://www.tacc.utexas.edu)
+[![de.NBI](/images/covid19/logos/denbi-logo-color.svg)](https://www.denbi.de)
+[![ELIXIR](/images/covid19/logos/elixir_logo.png)](https://elixir-europe.org)
+[![PSC](/images/covid19/logos/psc_logo.jpg)](https://www.psc.edu)
+[![Indiana University](/images/covid19/logos/iu_logo.jpg)](https://www.iu.edu)
+[![Galaxy Training Network](/images/covid19/logos/gtn_logo.png)](https://training.galaxyproject.org)
+[![Bio Platforms Australia](/images/covid19/logos/bpa_logo.png)](https://bioplatforms.com)
+[![Australian Research Data Commons](/images/covid19/logos/ardc_logo.png)](https://ardc.ed.au)
+[![VIB](/images/covid19/logos/vib_tagline_pos_rgb.png)](http://www.vib.be/)
+[![ELIXIR Belgium](/images/covid19/logos/ELIXIR_BELGIUM_white_background.png)](https://www.elixir-belgium.org)
+[![Vlaams Supercomputer Center](/images/covid19/logos/VSC-logo.png)](https://www.vscentrum.be)
+[![EOSC-Life](/images/covid19/logos/eosclife.png)](https://www.eosc-life.eu)
+[![Datamonkey](/images/covid19/logos/datamonkey.svg)](https://datamonkey.org)
+[![IFB](/images/covid19/logos/ifb.png)](https://www.france-bioinformatique.fr/en)
+[![GalaxyP](/images/covid19/logos/galaxyp.png)](http://galaxyp.org/)
+[![NIAID](/images/covid19/logos/niaid_logo.jpg)](https://www.niaid.nih.gov/)
+[![NHGRI](/images/covid19/logos/nhgri_logo_vertical.jpg)](https://www.nhgri.nih.gov/)
+
+  </div>
 </div>


### PR DESCRIPTION
I got the logos to be a manageable size and the container element to be larger than its contents.

But I did it by making the logo heights uniform, while at their ideal sizes their heights are slightly different.
Also, there's not much spacing between the logos. I'm not sure the best way to go about increasing it.