### PR TITLE
Use GraphQL fragments

### DIFF
--- a/content/events/2022-02-04-VIB/index.md
+++ b/content/events/2022-02-04-VIB/index.md
@@ -10,3 +10,4 @@ location_url: ""
 external_url: "https://training.vib.be/all-trainings/bulk-rnaseq-counts-differential-expression-online-1"
 gtn: false
 contact: "Janick Mathys"
+---

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -46,14 +46,14 @@ function addGATag() {
 
 <static-query>
 query {
-  metadata {
-    siteName
-  }
-  footer: insert(path: "/insert:/site-footer/") {
-    id
-    title
-    content
-  }
+    metadata {
+        siteName
+    }
+    footer: insert(path: "/insert:/site-footer/") {
+        id
+        title
+        content
+    }
 }
 </static-query>
 

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -69,13 +69,13 @@ function isFilenamePath(path, maxExtLen = 6) {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/404/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/404/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
 }
 </page-query>

--- a/src/pages/Blog.vue
+++ b/src/pages/Blog.vue
@@ -34,34 +34,34 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/blog/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
-    }
-  }
-  footer: insert(path: "/insert:/blog/footer/") {
-    id
-    title
-    content
-  }
-  articles: allArticle(sortBy: "date", order: DESC, filter: {category: {eq: "blog"}, draft: {ne: true}}) {
-    totalCount
-    edges {
-      node {
+    main: insert(path: "/insert:/blog/main/") {
         id
         title
-        tease
-        authors
-        source_blog
-        source_blog_url
-        external_url
-        date (format: "D MMM YYYY")
-        path
-      }
+        content
+        fileInfo {
+            path
+        }
     }
-  }
+    footer: insert(path: "/insert:/blog/footer/") {
+        id
+        title
+        content
+    }
+    articles: allArticle(sortBy: "date", order: DESC, filter: {category: {eq: "blog"}, draft: {ne: true}}) {
+        totalCount
+        edges {
+            node {
+                id
+                title
+                tease
+                authors
+                source_blog
+                source_blog_url
+                external_url
+                date (format: "D MMM YYYY")
+                path
+            }
+        }
+    }
 }
 </page-query>

--- a/src/pages/Careers.vue
+++ b/src/pages/Careers.vue
@@ -30,54 +30,54 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/careers/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/careers/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
-  footer: insert(path: "/insert:/careers/footer/") {
-    id
-    title
-    content
-  }
-  openings: allArticle(sortBy: "date", order: DESC, filter: {
-    category: {eq: "careers"}, closed: {eq: false}, draft: {ne: true}
-  }) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+    footer: insert(path: "/insert:/careers/footer/") {
+        id
+        title
+        content
     }
-  }
-  previous: allArticle(sortBy: "date", order: DESC, filter: {
-    category: {eq: "careers"}, closed: {eq: true}, draft: {ne: true}
-  }) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+    openings: allArticle(sortBy: "date", order: DESC, filter: {
+        category: {eq: "careers"}, closed: {eq: false}, draft: {ne: true}
+    }) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
+    previous: allArticle(sortBy: "date", order: DESC, filter: {
+        category: {eq: "careers"}, closed: {eq: true}, draft: {ne: true}
+    }) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
+    }
 }
 fragment articleFields on Article {
-  id
-  title
-  date (format: "D MMM YYYY")
-  closes (format: "D MMM YYYY")
-  closed
-  continent
-  location
-  location_url
-  external_url
-  contact
-  summary
-  images
-  image
-  path
+    id
+    title
+    date (format: "D MMM YYYY")
+    closes (format: "D MMM YYYY")
+    closed
+    continent
+    location
+    location_url
+    external_url
+    contact
+    summary
+    images
+    image
+    path
 }
 </page-query>

--- a/src/pages/Careers.vue
+++ b/src/pages/Careers.vue
@@ -49,20 +49,7 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        date (format: "D MMM YYYY")
-        closes (format: "D MMM YYYY")
-        closed
-        continent
-        location
-        location_url
-        external_url
-        contact
-        summary
-        images
-        image
-        path
+        ...articleFields
       }
     }
   }
@@ -72,22 +59,25 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        date (format: "D MMM YYYY")
-        closes (format: "D MMM YYYY")
-        closed
-        continent
-        location
-        location_url
-        external_url
-        contact
-        summary
-        images
-        image
-        path
+        ...articleFields
       }
     }
   }
+}
+fragment articleFields on Article {
+  id
+  title
+  date (format: "D MMM YYYY")
+  closes (format: "D MMM YYYY")
+  closed
+  continent
+  location
+  location_url
+  external_url
+  contact
+  summary
+  images
+  image
+  path
 }
 </page-query>

--- a/src/pages/Events.vue
+++ b/src/pages/Events.vue
@@ -86,21 +86,7 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
@@ -112,23 +98,26 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
+}
+fragment articleFields on Article {
+  id
+  title
+  tease
+  location
+  location_url
+  continent
+  contact
+  external_url
+  gtn
+  links {
+    text
+    url
+  }
+  date (format: "D MMMM YYYY")
+  path
 }
 </page-query>

--- a/src/pages/Events.vue
+++ b/src/pages/Events.vue
@@ -65,59 +65,59 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/events/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/events/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
-  footer: insert(path: "/insert:/events/footer/") {
-    id
-    title
-    content
-  }
-  upcoming: allArticle(
-      sortBy: "date", order: ASC, filter: {
-        category: {eq: "events"}, has_date: {eq: true}, days_ago: {lte: 0}, draft: {ne: true}
-      }
+    footer: insert(path: "/insert:/events/footer/") {
+        id
+        title
+        content
+    }
+    upcoming: allArticle(
+        sortBy: "date", order: ASC, filter: {
+            category: {eq: "events"}, has_date: {eq: true}, days_ago: {lte: 0}, draft: {ne: true}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
-  recent: allArticle(
-      sortBy: "date", order: DESC, filter: {
-        category: {eq: "events"}, has_date: {eq: true}, days_ago: {between: [1, 365]}, draft: {ne: true}
-      }
+    recent: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, has_date: {eq: true}, days_ago: {between: [1, 365]}, draft: {ne: true}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
 }
 fragment articleFields on Article {
-  id
-  title
-  tease
-  location
-  location_url
-  continent
-  contact
-  external_url
-  gtn
-  links {
-    text
-    url
-  }
-  date (format: "D MMMM YYYY")
-  path
+    id
+    title
+    tease
+    location
+    location_url
+    continent
+    contact
+    external_url
+    gtn
+    links {
+        text
+        url
+    }
+    date (format: "D MMMM YYYY")
+    path
 }
 </page-query>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -208,11 +208,7 @@ query {
         totalCount
         edges {
             node {
-                id
-                title
-                tease
-                external_url
-                path
+                ...articleFields
             }
         }
     }
@@ -223,12 +219,8 @@ query {
         totalCount
         edges {
             node {
-                id
-                title
-                tease
+                ...articleFields
                 date (format: "MMM D")
-                external_url
-                path
             }
         }
     }
@@ -236,11 +228,7 @@ query {
         totalCount
         edges {
             node {
-                id
-                title
-                tease
-                external_url
-                path
+                ...articleFields
             }
         }
     }
@@ -260,6 +248,13 @@ query {
             }
         }
     }
+}
+fragment articleFields on Article {
+    id
+    title
+    tease
+    external_url
+    path
 }
 </page-query>
 

--- a/src/pages/News.vue
+++ b/src/pages/News.vue
@@ -26,31 +26,31 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/news/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
-    }
-  }
-  footer: insert(path: "/insert:/news/footer/") {
-    id
-    title
-    content
-  }
-  articles: allArticle(sortBy: "date", order: DESC, filter: {category: {eq: "news"}, draft: {ne: true}}) {
-    totalCount
-    edges {
-      node {
+    main: insert(path: "/insert:/news/main/") {
         id
         title
-        tease
-        external_url
-        date (format: "D MMMM YYYY")
-        path
-      }
+        content
+        fileInfo {
+            path
+        }
     }
-  }
+    footer: insert(path: "/insert:/news/footer/") {
+        id
+        title
+        content
+    }
+    articles: allArticle(sortBy: "date", order: DESC, filter: {category: {eq: "news"}, draft: {ne: true}}) {
+        totalCount
+        edges {
+            node {
+                id
+                title
+                tease
+                external_url
+                date (format: "D MMMM YYYY")
+                path
+            }
+        }
+    }
 }
 </page-query>

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -134,19 +134,19 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/search/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/search/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
-  footer: insert(path: "/insert:/search/footer/") {
-    id
-    title
-    content
-  }
+    footer: insert(path: "/insert:/search/footer/") {
+        id
+        title
+        content
+    }
 }
 </page-query>
 

--- a/src/pages/Use.vue
+++ b/src/pages/Use.vue
@@ -351,40 +351,40 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/use/main/") {
-    fileInfo {
-      path
-    }
-  }
-  allInsert(filter: {path: {regex: "^/insert:/use/[^/]+/$"}}) {
-    totalCount
-    edges {
-      node {
-        id
-        path
-        title
-        content
-      }
-    }
-  }
-  platforms: allPlatform(sortBy: "title", order: ASC) {
-    totalCount
-    edges {
-      node {
-        id
-        title
-        scope
-        summary
-        url
-        path
-        platforms {
-          platform_group
-          platform_url
-          platform_purview
+    main: insert(path: "/insert:/use/main/") {
+        fileInfo {
+            path
         }
-      }
     }
-  }
+    allInsert(filter: {path: {regex: "^/insert:/use/[^/]+/$"}}) {
+        totalCount
+        edges {
+            node {
+                id
+                path
+                title
+                content
+            }
+        }
+    }
+    platforms: allPlatform(sortBy: "title", order: ASC) {
+        totalCount
+        edges {
+            node {
+                id
+                title
+                scope
+                summary
+                url
+                path
+                platforms {
+                    platform_group
+                    platform_url
+                    platform_purview
+                }
+            }
+        }
+    }
 }
 </page-query>
 

--- a/src/pages/community/Devroundtable.vue
+++ b/src/pages/community/Devroundtable.vue
@@ -50,61 +50,61 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/community/devroundtable/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/community/devroundtable/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
-  footer: insert(path: "/insert:/community/devroundtable/footer/") {
-    id
-    title
-    content
-  }
-  upcoming: allArticle(
-      sortBy: "date", order: ASC, filter: {
-        category: {eq: "events"}, tags: {contains: "devroundtable"}, draft: {ne: true},
-        has_date: {eq: true}, days_ago: {lte: 0}
-      }
+    footer: insert(path: "/insert:/community/devroundtable/footer/") {
+        id
+        title
+        content
+    }
+    upcoming: allArticle(
+        sortBy: "date", order: ASC, filter: {
+            category: {eq: "events"}, tags: {contains: "devroundtable"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {lte: 0}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
-  recent: allArticle(
-      sortBy: "date", order: DESC, filter: {
-        category: {eq: "events"}, tags: {contains: "devroundtable"}, draft: {ne: true},
-        has_date: {eq: true}, days_ago: {gte: 1}
-      }
+    recent: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, tags: {contains: "devroundtable"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {gte: 1}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
 }
 fragment articleFields on Article {
-  id
-  title
-  tease
-  location
-  location_url
-  continent
-  contact
-  external_url
-  gtn
-  links {
-    text
-    url
-  }
-  date (format: "D MMMM YYYY")
-  path
+    id
+    title
+    tease
+    location
+    location_url
+    continent
+    contact
+    external_url
+    gtn
+    links {
+        text
+        url
+    }
+    date (format: "D MMMM YYYY")
+    path
 }
 </page-query>

--- a/src/pages/community/Devroundtable.vue
+++ b/src/pages/community/Devroundtable.vue
@@ -72,21 +72,7 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
@@ -99,23 +85,26 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
+}
+fragment articleFields on Article {
+  id
+  title
+  tease
+  location
+  location_url
+  continent
+  contact
+  external_url
+  gtn
+  links {
+    text
+    url
+  }
+  date (format: "D MMMM YYYY")
+  path
 }
 </page-query>

--- a/src/pages/events/Archive.vue
+++ b/src/pages/events/Archive.vue
@@ -37,44 +37,44 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/events/archive/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
-    }
-  }
-  footer: insert(path: "/insert:/events/archive/footer/") {
-    id
-    title
-    content
-  }
-  events: allArticle(
-      sortBy: "date", order: DESC, filter: {
-        category: {eq: "events"}, has_date: {eq: true}, days_ago: {gt: 364}, draft: {ne: true}
-      }
-    ) {
-    totalCount
-    edges {
-      node {
+    main: insert(path: "/insert:/events/archive/main/") {
         id
         title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
+        content
+        fileInfo {
+            path
         }
-        date (format: "D MMMM YYYY")
-        path
-      }
     }
-  }
+    footer: insert(path: "/insert:/events/archive/footer/") {
+        id
+        title
+        content
+    }
+    events: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, has_date: {eq: true}, days_ago: {gt: 364}, draft: {ne: true}
+        }
+    ) {
+        totalCount
+        edges {
+            node {
+                id
+                title
+                tease
+                location
+                location_url
+                continent
+                contact
+                external_url
+                gtn
+                links {
+                    text
+                    url
+                }
+                date (format: "D MMMM YYYY")
+                path
+            }
+        }
+    }
 }
 </page-query>

--- a/src/pages/events/Cofests.vue
+++ b/src/pages/events/Cofests.vue
@@ -51,61 +51,61 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/events/cofests/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/events/cofests/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
-  footer: insert(path: "/insert:/events/cofests/footer/") {
-    id
-    title
-    content
-  }
-  upcoming: allArticle(
-      sortBy: "date", order: ASC, filter: {
-        category: {eq: "events"}, tags: {contains: "cofest"}, draft: {ne: true},
-        has_date: {eq: true}, days_ago: {lte: 0}
-      }
+    footer: insert(path: "/insert:/events/cofests/footer/") {
+        id
+        title
+        content
+    }
+    upcoming: allArticle(
+        sortBy: "date", order: ASC, filter: {
+            category: {eq: "events"}, tags: {contains: "cofest"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {lte: 0}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
-  recent: allArticle(
-      sortBy: "date", order: DESC, filter: {
-        category: {eq: "events"}, tags: {contains: "cofest"}, draft: {ne: true},
-        has_date: {eq: true}, days_ago: {between: [1, 365]}
-      }
+    recent: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, tags: {contains: "cofest"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {between: [1, 365]}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
 }
 fragment articleFields on Article {
-  id
-  title
-  tease
-  location
-  location_url
-  continent
-  contact
-  external_url
-  gtn
-  links {
-    text
-    url
-  }
-  date (format: "D MMMM YYYY")
-  path
+    id
+    title
+    tease
+    location
+    location_url
+    continent
+    contact
+    external_url
+    gtn
+    links {
+        text
+        url
+    }
+    date (format: "D MMMM YYYY")
+    path
 }
 </page-query>

--- a/src/pages/events/Cofests.vue
+++ b/src/pages/events/Cofests.vue
@@ -73,21 +73,7 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
@@ -100,23 +86,26 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
+}
+fragment articleFields on Article {
+  id
+  title
+  tease
+  location
+  location_url
+  continent
+  contact
+  external_url
+  gtn
+  links {
+    text
+    url
+  }
+  date (format: "D MMMM YYYY")
+  path
 }
 </page-query>

--- a/src/pages/events/Webinars.vue
+++ b/src/pages/events/Webinars.vue
@@ -51,61 +51,61 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/events/webinars/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/events/webinars/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
-  footer: insert(path: "/insert:/events/webinars/footer/") {
-    id
-    title
-    content
-  }
-  upcoming: allArticle(
-      sortBy: "date", order: ASC, filter: {
-        category: {eq: "events"}, tags: {contains: "webinar"}, draft: {ne: true},
-        has_date: {eq: true}, days_ago: {lte: 0}
-      }
+    footer: insert(path: "/insert:/events/webinars/footer/") {
+        id
+        title
+        content
+    }
+    upcoming: allArticle(
+        sortBy: "date", order: ASC, filter: {
+            category: {eq: "events"}, tags: {contains: "webinar"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {lte: 0}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
-  recent: allArticle(
-      sortBy: "date", order: DESC, filter: {
-        category: {eq: "events"}, tags: {contains: "webinar"},
-        has_date: {eq: true}, days_ago: {between: [1, 365]}
-      }
+    recent: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, tags: {contains: "webinar"},
+            has_date: {eq: true}, days_ago: {between: [1, 365]}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
 }
 fragment articleFields on Article {
-  id
-  title
-  tease
-  location
-  location_url
-  continent
-  contact
-  external_url
-  gtn
-  links {
-    text
-    url
-  }
-  date (format: "D MMMM YYYY")
-  path
+    id
+    title
+    tease
+    location
+    location_url
+    continent
+    contact
+    external_url
+    gtn
+    links {
+        text
+        url
+    }
+    date (format: "D MMMM YYYY")
+    path
 }
 </page-query>

--- a/src/pages/events/Webinars.vue
+++ b/src/pages/events/Webinars.vue
@@ -73,21 +73,7 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
@@ -100,23 +86,26 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
+}
+fragment articleFields on Article {
+  id
+  title
+  tease
+  location
+  location_url
+  continent
+  contact
+  external_url
+  gtn
+  links {
+    text
+    url
+  }
+  date (format: "D MMMM YYYY")
+  path
 }
 </page-query>

--- a/src/pages/events/cofests/Papercuts.vue
+++ b/src/pages/events/cofests/Papercuts.vue
@@ -51,61 +51,61 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/events/cofests/papercuts/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/events/cofests/papercuts/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
-  footer: insert(path: "/insert:/events/cofests/papercuts/footer/") {
-    id
-    title
-    content
-  }
-  upcoming: allArticle(
-      sortBy: "date", order: ASC, filter: {
-        category: {eq: "events"}, tags: {contains: "papercuts"}, draft: {ne: true},
-        has_date: {eq: true}, days_ago: {lte: 0}
-      }
+    footer: insert(path: "/insert:/events/cofests/papercuts/footer/") {
+        id
+        title
+        content
+    }
+    upcoming: allArticle(
+        sortBy: "date", order: ASC, filter: {
+            category: {eq: "events"}, tags: {contains: "papercuts"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {lte: 0}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
-  recent: allArticle(
-      sortBy: "date", order: DESC, filter: {
-        category: {eq: "events"}, tags: {contains: "papercuts"}, draft: {ne: true},
-        has_date: {eq: true}, days_ago: {between: [1, 365]}
-      }
+    recent: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, tags: {contains: "papercuts"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {between: [1, 365]}
+        }
     ) {
-    totalCount
-    edges {
-      node {
-        ...articleFields
-      }
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
     }
-  }
 }
 fragment articleFields on Article {
-  id
-  title
-  tease
-  location
-  location_url
-  continent
-  contact
-  external_url
-  gtn
-  links {
-    text
-    url
-  }
-  date (format: "D MMMM YYYY")
-  path
+    id
+    title
+    tease
+    location
+    location_url
+    continent
+    contact
+    external_url
+    gtn
+    links {
+        text
+        url
+    }
+    date (format: "D MMMM YYYY")
+    path
 }
 </page-query>

--- a/src/pages/events/cofests/Papercuts.vue
+++ b/src/pages/events/cofests/Papercuts.vue
@@ -73,21 +73,7 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
@@ -100,23 +86,26 @@ query {
     totalCount
     edges {
       node {
-        id
-        title
-        tease
-        location
-        location_url
-        continent
-        contact
-        external_url
-        gtn
-        links {
-          text
-          url
-        }
-        date (format: "D MMMM YYYY")
-        path
+        ...articleFields
       }
     }
   }
+}
+fragment articleFields on Article {
+  id
+  title
+  tease
+  location
+  location_url
+  continent
+  contact
+  external_url
+  gtn
+  links {
+    text
+    url
+  }
+  date (format: "D MMMM YYYY")
+  path
 }
 </page-query>

--- a/src/pages/usegalaxy/Welcome.vue
+++ b/src/pages/usegalaxy/Welcome.vue
@@ -16,14 +16,14 @@ export default {
 
 <page-query>
 query {
-  main: insert(path: "/insert:/usegalaxy/welcome/main/") {
-    id
-    title
-    content
-    fileInfo {
-      path
+    main: insert(path: "/insert:/usegalaxy/welcome/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
     }
-  }
 }
 </page-query>
 

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -7,36 +7,37 @@
 </template>
 
 <page-query>
-query Article ($path: String!) {
-   article: article (path: $path) {
-    id
-    title
-    tease
-    category
-    date (format: "YYYY-MM-DD")
-    end (format: "YYYY-MM-DD")
-    contact
-    contact_url
-    authors
-    location
-    location_url
-    source_blog
-    source_blog_url
-    skip_title_render
-    redirect
-    external_url
-    autotoc
-    links {
-      url
-      text
+query Article($path: String!) {
+    article: article(path: $path) {
+        id
+        title
+        tease
+        subsites
+        category
+        date (format: "YYYY-MM-DD")
+        end (format: "YYYY-MM-DD")
+        contact
+        contact_url
+        authors
+        location
+        location_url
+        source_blog
+        source_blog_url
+        skip_title_render
+        redirect
+        external_url
+        autotoc
+        links {
+            url
+            text
+        }
+        image
+        images
+        fileInfo {
+            path
+        }
+        content
     }
-    image
-    images
-    fileInfo {
-        path
-    }
-    content
-  }
 }
 </page-query>
 

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -12,7 +12,6 @@ query Article($path: String!) {
         id
         title
         tease
-        subsites
         category
         date (format: "YYYY-MM-DD")
         end (format: "YYYY-MM-DD")

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -50,29 +50,29 @@
 
 <page-query>
 query Platform($path: String!) {
-   platform(path: $path) {
-    id
-    title
-    url
-    image
-    images
-    platforms {
-      platform_group
-      platform_url
-      platform_text
+    platform(path: $path) {
+        id
+        title
+        url
+        image
+        images
+        platforms {
+            platform_group
+            platform_url
+            platform_text
+        }
+        scope
+        summary
+        comments
+        user_support
+        pub_libraries
+        quotas
+        citations
+        sponsors
+        fileInfo {
+            path
+        }
     }
-    scope
-    summary
-    comments
-    user_support
-    pub_libraries
-    quotas
-    citations
-    sponsors
-    fileInfo {
-        path
-    }
-  }
 }
 </page-query>
 

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -20,39 +20,40 @@
 
 <page-query>
 query VueArticle($path: String!) {
-   article: vueArticle(path: $path) {
-    id
-    title
-    tease
-    category
-    date (format: "YYYY-MM-DD")
-    end (format: "YYYY-MM-DD")
-    contact
-    contact_url
-    authors
-    location
-    location_url
-    source_blog
-    source_blog_url
-    skip_title_render
-    redirect
-    external_url
-    autotoc
-    links {
-      url
-      text
+    article: vueArticle(path: $path) {
+        id
+        title
+        tease
+        subsites
+        category
+        date (format: "YYYY-MM-DD")
+        end (format: "YYYY-MM-DD")
+        contact
+        contact_url
+        authors
+        location
+        location_url
+        source_blog
+        source_blog_url
+        skip_title_render
+        redirect
+        external_url
+        autotoc
+        links {
+            url
+            text
+        }
+        image
+        images
+        fileInfo {
+            path
+        }
+        inserts {
+            name
+            content
+        }
+        content
     }
-    image
-    images
-    fileInfo {
-        path
-    }
-    inserts {
-      name
-      content
-    }
-    content
-  }
 }
 </page-query>
 

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -24,7 +24,6 @@ query VueArticle($path: String!) {
         id
         title
         tease
-        subsites
         category
         date (format: "YYYY-MM-DD")
         end (format: "YYYY-MM-DD")


### PR DESCRIPTION
Use [fragments](https://graphql.org/learn/queries/#fragments) to reduce duplicated GraphQL query code.

This also finally fixes GraphQL code indentation (to 4 spaces).