### PR TITLE
Default to copy for preprocessing, except resource files on build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ read and explore the web site, then you should absolutely do that through
 
 ## Getting started
 
-First, make sure you have [Node](https://nodejs.org/en/) installed. Then, you'll need a package manager. These instructions use [yarn 1*](https://yarnpkg.com/), but there are equivalent commands for [npm](https://docs.npmjs.com/cli/v7/commands/npm).
+First, make sure you have [Node](https://nodejs.org/en/) installed. Then, you'll need a package manager. These instructions use [yarn 1](https://yarnpkg.com/)\*, but there are equivalent commands for [npm](https://docs.npmjs.com/cli/v7/commands/npm).
 
-<sup>*</sup> <small>Do not use Yarn 2.</small>
+\*Do not use Yarn 2.
 
 You can get the site running locally by first cloning this repo:  
 ```sh
@@ -39,8 +39,7 @@ Then you can build the site in development mode to run it in a local server (at 
 ```sh
 $ yarn develop
 ```
-This command includes a hot reloader which will update the site automatically each time you edit a file.  
-Note: There's a [minor known issue](https://github.com/galaxyproject/galaxy-hub/issues/748) that can occur when you're renaming/moving/deleting directories or image files. If you're finding the development server crashes too often, try adding the arguments `--resource copy` to the `yarn develop` command. This fixes the issue, at the cost of a far larger build directory (because all images are copied to it instead of linked).
+This command includes a hot reloader which will update the site automatically each time you edit a file.
 
 To generate the static files for the entire site, just run `build` instead:
 ```sh

--- a/src/build/preprocess.mjs
+++ b/src/build/preprocess.mjs
@@ -11,16 +11,8 @@ import * as mdfixer from "./mdfixer.mjs";
 import { repr } from "../utils.js";
 import { PathInfo } from "../paths.js";
 
-// When running `gridsome build` or `develop`, links are sufficient for it to do the right thing
-// (except in the case of `vue-remark`, of course).
-const PREPROCESS_PLACERS = { md: "link", vue: "copy", insert: "link", resource: "link" };
-// But the development server's hot reloader doesn't deal well with links. When the target of a link
-// has been edited, it notices and does some work, but ultimately doesn't recompile the page.
-// Even worse, if a link is ever broken, it crashes.
-const WATCH_PLACERS = { md: "copy", vue: "copy", insert: "copy", resource: "copy" };
-// If we're running mdfixer.mjs on the build directory after partitioning, the Markdown files can't
-// be links. If they are, mdfixer.mjs will overwrite the targets of the links, altering the originals.
-const MDFIX_PREPROCESS_PLACERS = { md: "copy", vue: "copy", insert: "copy", resource: "link" };
+// Without additional context or instructions, default to copy for everything, which is the safest.
+const DEFAULT_PLACERS = { md: "copy", vue: "copy", insert: "copy", resource: "copy" };
 
 // Define command line arguments.
 export const program = new Command();
@@ -82,17 +74,7 @@ function main(command, opts) {
     }
     // Assign placers.
     let placers = {};
-    let defaultPlacers;
-    if (command === "preprocess") {
-        if (opts.fixMarkdown) {
-            defaultPlacers = MDFIX_PREPROCESS_PLACERS;
-        } else {
-            defaultPlacers = PREPROCESS_PLACERS;
-        }
-    } else if (command === "watch") {
-        defaultPlacers = WATCH_PLACERS;
-    }
-    Object.assign(placers, defaultPlacers);
+    Object.assign(placers, DEFAULT_PLACERS);
     for (let contentType of CONTENT_TYPES) {
         if (opts[contentType]) {
             placers[contentType] = opts[contentType];

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -69,7 +69,7 @@ function main(rawArgv) {
     // Start hot reloader, if running developer server.
     let watcher, cmd2;
     if (command === "develop") {
-        exe = PREPROCESSOR_RELPATH
+        exe = PREPROCESSOR_RELPATH;
         let rawArgs = ["watch", ...argv.slice(3)];
         let args = setPlacerArgs(rawArgs, DEFAULT_PLACERS[command]);
         cmd2 = exe + " " + args.join(" ");
@@ -124,7 +124,7 @@ function setPlacerArgs(args, defaultPlacers) {
     // Parse the arguments for placer options.
     let contentType;
     for (let arg of args) {
-        if (arg.slice(0,2) === "--" && CONTENT_TYPES.includes(arg.slice(2))) {
+        if (arg.slice(0, 2) === "--" && CONTENT_TYPES.includes(arg.slice(2))) {
             // It's a placer argument like --resource or --md.
             contentType = arg.slice(2);
         } else if (contentType) {

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -7,6 +7,7 @@ import which from "which";
 import cpy from "cpy";
 import { repr } from "../utils.js";
 import { PathInfo } from "../paths.js";
+import { CONTENT_TYPES } from "./partition-content.mjs";
 // Direct importing of JSON files isn't supported yet in ES modules. This is a workaround.
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
@@ -17,6 +18,23 @@ const PROJECT_ROOT = nodePath.dirname(nodePath.dirname(SCRIPT_DIR));
 const PREPROCESSOR_PATH = nodePath.join(SCRIPT_DIR, "preprocess.mjs");
 const PREPROCESSOR_RELPATH = nodePath.relative(process.cwd(), PREPROCESSOR_PATH);
 
+const DEFAULT_PLACERS = {
+    /* If we're just running `gridsome build`, resources (non-Markdown files) can be symlinks.
+     * But things `vue-remark` will touch can't be symlinks because it can't handle them.
+     * And even regular Markdown files that `vue-remark` doesn't see should be hard copies just in
+     * case we run an mdfixer.mjs step. If we run that on symlinks, the targets of the links get
+     * overwritten. That is, your original Markdown files in the content directory could get screwed
+     * up. So just to be safe, never default to symlinks for Markdown files.
+     */
+    build: { md: "copy", vue: "copy", insert: "copy", resource: "link" },
+    /* The development server's hot reloader doesn't deal well with links. When the target of a link
+     * has been edited, it notices and does some work, but ultimately doesn't recompile the page.
+     * Even worse, if a link is ever broken, it crashes. Copying everything takes a lot more disk
+     * space but avoids issues like #748 and #1207.
+     */
+    develop: { md: "copy", vue: "copy", insert: "copy", resource: "copy" },
+};
+
 let code = main(process.argv);
 if (code) {
     process.exitCode = code;
@@ -24,6 +42,7 @@ if (code) {
 
 function main(rawArgv) {
     let argv = rawArgv.slice();
+    // argv[0] is the node binary and argv[1] is run.mjs, so argv[2] should be the command.
     let command = argv[2];
     if (command !== "develop" && command !== "build") {
         console.error(repr`Invalid command ${command}. Must give 'develop' or 'build'.`);
@@ -31,10 +50,12 @@ function main(rawArgv) {
     }
 
     // Preprocess content.
-    argv[2] = "preprocess";
-    let cmd1 = [PREPROCESSOR_RELPATH, ...argv.slice(2)].join(" ");
+    let exe = PREPROCESSOR_RELPATH;
+    let rawArgs = ["preprocess", ...argv.slice(3)];
+    let args = setPlacerArgs(rawArgs, DEFAULT_PLACERS[command]);
+    let cmd1 = exe + " " + args.join(" ");
     console.log(`$ ${cmd1}`);
-    let { status: code, signal } = childProcess.spawnSync(PREPROCESSOR_RELPATH, argv.slice(2), { stdio: "inherit" });
+    let { status: code, signal } = childProcess.spawnSync(exe, args, { stdio: "inherit" });
     if (code) {
         console.error(`${cmd1} exited with code ${code}`);
     }
@@ -48,10 +69,12 @@ function main(rawArgv) {
     // Start hot reloader, if running developer server.
     let watcher, cmd2;
     if (command === "develop") {
-        let args = ["watch", ...argv.slice(3)];
-        cmd2 = [PREPROCESSOR_RELPATH, ...args].join(" ");
+        exe = PREPROCESSOR_RELPATH
+        let rawArgs = ["watch", ...argv.slice(3)];
+        let args = setPlacerArgs(rawArgs, DEFAULT_PLACERS[command]);
+        cmd2 = exe + " " + args.join(" ");
         console.log(`$ ${cmd2} &`);
-        watcher = childProcess.spawn(PREPROCESSOR_PATH, args, { stdio: "inherit" });
+        watcher = childProcess.spawn(exe, args, { stdio: "inherit" });
     }
 
     // Start Gridsome.
@@ -93,6 +116,38 @@ function main(rawArgv) {
             process.exitCode = code;
         });
     }
+}
+
+function setPlacerArgs(args, defaultPlacers) {
+    let newArgs = [];
+    let argPlacers = {};
+    // Parse the arguments for placer options.
+    let contentType;
+    for (let arg of args) {
+        if (arg.slice(0,2) === "--" && CONTENT_TYPES.includes(arg.slice(2))) {
+            // It's a placer argument like --resource or --md.
+            contentType = arg.slice(2);
+        } else if (contentType) {
+            // The previous argument was a placer one. This is the value for it.
+            argPlacers[contentType] = arg;
+            contentType = null;
+        } else {
+            // Any other type of argument. Just pass it through unmodified.
+            newArgs.push(arg);
+            contentType = null;
+        }
+    }
+    // Compute what the placers should be, based on the inputs.
+    // Any placers defined in the `args` should take precedence, with `defaultPlacers` as fallbacks.
+    let finalPlacers = {};
+    Object.assign(finalPlacers, defaultPlacers);
+    Object.assign(finalPlacers, argPlacers);
+    // Add the final, computed placers to the arguments list.
+    for (let [contentType, placer] of Object.entries(finalPlacers)) {
+        newArgs.push(`--${contentType}`);
+        newArgs.push(placer);
+    }
+    return newArgs;
 }
 
 /** Find the correct command to execute Gridsome. */


### PR DESCRIPTION
Should fix #748 and #1207.

Bottom line: Copy all content files into the build directory instead of symlinking any of them. Unless we're doing `gridsome build` and it's a non-Markdown file.

For more detail, see discussion at the bottom of #1207.