### PR TITLE
Fix typo in title of /tutorials/ngs/

### DIFF
--- a/content/tutorials/ngs/index.md
+++ b/content/tutorials/ngs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Manupulating NGS data with Galaxy
+title: Manipulating NGS data with Galaxy
 redirect: "/learn"
 ---
 


### PR DESCRIPTION
I know this page is deprecated but it's still in the top 10 most visited pages. And it's the 3rd result when you Google "galaxy sanger". It'd be nice if the first thing users see isn't a misspelled title.