### PR TITLE
Add social preview <head> meta tags.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "host": "galaxyproject.org",
     "contentDir": "content",
     "collections": {
         "Platform": "/use/"

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -46,13 +46,43 @@
 
 <script>
 import Redirect from "@/components/Redirect";
-import { getImage, humanDateSpan } from "~/utils.js";
+import { ensureDomain, getImage, humanDateSpan } from "~/utils.js";
 import CONFIG from "~/../config.json";
 import * as dayjs from "dayjs";
 
 export default {
     components: {
         Redirect,
+    },
+    metaInfo() {
+        let info = {}
+        if (this.article.title) {
+            info.title = this.article.title;
+        }
+        // Set <meta> values for social previews.
+        // https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup
+        const KEYS_METADATA = [["title","title",70],["tease","description",200],["image","image",null]];
+        for (let [articleKey, metaKey, maxLen] of KEYS_METADATA) {
+            let value = this.article[articleKey];
+            if (value) {
+                if (maxLen) {
+                    value = value.slice(0,maxLen);
+                }
+                if (articleKey === "image") {
+                    value = ensureDomain(value);
+                }
+                if (info.meta === undefined) {
+                    info.meta = [];
+                }
+                for (let prefix of ["og", "twitter"]) {
+                    info.meta.push({ property: `${prefix}:${metaKey}`, content: value });
+                }
+            }
+        }
+        if (info.meta !== undefined) {
+            info.meta.push({ property: "twitter:card", content: "summary_large_image" });
+            return info;
+        }
     },
     props: {
         article: { type: Object, required: true },

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -49,24 +49,27 @@ import Redirect from "@/components/Redirect";
 import { ensureDomain, getImage, humanDateSpan } from "~/utils.js";
 import CONFIG from "~/../config.json";
 import * as dayjs from "dayjs";
-
+const SOCIAL_TAGS_METADATA = [
+    ["title", "title", 70],
+    ["tease", "description", 200],
+    ["image", "image", null],
+];
 export default {
     components: {
         Redirect,
     },
     metaInfo() {
-        let info = {}
+        let info = {};
         if (this.article.title) {
             info.title = this.article.title;
         }
         // Set <meta> values for social previews.
         // https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup
-        const KEYS_METADATA = [["title","title",70],["tease","description",200],["image","image",null]];
-        for (let [articleKey, metaKey, maxLen] of KEYS_METADATA) {
+        for (let [articleKey, metaKey, maxLen] of SOCIAL_TAGS_METADATA) {
             let value = this.article[articleKey];
             if (value) {
                 if (maxLen) {
-                    value = value.slice(0,maxLen);
+                    value = value.slice(0, maxLen);
                 }
                 if (articleKey === "image") {
                     value = ensureDomain(value);

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -83,6 +83,7 @@ export default {
             }
         }
         if (info.meta !== undefined) {
+            info.meta.push({ property: "og:type", content: "article" });
             info.meta.push({ property: "twitter:card", content: "summary_large_image" });
             return info;
         }

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -48,11 +48,6 @@ export default {
         ArticleHeader,
         ArticleFooter,
     },
-    metaInfo() {
-        return {
-            title: this.$page.article.title,
-        };
-    },
     computed: {
         mdClasses() {
             let classes = [];

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -64,11 +64,6 @@ export default {
         ArticleHeader,
         ArticleFooter,
     },
-    metaInfo() {
-        return {
-            title: this.$page.article.title,
-        };
-    },
     computed: {
         mdClasses() {
             let classes = [];

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ const util = require("util");
 const remark = require("remark");
 const remarkHtml = require("remark-html");
 const slugify = require("@sindresorhus/slugify");
+const urlParse = require("url-parse");
 const CONFIG = require("../config.json");
 
 /* Using a kludge here to allow:
@@ -262,6 +263,27 @@ function getFilesShallow(dirPath, excludeExt = null) {
     return files;
 }
 module.exports.getFilesShallow = getFilesShallow;
+
+/**
+ * Make sure a url includes a domain name.
+ * @param {String} rawUrl The input url. Currently this only handles two types of urls: (1) fully qualified ones
+ *                        including a scheme and domain and (2) absolute urls (without a domain, starting with a slash).
+ * @param {String} defaultDomain
+ * @param {String} defaultScheme
+ */
+function ensureDomain(rawUrl, defaultDomain = CONFIG.host, defaultScheme = "https") {
+    // Note: url-parse doesn't handle urls missing only the scheme, like google.com/path.
+    // Handling these is tricky anyway, since that could also be a valid relative url.
+    let url = urlParse(rawUrl, {});
+    if (! url.protocol) {
+        url.set("protocol", defaultScheme);
+    }
+    if (! url.hostname) {
+        url.set("hostname", defaultDomain);
+    }
+    return url.href;
+}
+module.exports.ensureDomain = ensureDomain;
 
 function doRedirect(destUrl, currentPath, cancelled) {
     if (cancelled) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,10 +275,10 @@ function ensureDomain(rawUrl, defaultDomain = CONFIG.host, defaultScheme = "http
     // Note: url-parse doesn't handle urls missing only the scheme, like google.com/path.
     // Handling these is tricky anyway, since that could also be a valid relative url.
     let url = urlParse(rawUrl, {});
-    if (! url.protocol) {
+    if (!url.protocol) {
         url.set("protocol", defaultScheme);
     }
-    if (! url.hostname) {
+    if (!url.hostname) {
         url.set("hostname", defaultDomain);
     }
     return url.href;


### PR DESCRIPTION
This adds Twitter and Open Graph `<meta>` tags to the `<head>` of pages with the proper metadata.

Fixes #1145.