### PR TITLE
Fix site-wide footer layout.

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -102,10 +102,8 @@ query {
     padding-right: 0 !important;
 }
 .static-footer {
-    position: absolute;
     width: 100%;
     bottom: 0;
-    padding-top: 1rem;
     padding-bottom: 0.5rem;
 }
 /***** Markdown image sizing *****/


### PR DESCRIPTION
The site-wide footer was bunching up and overlapping the bottom of the article contents on very small screens.