### PR TITLE
Start categorizing posts by subsite

### DIFF
--- a/content/events/2021-11-gi/index.md
+++ b/content/events/2021-11-gi/index.md
@@ -10,4 +10,5 @@ external_url: "https://meetings.cshl.edu/abstracts.aspx?meet=info&year=21"
 gtn: false
 contact: "Delphine Larivière"
 image: 
+subsites: [us]
 ---

--- a/content/events/2022-03-genome-assembly/index.md
+++ b/content/events/2022-03-genome-assembly/index.md
@@ -12,4 +12,5 @@ contact: "Bioinformatics Resource Center, Rockefeller University (brc@rockefelle
 tags: []
 links:
 image: ""
+subsites: [us, eu]
 ---

--- a/content/events/2022-03-microbial/index.md
+++ b/content/events/2022-03-microbial/index.md
@@ -10,4 +10,5 @@ external_url: "https://www.earlham.ac.uk/microbial-community-analysis-workshop-2
 gtn: true
 contact: "Falk Hildebrand"
 image: 
+subsites: [eu]
 ---

--- a/content/news/2021-08-elixir-update/index.md
+++ b/content/news/2021-08-elixir-update/index.md
@@ -3,4 +3,5 @@ title: "Updates from the ELIXIR Galaxy Community"
 tease: "An updated ELIXIR Galaxy website includes our goals, with a special emphasis on interactions with the local, domain-specific and global communities; plus much more"
 external_url: "https://galaxyproject.eu/posts/2021/08/24/new-elixir-galaxy-community-website/"
 date: "2021-08-24"
+subsites: [us]
 ---

--- a/content/news/2021-10-bycovid/index.md
+++ b/content/news/2021-10-bycovid/index.md
@@ -3,4 +3,5 @@ title: "BY-COVID: A new EU project for pandemic preparedness"
 tease: "A new €12 million Horizon Europe funded project which will tackle the data challenges that can hinder effective pandemic response."
 external_url: "https://galaxyproject.eu/posts/2021/10/13/bycovid-kickoff/"
 date: "2021-10-13"
+subsites: [eu]
 ---

--- a/content/news/2021-11-omicron/index.md
+++ b/content/news/2021-11-omicron/index.md
@@ -3,4 +3,5 @@ title: "Omicron and SARS-CoV-2 genome surveillance"
 tease: "A first view of the Omicron lineage’s mutational pattern derived transparently and fully reproducibly from raw sequencing reads"
 external_url: "https://galaxyproject.eu/posts/2021/11/29/omicron-and-galaxy/"
 date: "2021-11-29"
+subsites: [eu]
 ---

--- a/src/pages/eu/Events.vue
+++ b/src/pages/eu/Events.vue
@@ -96,7 +96,7 @@ query {
             category: {eq: "events"}, subsites: {contains: "eu"}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {between: [1, 365]}
         }
-        ) {
+    ) {
         totalCount
         edges {
             node {


### PR DESCRIPTION
I thought I'd start tagging some events and news posts as `eu` or `us`, both to give the subsites logic some example data to work with and to start the discussion on what sorts of posts we want to categorize into specific subsites.

It was tricky to find clear examples of a "US" or "EU" post, since most events and news posts are trying for global reach. I don't particularly care if everything ends up being listed as global, so that's okay. From what I understand, the idea of making subsites in the first place was to allow us to have one, unified Hub while still letting people from different sites manage their own posts and content if they'd like. So we'll still maintain that option even if everything is global at first.

Also, a note: the posts I tagged as `eu` are basically duplicates also found on the current .eu Hub. When we eventually merge their content in, we'll remove these duplicates. And as a consequence, instead of the generic `eu` subsite, these events will maintain whatever list of EU-specific sites they currently have (`freiburg`, `pasteur`, etc).