### PR TITLE
Fix <pre> code block font colors.

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -48,6 +48,13 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 
 @import "overrides.scss";
 
+pre {
+    background-color: $brand-dark;
+    color: white;
+    padding: 1rem;
+    border-radius: 0.5rem;
+}
+
 html {
     position: relative;
     min-height: 100%;

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -48,13 +48,6 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 
 @import "overrides.scss";
 
-pre {
-    background-color: $brand-dark;
-    color: white;
-    padding: 1rem;
-    border-radius: 0.5rem;
-}
-
 html {
     position: relative;
     min-height: 100%;
@@ -491,4 +484,15 @@ h6:hover .heading-anchor span:before {
 
 .bg-wg-all {
     background-color: #d87e55 !important;
+}
+
+/* *******
+   Gridsome era additions.
+ * *******/
+
+pre {
+    background-color: $brand-dark;
+    color: white;
+    padding: 1rem;
+    border-radius: 0.5rem;
 }

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -71,13 +71,6 @@ query {
     }
 }
 
-pre {
-    background-color: $brand-dark;
-    color: white;
-    padding: 1rem;
-    border-radius: 0.5rem;
-}
-
 /***** Generally useful styles *****/
 .text-nowrap {
     white-space: nowrap !important;


### PR DESCRIPTION
Fix the current (build-only) issue where the font color in code blocks is dark on a dark background.

It looks like the issue was the order in which the styles were concatenated. Moving our `pre` style to `styles.scss` fixes the order.