### PR TITLE
Redirect component and cancel button

### DIFF
--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -3,7 +3,7 @@
         <g-link v-if="article.category" :to="`/${article.category}/`" class="link">
             &larr; Back to <span class="text-capitalize">{{ article.category }}</span>
         </g-link>
-        <Redirect v-if="article.redirect" :url="article.redirect" :location="location">
+        <Redirect v-if="article.redirect" :url="article.redirect" :location="this.location">
         </Redirect>
         <div class="clearfix"></div>
         <g-image v-if="article.image" class="img-fluid main-image" :src="image" />
@@ -59,7 +59,7 @@ export default {
     },
     data() {
         return {
-            location: window.location,
+            location: undefined,
         };
     },
     computed: {
@@ -83,6 +83,11 @@ export default {
             return getImage(this.article.image, this.article.images);
         },
     },
+    mounted() {
+        // This has to be set in mounted() because window does not exist when building.
+        // This will execute in the browser on page load.
+        this.location = window.location;
+    }
 };
 </script>
 

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -3,12 +3,8 @@
         <g-link v-if="article.category" :to="`/${article.category}/`" class="link">
             &larr; Back to <span class="text-capitalize">{{ article.category }}</span>
         </g-link>
-        <p v-if="article.redirect" class="redirect alert alert-warning">
-            <strong>Note</strong>
-            This content has a new home at
-            <a :href="article.redirect">{{ article.redirect }}</a>
-            , which you will be redirected to in {{ redirectDelay }} seconds.
-        </p>
+        <Redirect v-if="article.redirect" :url="article.redirect" :location="location">
+        </Redirect>
         <div class="clearfix"></div>
         <g-image v-if="article.image" class="img-fluid main-image" :src="image" />
         <h1 class="title float-left" v-if="!article.skip_title_render">{{ article.title }}</h1>
@@ -50,16 +46,20 @@
 </template>
 
 <script>
-import { repr, doRedirect, getImage, humanDateSpan } from "~/utils.js";
+import Redirect from "@/components/Redirect";
+import { getImage, humanDateSpan } from "~/utils.js";
 import * as dayjs from "dayjs";
 
 export default {
+    components: {
+        Redirect,
+    },
     props: {
         article: { type: Object, required: true },
     },
     data() {
         return {
-            redirectDelay: 5,
+            location: window.location,
         };
     },
     computed: {
@@ -83,24 +83,7 @@ export default {
             return getImage(this.article.image, this.article.images);
         },
     },
-    mounted() {
-        if (this.article.redirect) {
-            let url = getRedirectUrl(this.article.redirect);
-            console.log(repr`Redirecting to ${url} in ${this.redirectDelay} seconds..`);
-            let currentPath = window.location.pathname;
-            setTimeout(() => doRedirect(url, currentPath), this.redirectDelay * 1000);
-        }
-    },
 };
-function getRedirectUrl(target) {
-    if (target.startsWith("/")) {
-        return `${window.location.origin}${target}`;
-    } else if (target.startsWith("http://") || target.startsWith("https://")) {
-        return target;
-    } else {
-        console.error(repr`Unrecognized redirect url ${target}`);
-    }
-}
 </script>
 
 <style scoped>
@@ -111,9 +94,6 @@ function getRedirectUrl(target) {
     width: auto;
     padding: 2px;
     border: 1px solid #666;
-}
-.redirect {
-    margin-top: 20px;
 }
 .title {
     font-size: 28px;

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -104,6 +104,7 @@ export default {
     font-weight: 300;
     line-height: 1.4em;
     padding: 0.5em 0;
+    margin-bottom: 5px;
 }
 .subtitle {
     font-weight: 400;

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -3,8 +3,7 @@
         <g-link v-if="article.category" :to="`/${article.category}/`" class="link">
             &larr; Back to <span class="text-capitalize">{{ article.category }}</span>
         </g-link>
-        <Redirect v-if="article.redirect" :url="article.redirect" :location="this.location">
-        </Redirect>
+        <Redirect v-if="article.redirect" :url="article.redirect" :location="this.location" />
         <div class="clearfix"></div>
         <g-image v-if="article.image" class="img-fluid main-image" :src="image" />
         <h1 class="title float-left" v-if="!article.skip_title_render">{{ article.title }}</h1>
@@ -87,7 +86,7 @@ export default {
         // This has to be set in mounted() because window does not exist when building.
         // This will execute in the browser on page load.
         this.location = window.location;
-    }
+    },
 };
 </script>
 

--- a/src/components/Redirect.vue
+++ b/src/components/Redirect.vue
@@ -16,7 +16,7 @@
 import { repr, doRedirect } from "~/utils.js";
 export default {
     props: {
-        location: { required: true },
+        location: { type: Object, required: true },
         preText: { type: String, required: false, default: "This content has a new home at " },
         url: { type: String, required: true },
         postText: { type: String, required: false, default: "." },

--- a/src/components/Redirect.vue
+++ b/src/components/Redirect.vue
@@ -26,8 +26,14 @@ export default {
     data() {
         return {
             cancelled: false,
-            parsedUrl: parseUrl(this.url, this.location),
         };
+    },
+    computed: {
+        // Need to set this here to make sure the component will update when
+        // `url` or `location` does.
+        parsedUrl() {
+            return parseUrl(this.url, this.location);
+        },
     },
     methods: {
         cancel() {
@@ -36,13 +42,23 @@ export default {
         },
     },
     mounted() {
-        console.log(repr`Redirecting to ${this.url} in ${this.delay} seconds..`);
-        let currentPath = location.pathname;
-        setTimeout(() => doRedirect(this.url, currentPath, this.cancelled), this.delay * 1000);
+        redirectIfPossible(this);
+    },
+    beforeUpdate() {
+        redirectIfPossible(this);
     },
 };
+function redirectIfPossible(data) {
+    if (data.location && data.url) {
+        console.log(repr`Redirecting to ${data.url} in ${data.delay} seconds..`);
+        let currentPath = data.location.pathname;
+        setTimeout(() => doRedirect(data.url, currentPath, data.cancelled), data.delay * 1000);
+    }
+}
 function parseUrl(rawUrl, location) {
-    if (rawUrl.startsWith("/")) {
+    if (location === undefined) {
+        return undefined;
+    } else if (rawUrl.startsWith("/")) {
         return `${location.origin}${rawUrl}`;
     } else if (rawUrl.startsWith("http://") || rawUrl.startsWith("https://")) {
         return rawUrl;

--- a/src/components/Redirect.vue
+++ b/src/components/Redirect.vue
@@ -1,0 +1,68 @@
+<template>
+    <div :class="['redirect', 'alert', 'alert-warning', cancelled ? 'cancelled' : 'active']">
+        <p>
+            {{ preText }}<a :href="parsedUrl">{{ url }}</a>{{ postText }}
+        </p>
+        <p class="button-line">
+            You will be redirected in {{ delay }} seconds.
+            <button @click="cancel" class="btn btn-light">Cancel</button>
+            <span v-if="cancelled">
+                Redirect cancelled!
+            </span>
+        </p>
+    </div>
+</template>
+
+<script>
+import { repr, doRedirect } from "~/utils.js";
+export default {
+    props: {
+        location: { required: true },
+        preText: { type: String, required: false, default: "This content has a new home at " },
+        url: { type: String, required: true },
+        postText: { type: String, required: false, default: "." },
+        delay: { type: Number, required: false, default: 5 },
+    },
+    data() {
+        return {
+            cancelled: false,
+            parsedUrl: parseUrl(this.url, this.location),
+        };
+    },
+    methods: {
+        cancel() {
+            console.log('Cancelling redirect..');
+            this.cancelled = true;
+        },
+    },
+    mounted() {
+        console.log(repr`Redirecting to ${this.url} in ${this.delay} seconds..`);
+        let currentPath = location.pathname;
+        setTimeout(() => doRedirect(this.url, currentPath, this.cancelled), this.delay * 1000);
+    },
+};
+function parseUrl(rawUrl, location) {
+    if (rawUrl.startsWith("/")) {
+        return `${location.origin}${rawUrl}`;
+    } else if (rawUrl.startsWith("http://") || rawUrl.startsWith("https://")) {
+        return rawUrl;
+    } else {
+        console.error(repr`Unrecognized redirect url ${rawUrl}`);
+    }
+}
+</script>
+
+<style scoped>
+.redirect {
+    margin-top: 20px;
+}
+p {
+    margin-bottom: 10px;
+}
+p.button-line {
+    margin-bottom: 0;
+}
+button {
+    margin: 0 10px;
+}
+</style>

--- a/src/components/Redirect.vue
+++ b/src/components/Redirect.vue
@@ -1,14 +1,13 @@
 <template>
     <div :class="['redirect', 'alert', 'alert-warning', cancelled ? 'cancelled' : 'active']">
         <p>
-            {{ preText }}<a :href="parsedUrl">{{ url }}</a>{{ postText }}
+            {{ preText }}<a :href="parsedUrl">{{ url }}</a
+            >{{ postText }}
         </p>
         <p class="button-line">
             You will be redirected in {{ delay }} seconds.
             <button @click="cancel" class="btn btn-light">Cancel</button>
-            <span v-if="cancelled">
-                Redirect cancelled!
-            </span>
+            <span v-if="cancelled">Redirect cancelled!</span>
         </p>
     </div>
 </template>
@@ -37,7 +36,7 @@ export default {
     },
     methods: {
         cancel() {
-            console.log('Cancelling redirect..');
+            console.log("Cancelling redirect..");
             this.cancelled = true;
         },
     },

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -27,17 +27,19 @@ export default {
     },
     data() {
         return {
-            location: window.location,
+            location: undefined,
             redirectUrl: undefined,
         };
     },
     mounted() {
+        // This has to be set in mounted() because window does not exist when building.
+        // This will execute in the browser on page load.
+        this.location = window.location;
         // If the url is different under Gridsome's slugification rules, redirect to that.
         this.redirectUrl = doRedirectIfNeeded(window.location.href);
     },
 };
 function doRedirectIfNeeded(currentUrl) {
-    let redirectUrl = currentUrl;
     let url = new URL(currentUrl);
     if (isFilenamePath(url.pathname)) {
         console.log('Current url path looks like a filename.');
@@ -45,7 +47,7 @@ function doRedirectIfNeeded(currentUrl) {
     }
     url.pathname = gridifyPath(url.pathname);
     if (url.href !== currentUrl) {
-        console.log(repr`Slugified url ${redirectUrl} is different from current one.`);
+        console.log(repr`Slugified url ${url.href} is different from current one.`);
         return url.href;
     }
 }

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -42,7 +42,7 @@ export default {
 function doRedirectIfNeeded(currentUrl) {
     let url = new URL(currentUrl);
     if (isFilenamePath(url.pathname)) {
-        console.log('Current url path looks like a filename.');
+        console.log("Current url path looks like a filename.");
         return;
     }
     url.pathname = gridifyPath(url.pathname);

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -1,49 +1,52 @@
 <template>
     <Layout>
-        <div v-if="this.redirectUrl" class="redirect alert alert-warning trim-p">
-            <p>
-                This url is no longer valid. Perhaps you meant
-                <a :href="this.redirectUrl">{{ this.redirectUrl }}</a>
-                ?
-            </p>
-            <p>You will be redirected in {{ redirectDelay }} seconds.</p>
-        </div>
+        <Redirect
+            v-if="redirectUrl"
+            preText="This url is no longer valid. Perhaps you meant "
+            :url="redirectUrl"
+            postText="?"
+            :location="location"
+        >
+        </Redirect>
         <h1 class="page-title">{{ $page.main.title }}</h1>
         <div class="markdown" v-html="$page.main.content" />
     </Layout>
 </template>
 
 <script>
-import { repr, gridifyPath, doRedirect } from "~/utils.js";
+import Redirect from "@/components/Redirect";
+import { repr, gridifyPath } from "~/utils.js";
 export default {
     metaInfo() {
         return {
             title: this.$page.main.title,
         };
     },
+    components: {
+        Redirect,
+    },
     data() {
         return {
-            redirectDelay: 5,
+            location: window.location,
             redirectUrl: undefined,
         };
     },
     mounted() {
         // If the url is different under Gridsome's slugification rules, redirect to that.
-        this.redirectUrl = doRedirectIfNeeded(window.location.href, window.location.pathname, this.redirectDelay);
+        this.redirectUrl = doRedirectIfNeeded(window.location.href);
     },
 };
-function doRedirectIfNeeded(currentUrl, currentPath, redirectDelay) {
+function doRedirectIfNeeded(currentUrl) {
     let redirectUrl = currentUrl;
     let url = new URL(currentUrl);
     if (isFilenamePath(url.pathname)) {
+        console.log('Current url path looks like a filename.');
         return;
     }
     url.pathname = gridifyPath(url.pathname);
     if (url.href !== currentUrl) {
-        redirectUrl = url.href;
-        console.log(repr`Redirecting to slugified url ${redirectUrl} in ${redirectDelay} seconds.`);
-        setTimeout(() => doRedirect(redirectUrl, currentPath), redirectDelay * 1000);
-        return redirectUrl;
+        console.log(repr`Slugified url ${redirectUrl} is different from current one.`);
+        return url.href;
     }
 }
 /** Does the path look like it ends with a filename?

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -2,9 +2,9 @@
     <Layout>
         <Redirect
             v-if="redirectUrl"
-            preText="This url is no longer valid. Perhaps you meant "
+            pre-text="This url is no longer valid. Perhaps you meant "
             :url="redirectUrl"
-            postText="?"
+            post-text="?"
             :location="location"
         >
         </Redirect>

--- a/src/utils.js
+++ b/src/utils.js
@@ -263,8 +263,10 @@ function getFilesShallow(dirPath, excludeExt = null) {
 }
 module.exports.getFilesShallow = getFilesShallow;
 
-function doRedirect(destUrl, currentPath) {
-    if (currentPath === undefined || window.location.pathname === currentPath) {
+function doRedirect(destUrl, currentPath, cancelled) {
+    if (cancelled) {
+        console.log('Redirect cancelled.');
+    } else if (currentPath === undefined || window.location.pathname === currentPath) {
         window.location.href = destUrl;
     } else {
         // Cancel redirect if the user has navigated away already.

--- a/src/utils.js
+++ b/src/utils.js
@@ -265,7 +265,7 @@ module.exports.getFilesShallow = getFilesShallow;
 
 function doRedirect(destUrl, currentPath, cancelled) {
     if (cancelled) {
-        console.log('Redirect cancelled.');
+        console.log("Redirect cancelled.");
     } else if (currentPath === undefined || window.location.pathname === currentPath) {
         window.location.href = destUrl;
     } else {


### PR DESCRIPTION
This compartmentalizes all the redirect logic of the 404 page and pages with a `redirect` property into a Redirect component.

It also adds a "Cancel" button so the user can stay on the page if they wish. This can be useful in many situations, for example #1116 where a page is deprecated and redirected, but the user still wants access to the content.