### PR TITLE
Change get started button to Get Started: First Steps with Galaxy

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -8,7 +8,9 @@
             <section class="col-sm-5" v-if="$page.jumbotron && $page.jumbotron.content.trim()">
                 <div class="lead markdown" v-html="$page.main.content" />
                 <b-row id="get-started-button" class="justify-content-center">
-                    <b-button class="w-75" size="lg" variant="primary" href="/get-started/"> Get Started: First Steps with Galaxy </b-button>
+                    <b-button class="w-75" size="lg" variant="primary" href="/get-started/">
+                        Get Started: First Steps with Galaxy
+                    </b-button>
                 </b-row>
             </section>
             <section class="col-sm-7 jumbotron" v-if="$page.jumbotron && $page.jumbotron.content.trim()">

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -8,7 +8,7 @@
             <section class="col-sm-5" v-if="$page.jumbotron && $page.jumbotron.content.trim()">
                 <div class="lead markdown" v-html="$page.main.content" />
                 <b-row id="get-started-button" class="justify-content-center">
-                    <b-button class="w-75" size="lg" variant="primary" href="/get-started/"> Get Started </b-button>
+                    <b-button class="w-75" size="lg" variant="primary" href="/get-started/"> Get Started: First Steps with Galaxy </b-button>
                 </b-row>
             </section>
             <section class="col-sm-7 jumbotron" v-if="$page.jumbotron && $page.jumbotron.content.trim()">


### PR DESCRIPTION
Proposed change for Get Started button to make it clearer for newcomers where to go. Get Started could be understood as a instalation guide or "setting up your own galaxy instance" kind of guide.

![image](https://user-images.githubusercontent.com/92181987/158712482-67f8d7c2-1c72-414a-82f4-7ef1157724f0.png)

@NickSto what do you think?