### PR TITLE
Disable COVID-19 NavBar link for now.

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -34,7 +34,6 @@
                     <b-dropdown-item to="/support/">FAQ</b-dropdown-item>
                     <b-dropdown-item href="https://help.galaxyproject.org/">Galaxy Help Forum</b-dropdown-item>
                 </b-nav-item-dropdown>
-                <b-nav-item to="/covid19/">COVID-19</b-nav-item>
                 <b-nav-item to="/jxtx/">@jxtx</b-nav-item>
             </b-navbar-nav>
             <b-navbar-nav id="navbar-misc" class="ml-auto">


### PR DESCRIPTION
Until it's ready.