### PR TITLE
Update the Galaxy Code of Conduct

### DIFF
--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -5,89 +5,86 @@ title: "Galaxy Project Code of Conduct"
 
 <img src="/images/undraw-illustrations/coc.svg" alt="coc" style="width:230px; float:right;"/>
 
+The Galaxy Community is dedicated to provide a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
 
-## Galaxy Project Code of Conduct
+This Code of Conduct applies to all Galaxy Community spaces, including but not limited to GitHub, gitter, matrix, Slack, twitter and the Galaxy mailing lists, both online and off. 
 
-This code of conduct outlines our expectations for participants within the
-Galaxy community, as well as steps to reporting unacceptable behavior. We are
-committed to providing a welcoming and inspiring community for all and expect
-our code of conduct to be honored. Anyone who violates this code of conduct may
-be banned from the community.
+Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the [Galaxy CoC Committee](#the-galaxy-coc-committee).
+Some Galaxy Community spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
 
-Our open source community strives to:
+### Our principles
+
+The Galaxy Community strives to:
 
 * **Be friendly and patient.**
 
-* **Be welcoming**: We strive to be a community that welcomes and
-  supports people of all backgrounds and identities. This includes, but is not
-  limited to members of any race, ethnicity, culture, national origin, colour,
-  immigration status, social and economic class, educational level, sex, sexual
-  orientation, gender identity and expression, age, size, family status,
-  political belief, religion, and mental and physical ability.
+* **Be welcoming**: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
-* **Be considerate**: Your work will be used by other people, and you in turn
-  will depend on the work of others. Any decision you take will affect users
-  and colleagues, and you should take those consequences into account when
-  making decisions. Remember that we're a world-wide community, so you might
-  not be communicating in someone else's primary language.
+* **Be considerate**: Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
 
-* **Be respectful**: Not all of us will agree all the time, but disagreement is
-  no excuse for poor behavior and poor manners. We might all experience some
-  frustration now and then, but we cannot allow that frustration to turn into a
-  personal attack. It’s important to remember that a community where people
-  feel uncomfortable or threatened is not a productive one.
+* **Be respectful**: Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one.
 
-* **Be careful in the words that we choose**: We are a community of
-  professionals, and we conduct ourselves professionally. Be kind to others. Do
-  not insult or put down other participants. Harassment and other exclusionary
-  behavior aren't acceptable. This includes, but is not limited to: Violent
-  threats or language directed against another person, Discriminatory jokes and
-  language, Posting sexually explicit or violent material, Posting (or
-  threatening to post) other people’s personally identifying information
-  (“doxing”), Personal insults, especially those using racist or sexist terms,
-  Unwelcome sexual attention, Advocating for, or encouraging, any of the above
-  behavior, Repeated harassment of others. In general, if someone asks you to
-  stop, then stop.
+* **Try to understand why we disagree**: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. Diversity contributes to the strength of our community, which is composed of people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err, and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
-* **Try to understand why we disagree**: Disagreements, both social and
-  technical, happen all the time. It is important that we resolve disagreements
-  and differing views constructively. Remember that we’re different. Diversity
-  contributes to the strength of our community, which is composed of people
-  from a wide range of backgrounds. Different people have different
-  perspectives on issues. Being unable to understand why someone holds a
-  viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to
-  err and blaming each other doesn’t get us anywhere. Instead, focus on helping
-  to resolve issues and learning from mistakes.
+* **Be careful in the words that we choose**: Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. Harassment includes, but is not limited to:
 
-### Diversity Statement
+  - Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, or religion.
+  - Unwelcome comments or jokes, to an audience or personally, regarding another person’s lifestyle choices and practices, including those related to food, health, religion, parenting, drugs, and employment.
+  - Mocking or insulting another person’s intellect, work, perspective, or question/comment.
+  - Deliberate misgendering or use of ‘dead’ or rejected names.
+  - Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate.
+  - Physical contact and simulated physical contact (e.g., textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
+  - Threats of violence.
+  - Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm.
+  - Deliberate intimidation.
+  - Stalking or following.
+  - Harassing photography or recording, including logging online activity for harassment purposes.
+  - Sustained disruption of discussion.
+  - Unwelcome sexual attention.
+  - Patterns of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others.
+  - Continued one-on-one communication after requests to cease.
+  - Deliberate “outing” of any aspect of a person’s identity without their consent, except as necessary to protect vulnerable people from intentional abuse.
+  - Malicious publication of otherwise private communication, or private personal information (“doxing” or “outing”).
 
-We encourage everyone to participate and are committed to building a community
-for all. Although we will fail at times, we seek to treat everyone both as
-fairly and equally as possible. Whenever a participant has made a mistake, we
-expect them to take responsibility for it. If someone has been harmed or
-offended, it is our responsibility to listen carefully and respectfully, and do
-our best to right the wrong.
 
-Although this list cannot be exhaustive, we explicitly honor diversity in age,
-gender, gender identity or expression, culture, ethnicity, language, national
-origin, political beliefs, profession, race, religion, sexual orientation,
-socioeconomic status, and technical ability. We will not tolerate
-discrimination based on any of the protected characteristics above, including
-participants with disabilities.
+The Galaxy Community prioritizes marginalized people’s safety overprivileged people’s comfort. The Galaxy CoC Committee reserves the right not to act on complaints regarding:
+- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’.
+- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
+- Communicating in a ‘tone’ you don’t find congenial.
+- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions.
 
-### Reporting Issues
 
-If you experience or witness unacceptable behavior, or have any other concerns,
-please report it to any combination of the following people that makes you feel
-the most comfortable:
+### Reporting
 
-* Dave Clements (clementsgalaxy@gmail.com). Dave is the Galaxy Project community
-  outreach manager and has experience handling Code of Conduct related issues.
-* Dr. Mike Schatz (mschatz@cs.jhu.edu). Mike is Dave Clements' direct manager
-  and issues related to Dave in some way should be reported to Mike.
-* Helena Rasche (helena.rasche@gmail.com). Helena is a well-known, trusted
-  community member, is LGBT+, and has completely separate funding and
-  institutional affiliation from Dave and Mike.
+If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please contact the [CoC Committee](#the-galaxy-coc-committee). If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+
+This code of conduct applies to Galaxy Community spaces, but if you are being harassed by a member of Galaxy Community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Galaxy Community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from the Galaxy Community based on their past behavior, including behavior outside Galaxy Community spaces and behavior towards people who are not in the Galaxy Community.
+
+To protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. 
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Galaxy Community members or the general public. We will not name harassment victims without their affirmative consent.
+
+### Consequences
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behavior, the CoC Committee may take any action they deem appropriate, up to and including expulsion from all Galaxy Community spaces and identification of the participant as a harasser to other Galaxy Community members or the general public. If the harasser is directly funded through the Galaxy project, the harasser may be subject to additional oversight at their home institution.
+
+### The Galaxy CoC Committee
+
+* Assunta DeSanto (she/her) [EN]
+* [Helena Rasche](mailto:helena.rasche@gmail.com) (she/her) [EN] (LGBTQ+, not funded by galaxyproject) 
+* [Mike Schatz](mailto:mschatz@cs.jhu.edu) [EN] (he/him)
+* Beatriz Serrano Solano (she/her) [ES, EN]
+* Ross Lazarus (he/him) [EN]
+* Frederik Coppens (he/him) [EN]
+* Gareth Price (he/him) [EN]
+
+
+* Ombuds person: Laurent Gatto (he/him) [FR, EN]
+
+
+---
 
 All reports will be handled with discretion. In your report please include:
 
@@ -111,7 +108,7 @@ for the purpose of protecting victims of abuse.
 
 ### Attribution & Acknowledgements
 
-This code of conduct is based on the [Open Code of Conduct from the TODOGroup](https://todogroup.org/blog/followup-open-code-of-conduct/).
+This CoC is based on the Geek Feminism Code of Conduct and the [Open Code of Conduct from the TODOGroup](https://todogroup.org/blog/followup-open-code-of-conduct/).
 
 ## Historical note: Change is Coming
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -76,16 +76,14 @@ If a participant engages in harassing behavior, the [Galaxy CoC Committee](#the-
 | --- | --- | --- | --- | --- | --- |
 | [Assunta DeSanto](mailto:assuntad23@gmail.com) | she/her | EN | US | 2 ||
 | [Beatriz Serrano Solano](mailto:beatrizserrano.galaxy@gmail.com) | she/her | ES, EN | DE | 2 | Ombudsperson in the Bioconductor Community CoC Committee |
-| [Frederik Coppens](mailto:frcop@psb.vib-ugent.be) | he/him | EN | BE | 7 ||
-| [Gareth Price](mailto:g.price@qcif.edu.au) | he/him | EN | AU | 5 ||
+| [Frederik Coppens](mailto:frcop@psb.vib-ugent.be) | he/him | NL EN FR | BE | 7 ||
 | [Helena Rasche](mailto:helena.rasche@gmail.com) | she/they | EN | NL | 9 | LGBTQ+ 🏳️‍⚧️🏳️‍🌈, not funded by the Galaxy project |
-| [Mike Schatz](mailto:mschatz@cs.jhu.edu) | he/him | EN | US | 2 | Galaxy PI |
 | [Ross Lazarus](mailto:ross.lazarus@gmail.com) | he/him | EN | AU | 16 | Retired, not funded by the Galaxy project |
 
 The Galaxy Code of Conduct Committee has appointed an Ombudsperson from the Bioconductor community to provide independent and impartial oversight and to resolve conflicts. This person can be contacted in case you believe that other avenues of reporting may be biased.
 
 | Member | Pronouns | Language | Location | Relevant information |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | [Laurent Gatto](mailto:laurent.gatto@gmail.com) | he/him | FR, EN | BE | Ombudsperson, member of the Bioconductor community |
 
 ### Attribution & Acknowledgements

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -7,7 +7,7 @@ title: "Galaxy Project Code of Conduct"
 
 The Galaxy Community is dedicated to provide a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
 
-This Code of Conduct applies to all Galaxy Community spaces, including but not limited to GitHub, gitter, matrix, Slack, twitter and the Galaxy mailing lists, both online and off. 
+This Code of Conduct outlines the behaviours deemed acceptable and unacceptable to the global Galaxy community and applies to all public Galaxy spaces, including but not limited to GitHub, gitter, matrix, Slack, twitter and the Galaxy mailing lists, both online and off. 
 
 Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the [Galaxy CoC Committee](#the-galaxy-coc-committee).
 Some Galaxy Community spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
@@ -47,7 +47,7 @@ The Galaxy Community strives to:
   - Malicious publication of otherwise private communication, or private personal information (“doxing” or “outing”).
 
 
-The Galaxy Community prioritizes marginalized people’s safety overprivileged people’s comfort. The Galaxy CoC Committee reserves the right not to act on complaints regarding:
+The Galaxy Community prioritizes marginalized people’s safety over privileged people’s comfort. The [Galaxy CoC Committee](#the-galaxy-coc-committee) reserves the right not to act on complaints regarding:
 - ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’.
 - Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
 - Communicating in a ‘tone’ you don’t find congenial.
@@ -56,7 +56,7 @@ The Galaxy Community prioritizes marginalized people’s safety overprivileged p
 
 ### Reporting
 
-If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please contact the [CoC Committee](#the-galaxy-coc-committee). If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please contact the [Galaxy CoC Committee](#the-galaxy-coc-committee). If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
 This code of conduct applies to Galaxy Community spaces, but if you are being harassed by a member of Galaxy Community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Galaxy Community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from the Galaxy Community based on their past behavior, including behavior outside Galaxy Community spaces and behavior towards people who are not in the Galaxy Community.
 
@@ -68,7 +68,7 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 Participants asked to stop any harassing behavior are expected to comply immediately.
 
-If a participant engages in harassing behavior, the CoC Committee may take any action they deem appropriate, up to and including expulsion from all Galaxy Community spaces and identification of the participant as a harasser to other Galaxy Community members or the general public. If the harasser is directly funded through the Galaxy project, the harasser may be subject to additional oversight at their home institution.
+If a participant engages in harassing behavior, the [Galaxy CoC Committee](#the-galaxy-coc-committee) may take any action they deem appropriate, up to and including expulsion from all Galaxy Community spaces and identification of the participant as a harasser to other Galaxy Community members or the general public. If the harasser is directly funded through the Galaxy project, the harasser may be subject to additional oversight at their home institution.
 
 ### The Galaxy CoC Committee
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -76,7 +76,7 @@ If a participant engages in harassing behavior, the [Galaxy CoC Committee](#the-
 | --- | --- | --- | --- | --- | --- |
 | [Assunta DeSanto](mailto:assuntad23@gmail.com) | she/her | EN | US | 2 ||
 | [Beatriz Serrano Solano](mailto:beatrizserrano.galaxy@gmail.com) | she/her | ES, EN | DE | 2 ||
-| [Frederik Coppens](mailto:ross.lazarus@gmail.com) | he/him | EN | BE | 7 ||
+| [Frederik Coppens](mailto:frcop@psb.vib-ugent.be) | he/him | EN | BE | 7 ||
 | [Gareth Price](mailto:g.price@qcif.edu.au) | he/him | EN | AU | 5 ||
 | [Helena Rasche](mailto:helena.rasche@gmail.com) | she/they | EN | NL | 9 | LGBTQ+, not funded by the Galaxy project |
 | [Mike Schatz](mailto:mschatz@cs.jhu.edu) | he/him | EN | US | 2 | Galaxy PI |

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -98,4 +98,4 @@ That code of conduct served us reasonably well over the years, but it is time fo
 
 As a result it is past time to update both our code of conduct and our process for maintaining it.  The first step in that was to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
 
-The Galaxy Outreach and Training [Working Group](/community/wg/) has worked on a first draft of a new Code and new processes. The final Code and processes were adopted after being discussed, revised, and approved by the community.
+The Galaxy Outreach, Training and Support [Working Group](/community/wg/) has worked on a first draft of a new Code and new processes. The final Code and processes were adopted after being discussed, revised, and approved by the community.

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -78,7 +78,7 @@ If a participant engages in harassing behavior, the [Galaxy CoC Committee](#the-
 | [Beatriz Serrano Solano](mailto:beatrizserrano.galaxy@gmail.com) | she/her | ES, EN | DE | 2 | Ombudsperson in the Bioconductor Community CoC Committee |
 | [Frederik Coppens](mailto:frcop@psb.vib-ugent.be) | he/him | EN | BE | 7 ||
 | [Gareth Price](mailto:g.price@qcif.edu.au) | he/him | EN | AU | 5 ||
-| [Helena Rasche](mailto:helena.rasche@gmail.com) | she/they | EN | NL | 9 | LGBTQ+, not funded by the Galaxy project |
+| [Helena Rasche](mailto:helena.rasche@gmail.com) | she/they | EN | NL | 9 | LGBTQ+ 🏳️‍⚧️🏳️‍🌈, not funded by the Galaxy project |
 | [Mike Schatz](mailto:mschatz@cs.jhu.edu) | he/him | EN | US | 2 | Galaxy PI |
 | [Ross Lazarus](mailto:ross.lazarus@gmail.com) | he/him | EN | AU | 16 | Retired, not funded by the Galaxy project |
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -72,14 +72,15 @@ If a participant engages in harassing behavior, the CoC Committee may take any a
 
 ### The Galaxy CoC Committee
 
-* Assunta DeSanto (she/her) [EN]
-* [Helena Rasche](mailto:helena.rasche@gmail.com) (she/her) [EN] (LGBTQ+, not funded by galaxyproject) 
-* [Mike Schatz](mailto:mschatz@cs.jhu.edu) [EN] (he/him)
-* Beatriz Serrano Solano (she/her) [ES, EN]
-* Ross Lazarus (he/him) [EN]
-* Frederik Coppens (he/him) [EN]
-* Gareth Price (he/him) [EN]
-
+| Member | Pronouns | Language | Location | Seniority in the project | Relevant information |
+| --- | --- | --- | --- | --- | --- |
+| [Assunta DeSanto](mailto:assuntad23@gmail.com) | she/her | EN | US | 2 ||
+| [Beatriz Serrano Solano](mailto:beatrizserrano.galaxy@gmail.com) | she/her | ES, EN | DE | 2 ||
+| [Frederik Coppens](mailto:ross.lazarus@gmail.com) | he/him | EN | BE | 7 ||
+| [Gareth Price](mailto:g.price@qcif.edu.au) | he/him | EN | AU | 5 ||
+| [Helena Rasche](mailto:helena.rasche@gmail.com) | she/they | EN | NL | 9 | LGBTQ+, not funded by the Galaxy project |
+| [Mike Schatz](mailto:mschatz@cs.jhu.edu) | he/him | EN | US | 2 | Galaxy PI |
+| [Ross Lazarus](mailto:ross.lazarus@gmail.com) | he/him | EN | AU | 16 | Retired, not funded by the Galaxy project |
 
 * Ombuds person: Laurent Gatto (he/him) [FR, EN]
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -56,11 +56,11 @@ The Galaxy Community prioritizes marginalized people’s safety over privileged 
 
 ### Reporting
 
-If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please contact the [Galaxy CoC Committee](#the-galaxy-coc-committee). If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
-
-This code of conduct applies to Galaxy Community spaces, but if you are being harassed by a member of Galaxy Community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Galaxy Community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from the Galaxy Community based on their past behavior, including behavior outside Galaxy Community spaces and behavior towards people who are not in the Galaxy Community.
+If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form]() that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct committee as a group, you can contact any individual committee member via email. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
 To protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. 
+
+This code of conduct applies to Galaxy Community spaces, but if you are being harassed by a member of Galaxy Community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Galaxy Community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from the Galaxy Community based on their past behavior, including behavior outside Galaxy Community spaces and behavior towards people who are not in the Galaxy Community.
 
 We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Galaxy Community members or the general public. We will not name harassment victims without their affirmative consent.
 
@@ -82,7 +82,11 @@ If a participant engages in harassing behavior, the [Galaxy CoC Committee](#the-
 | [Mike Schatz](mailto:mschatz@cs.jhu.edu) | he/him | EN | US | 2 | Galaxy PI |
 | [Ross Lazarus](mailto:ross.lazarus@gmail.com) | he/him | EN | AU | 16 | Retired, not funded by the Galaxy project |
 
-* Ombuds person: Laurent Gatto (he/him) [FR, EN]
+The Galaxy Code of Conduct Committee has appointed an Ombudsperson from the Bioconductor community to provide independent and impartial oversight and to resolve conflicts. This person can be contacted in case you believe that other avenues of reporting may be biased.
+
+| Member | Pronouns | Language | Location | Relevant information |
+| --- | --- | --- | --- | --- | --- |
+| [Laurent Gatto](mailto:laurent.gatto@gmail.com) | he/him | FR, EN | BE | Ombudsperson, member of the Bioconductor community |
 
 
 ---
@@ -99,14 +103,6 @@ All reports will be handled with discretion. In your report please include:
 
 * Any additional information that may be helpful.
 
-After filing a report, a representative will contact you personally, review the
-incident, follow up with any additional questions, and make a decision as to
-how to respond. If the person who is harassing you is part of the response
-team, they will recuse themselves from handling your incident. If the complaint
-originates from a member of the response team, it will be handled by a
-different member of the response team. We will respect confidentiality requests
-for the purpose of protecting victims of abuse.
-
 ### Attribution & Acknowledgements
 
 This CoC is based on the Geek Feminism Code of Conduct and the [Open Code of Conduct from the TODOGroup](https://todogroup.org/blog/followup-open-code-of-conduct/).
@@ -117,6 +113,6 @@ From 2015 through 2021 the Galaxy Project Code of Conduct [resided in the main G
 
 That code of conduct served us reasonably well over the years, but it is time for a refresh. Since 2015, the world has become much more aware of the need for codes of conduct, and best practices for creating and enforcing them have moved forward significantly.
 
-**As a result it is past time to update both our code of conduct and our process for maintaining it.**  The first step in that was to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
+As a result it is past time to update both our code of conduct and our process for maintaining it.  The first step in that was to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
 
 The Galaxy Outreach and Training [Working Group](/community/wg/) has worked on a first draft of a new code and new processes. The final code and processes we adopt is implemented only after it has been discussed, revised, and approved by the community.

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -56,7 +56,7 @@ The Galaxy Community prioritizes marginalized people’s safety over privileged 
 
 ### Reporting
 
-If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form]() that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct committee as a group, you can contact any individual committee member via email. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form](https://forms.gle/gEMubTrW9ifwemqe6) that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct committee as a group, you can contact any individual committee member via email. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
 To protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. 
 
@@ -87,21 +87,6 @@ The Galaxy Code of Conduct Committee has appointed an Ombudsperson from the Bioc
 | Member | Pronouns | Language | Location | Relevant information |
 | --- | --- | --- | --- | --- | --- |
 | [Laurent Gatto](mailto:laurent.gatto@gmail.com) | he/him | FR, EN | BE | Ombudsperson, member of the Bioconductor community |
-
-
----
-
-All reports will be handled with discretion. In your report please include:
-
-* Your contact information.
-
-* Names (real, nicknames, or pseudonyms) of any individuals involved. If there
-  are additional witnesses, please include them as well. Your account of what
-  occurred, and if you believe the incident is ongoing. If there is a publicly
-  available record (e.g. a mailing list archive or a public IRC logger), please
-  include a link.
-
-* Any additional information that may be helpful.
 
 ### Attribution & Acknowledgements
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -75,7 +75,7 @@ If a participant engages in harassing behavior, the [Galaxy CoC Committee](#the-
 | Member | Pronouns | Language | Location | Seniority in the project | Relevant information |
 | --- | --- | --- | --- | --- | --- |
 | [Assunta DeSanto](mailto:assuntad23@gmail.com) | she/her | EN | US | 2 ||
-| [Beatriz Serrano Solano](mailto:beatrizserrano.galaxy@gmail.com) | she/her | ES, EN | DE | 2 ||
+| [Beatriz Serrano Solano](mailto:beatrizserrano.galaxy@gmail.com) | she/her | ES, EN | DE | 2 | Ombudsperson in the Bioconductor Community CoC Committee |
 | [Frederik Coppens](mailto:frcop@psb.vib-ugent.be) | he/him | EN | BE | 7 ||
 | [Gareth Price](mailto:g.price@qcif.edu.au) | he/him | EN | AU | 5 ||
 | [Helena Rasche](mailto:helena.rasche@gmail.com) | she/they | EN | NL | 9 | LGBTQ+, not funded by the Galaxy project |

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -5,9 +5,9 @@ title: "Galaxy Project Code of Conduct"
 
 <img src="/images/undraw-illustrations/coc.svg" alt="coc" style="width:230px; float:right;"/>
 
-The Galaxy Community is dedicated to provide a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+The Galaxy Community is dedicated to provide a harassment-free experience for everyone. We do not tolerate harassment in any form.
 
-This Code of Conduct outlines the behaviours deemed acceptable and unacceptable to the global Galaxy community and applies to all public Galaxy spaces, including but not limited to GitHub, gitter, matrix, Slack, twitter and the Galaxy mailing lists, both online and off. 
+This Code of Conduct outlines the behaviours deemed acceptable and unacceptable to the global Galaxy community and applies to all public Galaxy spaces, including but not limited to events, GitHub, Gitter, Matrix, Slack, Twitter and the Galaxy mailing lists, both online and off. 
 
 Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the [Galaxy CoC Committee](#the-galaxy-coc-committee).
 Some Galaxy Community spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
@@ -56,7 +56,7 @@ The Galaxy Community prioritizes marginalized people’s safety over privileged 
 
 ### Reporting
 
-If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form](https://forms.gle/gEMubTrW9ifwemqe6) that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct committee as a group, you can contact any individual committee member via email. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form](https://forms.gle/gEMubTrW9ifwemqe6) that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct Committee as a group, you can contact any individual Committee member via email. If the person who is harassing you is on the Committee, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
 To protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. 
 
@@ -100,4 +100,4 @@ That code of conduct served us reasonably well over the years, but it is time fo
 
 As a result it is past time to update both our code of conduct and our process for maintaining it.  The first step in that was to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
 
-The Galaxy Outreach and Training [Working Group](/community/wg/) has worked on a first draft of a new code and new processes. The final code and processes we adopt is implemented only after it has been discussed, revised, and approved by the community.
+The Galaxy Outreach and Training [Working Group](/community/wg/) has worked on a first draft of a new Code and new processes. The final Code and processes were adopted after being discussed, revised, and approved by the community.

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -56,7 +56,7 @@ The Galaxy Community prioritizes marginalized people’s safety over privileged 
 
 ### Reporting
 
-If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form](https://forms.gle/gEMubTrW9ifwemqe6) that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct Committee as a group, you can contact any individual Committee member via email. If the person who is harassing you is on the Committee, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form](bit.ly/reporting-coc) that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct Committee as a group, you can contact any individual Committee member via email. If the person who is harassing you is on the Committee, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
 To protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. 
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -56,7 +56,7 @@ The Galaxy Community prioritizes marginalized people’s safety over privileged 
 
 ### Reporting
 
-If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form](bit.ly/reporting-coc) that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct Committee as a group, you can contact any individual Committee member via email. If the person who is harassing you is on the Committee, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+If you are being harassed by a member of the Galaxy Community, notice that someone else is being harassed, or have any other concerns, please send a report via [this form](https://bit.ly/reporting-coc) that will be forwarded to the [Galaxy CoC Committee](#the-galaxy-coc-committee). Alternatively, you can [email the Code of Conduct Committee](mailto:code-of-conduct@lists.galaxyproject.org). If you are uncomfortable reporting to the Code of Conduct Committee as a group, you can contact any individual Committee member via email. If the person who is harassing you is on the Committee, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
 To protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. 
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -84,7 +84,7 @@ The Galaxy Code of Conduct Committee has appointed an Ombudsperson from the Bioc
 
 | Member | Pronouns | Language | Location | Relevant information |
 | --- | --- | --- | --- | --- |
-| [Laurent Gatto](mailto:laurent.gatto@gmail.com) | he/him | FR, EN | BE | Ombudsperson, member of the Bioconductor community |
+| [Laurent Gatto](mailto:laurent.gatto@gmail.com) | he/him | FR, EN | BE | Ombudsperson, member of the Bioconductor CoC Committee |
 
 ### Attribution & Acknowledgements
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -90,7 +90,7 @@ The Galaxy Code of Conduct Committee has appointed an Ombudsperson from the Bioc
 
 ### Attribution & Acknowledgements
 
-This CoC is based on the Geek Feminism Code of Conduct and the [Open Code of Conduct from the TODOGroup](https://todogroup.org/blog/followup-open-code-of-conduct/).
+This CoC is based on the [Geek Feminism Code of Conduct](https://geekfeminismdotorg.wordpress.com/about/code-of-conduct/) and the [Open Code of Conduct from the TODOGroup](https://todogroup.org/blog/followup-open-code-of-conduct/).
 
 ### Historical note
 

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -111,14 +111,12 @@ for the purpose of protecting victims of abuse.
 
 This CoC is based on the Geek Feminism Code of Conduct and the [Open Code of Conduct from the TODOGroup](https://todogroup.org/blog/followup-open-code-of-conduct/).
 
-## Historical note: Change is Coming
+### Historical note
 
 From 2015 through 2021 the Galaxy Project Code of Conduct [resided in the main Galaxy repository on GitHub](https://github.com/galaxyproject/galaxy/blob/57d6a3857d397fedf9fbed724241584fd031033b/CODE_OF_CONDUCT.md), and updates to it were coordinated by the Committers Group for that repo.
 
-That code of conduct has served us reasonably well over the years, but it is time for a refresh.  Since 2015 the world has become much more aware of the need for codes of conduct, and best practices for creating and enforcing them have moved forward significantly.
+That code of conduct served us reasonably well over the years, but it is time for a refresh. Since 2015, the world has become much more aware of the need for codes of conduct, and best practices for creating and enforcing them have moved forward significantly.
 
-**As a result it is past time to update both our code of conduct and our process for maintaining it.**  The first step in that has been to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
+**As a result it is past time to update both our code of conduct and our process for maintaining it.**  The first step in that was to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
 
-The Galaxy Outreach and Training [Working Group](/community/wg/) is has started working on a first draft of a new code and new processes.  The final code and processes we adopt will be implemented only after it has been discussed, revised, and approved by the community.
-
-Watch this space (and Galaxy channels of course).
+The Galaxy Outreach and Training [Working Group](/community/wg/) has worked on a first draft of a new code and new processes. The final code and processes we adopt is implemented only after it has been discussed, revised, and approved by the community.

--- a/content/community/coc/index.md
+++ b/content/community/coc/index.md
@@ -5,17 +5,6 @@ title: "Galaxy Project Code of Conduct"
 
 <img src="/images/undraw-illustrations/coc.svg" alt="coc" style="width:230px; float:right;"/>
 
-## Note: Change is Coming
-
-From 2015 through 2021 the Galaxy Project Code of Conduct [resided in the main Galaxy repository on GitHub](https://github.com/galaxyproject/galaxy/blob/57d6a3857d397fedf9fbed724241584fd031033b/CODE_OF_CONDUCT.md), and updates to it were coordinated by the Committers Group for that repo.
-
-That code of conduct has served us reasonably well over the years, but it is time for a refresh.  Since 2015 the world has become much more aware of the need for codes of conduct, and best practices for creating and enforcing them have moved forward significantly.
-
-**As a result it is past time to update both our code of conduct and our process for maintaining it.**  The first step in that has been to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
-
-The Galaxy Outreach and Training [Working Group](/community/wg/) is has started working on a first draft of a new code and new processes.  The final code and processes we adopt will be implemented only after it has been discussed, revised, and approved by the community.
-
-Watch this space (and Galaxy channels of course).
 
 ## Galaxy Project Code of Conduct
 
@@ -123,3 +112,15 @@ for the purpose of protecting victims of abuse.
 ### Attribution & Acknowledgements
 
 This code of conduct is based on the [Open Code of Conduct from the TODOGroup](https://todogroup.org/blog/followup-open-code-of-conduct/).
+
+## Historical note: Change is Coming
+
+From 2015 through 2021 the Galaxy Project Code of Conduct [resided in the main Galaxy repository on GitHub](https://github.com/galaxyproject/galaxy/blob/57d6a3857d397fedf9fbed724241584fd031033b/CODE_OF_CONDUCT.md), and updates to it were coordinated by the Committers Group for that repo.
+
+That code of conduct has served us reasonably well over the years, but it is time for a refresh.  Since 2015 the world has become much more aware of the need for codes of conduct, and best practices for creating and enforcing them have moved forward significantly.
+
+**As a result it is past time to update both our code of conduct and our process for maintaining it.**  The first step in that has been to move the Code of Conduct to the Galaxy Community Hub, to make it more visible and to reflect that it is a document for the whole community.
+
+The Galaxy Outreach and Training [Working Group](/community/wg/) is has started working on a first draft of a new code and new processes.  The final code and processes we adopt will be implemented only after it has been discussed, revised, and approved by the community.
+
+Watch this space (and Galaxy channels of course).


### PR DESCRIPTION
This PR updates the content of the CoC based on the discussions in the google doc. I made some extra adjustments:

- Included a sentence at the beginning stating what the CoC is (thanks Gareth for the suggestion).
- Reporting
  - Creation of a form for (anonymous) reporting. Inspiration taken from the Bioconductor community.
  - Creation of a mailing list for the members of the committee and added it as an option to report.
- Committee
  - Included the members of the CoC in a table with emails embedded. Please fix the content as needed.  
  - After meeting the Bioconductor CoC committee, added Laurent Gatto as ombudsperson and a couple of sentences explaining when to contact the Ombudsperson.
- Moved the historical note to the end to give some context to this change.