### PR TITLE
Add some basic infrastructure for subsites.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "host": "galaxyproject.org",
     "contentDir": "content",
+    "subsites": ["us", "eu"],
     "collections": {
         "Platform": "/use/"
     },

--- a/content/0examples/non-vue/index.md
+++ b/content/0examples/non-vue/index.md
@@ -25,6 +25,7 @@ links:
 - text: "Video"
   url: "https://youtu.be/bQFv4EVunWw"
 redirect: "/"
+subsites: [eu, us]
 ---
 
 This also serves to provide a page with all the metadata fields present. If you have a dynamic page with a GraphQL query for a metadata field, there must be at least one page with that field present. Otherwise Gridsome throws an error.

--- a/content/0examples/vue-remark/index.md
+++ b/content/0examples/vue-remark/index.md
@@ -25,6 +25,7 @@ links:
 - text: "Video"
   url: "https://youtu.be/bQFv4EVunWw"
 redirect: /somewhere/else/
+subsites: [global]
 components: true
 ---
 

--- a/content/eu/events/main.md
+++ b/content/eu/events/main.md
@@ -1,0 +1,29 @@
+---
+title: Galaxy Europe Event Horizon
+layout: events_index.pug
+---
+
+<img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
+
+Upcoming (and past) events with Galaxy-related content. For events prior to this year, see the [events archive](/events/archive/).
+
+### Calendars
+
+- [__Galaxy Events Google Calendar__](https://bit.ly/gxycal), in which you'll find the events listed here. 
+- [__Galaxy Other Events Google Calendar__](https://bit.ly/gxyothercal), that lists additional events that are relevant to the Galaxy Community, but that are not known to feature significant Galaxy content.
+
+### Series
+
+Some events are part of a series:
+
+* [Galaxy Webinar Series](/events/webinars/)
+* [Galaxy Developer Round Table meetups](/community/devroundtable/)
+* [CollaborationFests](/events/cofests/) and [Papercuts CoFests](/events/cofests/papercuts/)
+
+### Advertise your event!
+
+If you know of any event that should be added to this page and/or to the Galaxy
+Event Calendar, please add it to the [GitHub repository](https://github.com/galaxyproject/galaxy-hub) or submit it through this [form](https://docs.google.com/forms/d/e/1FAIpQLSfhuvJ8koTrqUwU27BB269KRCIVutBDN7DrwUBd7WVTmFOB2w/viewform).
+
+<div class='center'>
+</div>

--- a/content/us/events/gcc2013/linktest.json
+++ b/content/us/events/gcc2013/linktest.json
@@ -1,9 +1,0 @@
-{
-    "horizontal": true,
-    "links": [
-        {"title":"GCC2013", "url":"/events/gcc2013/", "bold":true},
-        {"title":"Program", "url":"/events/gcc2013/program/"},
-        {"title":"Training", "url":"/events/gcc2013/training-day/"},
-        {"title":"BoFs", "url":"/events/gcc2013/bof/"}
-    ]
-}

--- a/content/us/events/gcc2013/linktest.json
+++ b/content/us/events/gcc2013/linktest.json
@@ -1,0 +1,9 @@
+{
+    "horizontal": true,
+    "links": [
+        {"title":"GCC2013", "url":"/events/gcc2013/", "bold":true},
+        {"title":"Program", "url":"/events/gcc2013/program/"},
+        {"title":"Training", "url":"/events/gcc2013/training-day/"},
+        {"title":"BoFs", "url":"/events/gcc2013/bof/"}
+    ]
+}

--- a/content/us/events/main.md
+++ b/content/us/events/main.md
@@ -1,0 +1,29 @@
+---
+title: Galaxy US Event Horizon
+layout: events_index.pug
+---
+
+<img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
+
+Upcoming (and past) events with Galaxy-related content. For events prior to this year, see the [events archive](/events/archive/).
+
+### Calendars
+
+- [__Galaxy Events Google Calendar__](https://bit.ly/gxycal), in which you'll find the events listed here. 
+- [__Galaxy Other Events Google Calendar__](https://bit.ly/gxyothercal), that lists additional events that are relevant to the Galaxy Community, but that are not known to feature significant Galaxy content.
+
+### Series
+
+Some events are part of a series:
+
+* [Galaxy Webinar Series](/events/webinars/)
+* [Galaxy Developer Round Table meetups](/community/devroundtable/)
+* [CollaborationFests](/events/cofests/) and [Papercuts CoFests](/events/cofests/papercuts/)
+
+### Advertise your event!
+
+If you know of any event that should be added to this page and/or to the Galaxy
+Event Calendar, please add it to the [GitHub repository](https://github.com/galaxyproject/galaxy-hub) or submit it through this [form](https://docs.google.com/forms/d/e/1FAIpQLSfhuvJ8koTrqUwU27BB269KRCIVutBDN7DrwUBd7WVTmFOB2w/viewform).
+
+<div class='center'>
+</div>

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -219,6 +219,7 @@ module.exports = function (api) {
          */
         actions.addSchemaTypes(`
             type Article implements Node @infer {
+                subsites: [String]
                 category: String
                 has_date: Boolean
                 end: Date

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -96,6 +96,18 @@ footer {
 // Masthead
 
 // ==== Masthead ====
+.global #masthead {
+    background-color: $brand-masthead;
+}
+
+.us #masthead {
+    background-color: #4e7152;
+}
+
+.eu #masthead {
+    background-color: #71684e;
+}
+
 #masthead {
     background-color: $brand-masthead;
     .navbar-nav {

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="layout">
+    <div :class="`layout ${subsite}`">
         <header id="masthead">
             <NavBar />
         </header>
@@ -17,6 +17,9 @@ import NavBar from "@/components/NavBar";
 export default {
     components: {
         NavBar,
+    },
+    props: {
+        subsite: { type: String, required: false, default: "global" },
     },
     mounted() {
         // Google Analytics tag.

--- a/src/pages/eu/Events.vue
+++ b/src/pages/eu/Events.vue
@@ -1,0 +1,125 @@
+<template>
+    <Layout subsite="eu">
+        <h1 class="page-title">{{ $page.main.title }}</h1>
+        <div class="toc-wrapper col-md-3">
+            <ul>
+                <li><a href="#upcoming-events">Upcoming Events</a></li>
+                <li><a href="#recent-events">Recent Events</a></li>
+            </ul>
+        </div>
+        <div class="body-wrapper col-md-9">
+            <div class="content markdown" v-html="$page.main.content" />
+        </div>
+        <h2 id="upcoming-events">
+            <a href="#upcoming-events" aria-hidden="true"><span class="icon icon-link"></span></a>
+            Upcoming Events
+        </h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Topic/Event</th>
+                    <th>Venue/Location</th>
+                    <th>Contact</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ArticleTableEvents v-for="edge in $page.upcoming.edges" :key="edge.node.id" :article="edge.node" />
+            </tbody>
+        </table>
+        <h2 id="recent-events">
+            <a href="#recent-events" aria-hidden="true"><span class="icon icon-link"></span></a>
+            Recent Events
+        </h2>
+        <p>Events in the past 12 months:</p>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Topic/Event</th>
+                    <th>Venue/Location</th>
+                    <th>Contact</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ArticleTableEvents v-for="edge in $page.recent.edges" :key="edge.node.id" :article="edge.node" />
+            </tbody>
+        </table>
+        <footer class="page-footer markdown" v-if="$page.footer" v-html="$page.footer.content" />
+    </Layout>
+</template>
+
+<script>
+import ArticleTableEvents from "@/components/ArticleTableEvents";
+export default {
+    components: {
+        ArticleTableEvents,
+    },
+    metaInfo() {
+        return {
+            title: this.$page.main.title,
+        };
+    },
+};
+</script>
+
+<page-query>
+query {
+    main: insert(path: "/insert:/eu/events/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
+    }
+    footer: insert(path: "/insert:/eu/events/footer/") {
+        id
+        title
+        content
+    }
+    upcoming: allArticle(
+        sortBy: "date", order: ASC, filter: {
+            category: {eq: "events"}, subsites: {contains: "eu"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {lte: 0}
+        }
+    ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
+    }
+    recent: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, subsites: {contains: "eu"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {between: [1, 365]}
+        }
+        ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
+    }
+}
+fragment articleFields on Article {
+    id
+    title
+    tease
+    location
+    location_url
+    continent
+    contact
+    external_url
+    gtn
+    links {
+        text
+        url
+    }
+    date (format: "D MMMM YYYY")
+    path
+}
+</page-query>

--- a/src/pages/us/Events.vue
+++ b/src/pages/us/Events.vue
@@ -1,0 +1,125 @@
+<template>
+    <Layout subsite="us">
+        <h1 class="page-title">{{ $page.main.title }}</h1>
+        <div class="toc-wrapper col-md-3">
+            <ul>
+                <li><a href="#upcoming-events">Upcoming Events</a></li>
+                <li><a href="#recent-events">Recent Events</a></li>
+            </ul>
+        </div>
+        <div class="body-wrapper col-md-9">
+            <div class="content markdown" v-html="$page.main.content" />
+        </div>
+        <h2 id="upcoming-events">
+            <a href="#upcoming-events" aria-hidden="true"><span class="icon icon-link"></span></a>
+            Upcoming Events
+        </h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Topic/Event</th>
+                    <th>Venue/Location</th>
+                    <th>Contact</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ArticleTableEvents v-for="edge in $page.upcoming.edges" :key="edge.node.id" :article="edge.node" />
+            </tbody>
+        </table>
+        <h2 id="recent-events">
+            <a href="#recent-events" aria-hidden="true"><span class="icon icon-link"></span></a>
+            Recent Events
+        </h2>
+        <p>Events in the past 12 months:</p>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Topic/Event</th>
+                    <th>Venue/Location</th>
+                    <th>Contact</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ArticleTableEvents v-for="edge in $page.recent.edges" :key="edge.node.id" :article="edge.node" />
+            </tbody>
+        </table>
+        <footer class="page-footer markdown" v-if="$page.footer" v-html="$page.footer.content" />
+    </Layout>
+</template>
+
+<script>
+import ArticleTableEvents from "@/components/ArticleTableEvents";
+export default {
+    components: {
+        ArticleTableEvents,
+    },
+    metaInfo() {
+        return {
+            title: this.$page.main.title,
+        };
+    },
+};
+</script>
+
+<page-query>
+query {
+    main: insert(path: "/insert:/us/events/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
+    }
+    footer: insert(path: "/insert:/us/events/footer/") {
+        id
+        title
+        content
+    }
+    upcoming: allArticle(
+        sortBy: "date", order: ASC, filter: {
+            category: {eq: "events"}, subsites: {contains: "us"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {lte: 0}
+        }
+    ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
+    }
+    recent: allArticle(
+        sortBy: "date", order: DESC, filter: {
+            category: {eq: "events"}, subsites: {contains: "us"}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {between: [1, 365]}
+        }
+    ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
+    }
+}
+fragment articleFields on Article {
+    id
+    title
+    tease
+    location
+    location_url
+    continent
+    contact
+    external_url
+    gtn
+    links {
+        text
+        url
+    }
+    date (format: "D MMMM YYYY")
+    path
+}
+</page-query>

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout>
+    <Layout :subsite="subsite">
         <ArticleHeader :article="$page.article" />
         <div :class="['content', 'markdown', ...mdClasses]" v-html="$page.article.content" />
         <ArticleFooter :article="$page.article" />
@@ -12,6 +12,7 @@ query Article($path: String!) {
         id
         title
         tease
+        subsites
         category
         date (format: "YYYY-MM-DD")
         end (format: "YYYY-MM-DD")
@@ -35,6 +36,7 @@ query Article($path: String!) {
         fileInfo {
             path
         }
+        path
         content
     }
 }
@@ -43,6 +45,7 @@ query Article($path: String!) {
 <script>
 import ArticleHeader from "@/components/ArticleHeader";
 import ArticleFooter from "@/components/ArticleFooter";
+import { subsiteFromPath } from "~/utils.js";
 export default {
     components: {
         ArticleHeader,
@@ -58,6 +61,9 @@ export default {
             }
             return classes;
         },
+        subsite() {
+            return subsiteFromPath(this.$page.article.path);
+        }
     },
 };
 </script>

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -63,7 +63,7 @@ export default {
         },
         subsite() {
             return subsiteFromPath(this.$page.article.path);
-        }
+        },
     },
 };
 </script>

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout>
+    <Layout subsite="global">
         <g-link to="/use/" class="link"> &larr; Platform Directory</g-link>
         <header>
             <h1 class="pageTitle">{{ $page.platform.title }}</h1>

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout>
+    <Layout :subsite="subsite">
         <ArticleHeader :article="$page.article" />
         <article :class="['content', 'markdown', ...mdClasses]">
             <VueRemarkContent>
@@ -24,6 +24,7 @@ query VueArticle($path: String!) {
         id
         title
         tease
+        subsites
         category
         date (format: "YYYY-MM-DD")
         end (format: "YYYY-MM-DD")
@@ -47,6 +48,7 @@ query VueArticle($path: String!) {
         fileInfo {
             path
         }
+        path
         inserts {
             name
             content
@@ -59,6 +61,7 @@ query VueArticle($path: String!) {
 <script>
 import ArticleHeader from "@/components/ArticleHeader";
 import ArticleFooter from "@/components/ArticleFooter";
+import { subsiteFromPath } from "~/utils.js";
 export default {
     components: {
         ArticleHeader,
@@ -74,6 +77,9 @@ export default {
             }
             return classes;
         },
+        subsite() {
+            return subsiteFromPath(this.$page.article.path);
+        }
     },
 };
 </script>

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -79,7 +79,7 @@ export default {
         },
         subsite() {
             return subsiteFromPath(this.$page.article.path);
-        }
+        },
     },
 };
 </script>

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,6 +117,17 @@ function getImage(imagePath, images) {
 }
 module.exports.getImage = getImage;
 
+function subsiteFromPath(path) {
+    let pathParts = path.split("/");
+    for (let candidate of CONFIG.subsites) {
+        if (pathParts[0] === candidate || (pathParts[0] === "" && pathParts[1] === candidate)) {
+            return candidate;
+        }
+    }
+    return "global";
+}
+module.exports.subsiteFromPath = subsiteFromPath;
+
 function mdToHtml(md) {
     //TODO: Fix links (E.g. `/src/main/index.md` -> `/main/`)
     let rawHtml;


### PR DESCRIPTION
This adds the barebones start of the subsites feature for the Hub unification effort.

It adds a `subsites` metadata key, the `us` and `eu` subsites, events pages for both, and a method for customizing the styling of pages in different subsites.

With this merged, we'll already be able to mark events with different subsites and they'll appear on the proper events listings.