### PR TITLE
Remote markdown render

### DIFF
--- a/src/build/partition-content.mjs
+++ b/src/build/partition-content.mjs
@@ -339,7 +339,7 @@ function fileRequiresVue(filePath) {
     if (Object.prototype.hasOwnProperty.call(metadata, "components")) {
         return !!metadata.components;
     }
-    if (fileContainsTags(content, ["slot", "g-image", "link-box", "vega-embed"])) {
+    if (fileContainsTags(content, ["slot", "g-image", "link-box", "vega-embed", "markdown-embed"])) {
         return true;
     }
     return false;

--- a/src/components/MarkdownEmbed.vue
+++ b/src/components/MarkdownEmbed.vue
@@ -34,7 +34,6 @@ export default {
     },
     mounted() {
         /* Load remote markdown, parse it, and inject in $el. */
-        console.debug("Mounted!");
         fetch(this.href)
             .then((response) => response.text())
             .then((markdownText) => {

--- a/src/components/MarkdownEmbed.vue
+++ b/src/components/MarkdownEmbed.vue
@@ -1,0 +1,49 @@
+<template>
+    <div>
+        <ClientOnly>
+            <div v-html="processedContents"></div>
+        </ClientOnly>
+    </div>
+</template>
+
+<script>
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkHtml from "remark-html";
+
+export default {
+    data() {
+        return {
+            markdownContents: "",
+        };
+    },
+    props: {
+        href: {
+            type: String,
+            required: true,
+        },
+    },
+    computed: {
+        processedContents() {
+            return unified()
+                .use(remarkParse)
+                .use(remarkHtml)
+                .processSync(this.markdownContents)
+                .toString();
+        },
+    },
+    mounted() {
+        /* Load remote markdown, parse it, and inject in $el. */
+        console.debug("Mounted!");
+        fetch(this.href)
+            .then((response) => response.text())
+            .then((markdownText) => {
+                this.markdownContents = markdownText;
+            });
+        // TODO: Add a loading spinner.
+        // TODO: Add a fallback for when the markdown is not available.
+    },
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/MarkdownEmbed.vue
+++ b/src/components/MarkdownEmbed.vue
@@ -25,11 +25,7 @@ export default {
     },
     computed: {
         processedContents() {
-            return unified()
-                .use(remarkParse)
-                .use(remarkHtml)
-                .processSync(this.markdownContents)
-                .toString();
+            return unified().use(remarkParse).use(remarkHtml).processSync(this.markdownContents).toString();
         },
     },
     mounted() {

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import "~/assets/covid.styl";
 import DefaultLayout from "~/layouts/Default.vue";
 import LinkBox from "~/components/LinkBox.vue";
 import VegaEmbed from "~/components/VegaEmbed.vue";
+import MarkdownEmbed from "~/components/MarkdownEmbed.vue";
 
 import BootstrapVue from "bootstrap-vue";
 
@@ -16,6 +17,7 @@ export default function (Vue, { router, head, isClient }) {
     Vue.component("Layout", DefaultLayout);
     Vue.component("LinkBox", LinkBox);
     Vue.component("VegaEmbed", VegaEmbed);
+    Vue.component("MarkdownEmbed", MarkdownEmbed);
 
     Vue.use(BootstrapVue);
     Vue.config.ignoredElements = ["gcse:search", "gcse:searchresults-only"];


### PR DESCRIPTION
Use it similar to `vega-embed`:

```
<markdown-embed href="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/client/README.md" />
```

This will load that markdown, process it, and inject it in the page inheriting all the expected styles, as seen here, where I inject that client readme into my personal hub page with the line above:

![image](https://user-images.githubusercontent.com/155398/152403166-54443680-b63c-4805-86c4-56bc2aeb965f.png)


(I really should update my person page, now that I see it...)