### PR TITLE
Remove jQuery and bootstrap <script>s from index.html.

### DIFF
--- a/cypress/integration/main.spec.js
+++ b/cypress/integration/main.spec.js
@@ -81,31 +81,6 @@ describe("Use Page Tests", () => {
     });
 });
 
-describe("Bootstrap component tests", () => {
-    it("Tests the video popup on /tutorials/chip/", () => {
-        cy.visit("/tutorials/chip/");
-        // This test gives intermittent failures without a wait here.
-        // Probably needs time to load Bootstrap's JS from the CDN (unpkg.com).
-        cy.wait(1000);
-        cy.get("h4.modal-title").should("not.be.visible");
-        cy.get('[data-target="#lib_video"]').first().click();
-        cy.get("h4.modal-title").should("be.visible");
-    });
-    it("Tests collapsing elements on /tutorials/nt-rnaseq/", () => {
-        cy.visit("/tutorials/nt-rnaseq/");
-        // This test gives intermittent failures without a wait here (just like above).
-        cy.wait(1000);
-        // First collapsible element
-        cy.get("#qc").should("not.be.visible");
-        cy.get('[href="#qc"]').click();
-        cy.get("#qc").should("be.visible");
-        // Second collapsible element
-        cy.get("#collapseOne").should("not.be.visible");
-        cy.get('[href="#collapseOne"]').click();
-        cy.get("#collapseOne").should("be.visible");
-    });
-});
-
 // Save the tests with long timeouts for the end.
 
 describe("Test 404 page", () => {

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,6 @@
 <html ${htmlAttrs}>
     <head>
         ${head}
-        <script src="//unpkg.com/jquery@3.3.1/dist/jquery.slim.min.js"></script>
         <script>
             ((window.gitter = {}).chat = {}).options = {
                 room: "galaxyproject/Lobby",
@@ -12,6 +11,5 @@
     </head>
     <body ${bodyAttrs}>
         ${app} ${scripts}
-        <script src="//unpkg.com/bootstrap@4.5.0/dist/js/bootstrap.min.js"></script>
     </body>
 </html>


### PR DESCRIPTION
This fulfills #785 by removing the dependency on jQuery and the Bootstrap plugins `<script>` (both sourced from unpkg.com). Based on the changes coming in #1102, the pages using this functionality are now deprecated.

It also removes the Cypress tests for this functionality.