### PR TITLE
Covid project: Remove client build instructions

### DIFF
--- a/content/projects/covid19/index.md
+++ b/content/projects/covid19/index.md
@@ -75,8 +75,6 @@ Many lineage defining sites have been present in SARS-CoV-2 genomes at below-con
 <vega-embed spec="https://raw.githubusercontent.com/galaxyproject/SARS-CoV-2/master/data/ipynb/graphs/voc_time_progression_S_NS.json"/>
 </div>
 
-<markdown-embed href="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/client/README.md" />
-
 
 -----
 


### PR DESCRIPTION
Guess that embedded markdown was just an accident.