### PR TITLE
Allow hierarchical subsites

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,18 @@
 {
     "host": "galaxyproject.org",
     "contentDir": "content",
-    "subsites": ["us", "eu"],
+    "subsites": {
+        "us": {},
+        "eu": {
+            "freiburg": {},
+            "pasteur": {},
+            "belgium": {},
+            "ifb": {},
+            "genouest": {},
+            "erasmusmc": {},
+            "elixir-it": {}
+        }
+    },
     "collections": {
         "Platform": "/use/"
     },

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -61,13 +61,13 @@ function mkPlugins(collections) {
             },
         },
     ];
+    let articlePlugin = getPlugin(plugins, "Article");
+    let vueArticlePlugin = getPlugin(plugins, "VueArticle");
     for (let [name, urlPath] of Object.entries(collections)) {
         let dirPath = nodePath.join(MD_CONTENT_DIR, urlPath);
         let globPath = nodePath.join(dirPath, "*/index.md");
-        let articlePlugin = getPlugin(plugins, "Article");
         articlePlugin.options.path.push("!" + globPath);
         let bareUrlPath = rmPrefix(rmSuffix(urlPath, "/"), "/");
-        let vueArticlePlugin = getPlugin(plugins, "VueArticle");
         vueArticlePlugin.options.ignore.push(bareUrlPath);
         //TODO: Allow custom collections to use vue-remark.
         let plugin = {

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -210,23 +210,34 @@ class nodeModifier {
 module.exports = function (api) {
     api.loadSource((actions) => {
         // Using the Data Store API: https://gridsome.org/docs/data-store-api/
-        // Add derived `category` field.
+        // Add derived fields like `category`.
         /*TODO: Replace this and the later api.onCreateNode() call with this technique instead:
          *      https://gridsome.org/docs/schema-api/#add-a-new-field-with-a-custom-resolver
          *      This currently causes problems because a bug prevents you from filtering based on fields
          *      added this way: https://github.com/gridsome/gridsome/issues/1196
          *      This is supposed to be fixed by Gridsome 1.0.
          */
-        actions.addSchemaTypes(`
-            type Article implements Node @infer {
-                subsites: [String]
-                category: String
-                has_date: Boolean
-                end: Date
-                days_ago: Int
-                closed: Boolean
-            }`);
-        let collections = ["Article", "VueArticle"].concat(Object.keys(CONFIG["collections"]));
+        const articleTypes = ["Article", "VueArticle"];
+        for (let type of articleTypes) {
+            actions.addSchemaTypes(
+                actions.schema.createObjectType(
+                    {
+                        name: type,
+                        interfaces: ["Node"],
+                        extensions: {infer: true},
+                        fields: {
+                            subsites: "[String]",
+                            category: "String",
+                            has_date: "Boolean",
+                            end: "Date",
+                            days_ago: "Int",
+                            closed: "Boolean",
+                        }
+                    }
+                )
+            );
+        }
+        let collections = articleTypes.concat(Object.keys(CONFIG["collections"]));
         let schemas = {};
         for (let collection of collections) {
             schemas[collection] = {

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -220,21 +220,19 @@ module.exports = function (api) {
         const articleTypes = ["Article", "VueArticle"];
         for (let type of articleTypes) {
             actions.addSchemaTypes(
-                actions.schema.createObjectType(
-                    {
-                        name: type,
-                        interfaces: ["Node"],
-                        extensions: {infer: true},
-                        fields: {
-                            subsites: "[String]",
-                            category: "String",
-                            has_date: "Boolean",
-                            end: "Date",
-                            days_ago: "Int",
-                            closed: "Boolean",
-                        }
-                    }
-                )
+                actions.schema.createObjectType({
+                    name: type,
+                    interfaces: ["Node"],
+                    extensions: { infer: true },
+                    fields: {
+                        subsites: "[String]",
+                        category: "String",
+                        has_date: "Boolean",
+                        end: "Date",
+                        days_ago: "Int",
+                        closed: "Boolean",
+                    },
+                })
             );
         }
         let collections = articleTypes.concat(Object.keys(CONFIG["collections"]));

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout :subsite="subsite">
+    <Layout :subsite="$page.article.main_subsite">
         <ArticleHeader :article="$page.article" />
         <div :class="['content', 'markdown', ...mdClasses]" v-html="$page.article.content" />
         <ArticleFooter :article="$page.article" />
@@ -13,6 +13,7 @@ query Article($path: String!) {
         title
         tease
         subsites
+        main_subsite
         category
         date (format: "YYYY-MM-DD")
         end (format: "YYYY-MM-DD")
@@ -45,7 +46,6 @@ query Article($path: String!) {
 <script>
 import ArticleHeader from "@/components/ArticleHeader";
 import ArticleFooter from "@/components/ArticleFooter";
-import { subsiteFromPath } from "~/utils.js";
 export default {
     components: {
         ArticleHeader,
@@ -60,9 +60,6 @@ export default {
                 classes.push("notoc");
             }
             return classes;
-        },
-        subsite() {
-            return subsiteFromPath(this.$page.article.path);
         },
     },
 };

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout :subsite="subsite">
+    <Layout :subsite="$page.article.main_subsite">
         <ArticleHeader :article="$page.article" />
         <article :class="['content', 'markdown', ...mdClasses]">
             <VueRemarkContent>
@@ -25,6 +25,7 @@ query VueArticle($path: String!) {
         title
         tease
         subsites
+        main_subsite
         category
         date (format: "YYYY-MM-DD")
         end (format: "YYYY-MM-DD")
@@ -61,7 +62,6 @@ query VueArticle($path: String!) {
 <script>
 import ArticleHeader from "@/components/ArticleHeader";
 import ArticleFooter from "@/components/ArticleFooter";
-import { subsiteFromPath } from "~/utils.js";
 export default {
     components: {
         ArticleHeader,
@@ -76,9 +76,6 @@ export default {
                 classes.push("notoc");
             }
             return classes;
-        },
-        subsite() {
-            return subsiteFromPath(this.$page.article.path);
         },
     },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -125,11 +125,11 @@ module.exports.getImage = getImage;
 function flattenSubsites(subsitesTree) {
     let subsites = [];
     for (let [subsite, subtree] of Object.entries(subsitesTree)) {
-        if (getType(subtree) !== 'Object') {
+        if (getType(subtree) !== "Object") {
             throw repr`Value in subsites config tree not an object: ${subtree}`;
         }
         subsites.push(subsite);
-        subsubsites = flattenSubsites(subtree);
+        let subsubsites = flattenSubsites(subtree);
         subsites = subsites.concat(subsubsites);
     }
     return subsites;
@@ -153,6 +153,14 @@ function getSubsiteAncestry(subsite) {
 }
 module.exports.getSubsiteAncestry = getSubsiteAncestry;
 
+/** Find the `query` in the tree and return a list containing it and its ancestors.
+ * @param {Object} tree  A tree represented as an object where each key is a string and each value
+ *                       is an object of the same format. Leaf nodes are keys whose values are empty
+ *                       objects.
+ * @param {String} query A key to search for in the tree.
+ * @returns {Array} A list of keys ending with `query`, preceded by its parent, and so on, until its
+ *                  top-level ancestor in the tree.
+ */
 function getTreeBranch(tree, query) {
     for (let [key, value] of Object.entries(tree)) {
         if (key === query) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,8 @@ const remarkHtml = require("remark-html");
 const slugify = require("@sindresorhus/slugify");
 const urlParse = require("url-parse");
 const CONFIG = require("../config.json");
+const TO_STRING = {}.toString;
+let SUBSITES_LIST = flattenSubsites(CONFIG.subsites);
 
 /* Using a kludge here to allow:
  * 1) importing this as a module with the `import` statement
@@ -137,14 +139,12 @@ function flattenSubsites(subsitesTree) {
 module.exports.flattenSubsites = flattenSubsites;
 
 function subsiteFromPath(path) {
-    const subsites = flattenSubsites(CONFIG.subsites);
     let pathParts = path.split("/");
-    for (let candidate of subsites) {
+    for (let candidate of SUBSITES_LIST) {
         if (pathParts[0] === candidate || (pathParts[0] === "" && pathParts[1] === candidate)) {
             return candidate;
         }
     }
-    return "global";
 }
 module.exports.subsiteFromPath = subsiteFromPath;
 
@@ -429,7 +429,6 @@ function logTree(root, depth, indent) {
 }
 module.exports.logTree = logTree;
 
-const TO_STRING = {}.toString;
 /** A better alternative to `typeof`.
  * Adapted from https://stackoverflow.com/questions/7390426/better-way-to-get-type-of-a-javascript-variable/7390612#7390612
  * @param {*} value  Any value, including `null` and `undefined`.


### PR DESCRIPTION
So far I've only implemented two top-level subsites: `eu` and `us`.

But the .eu Hub itself has a set of subsites (`freiburg`, `pasteur`, `elixir-it`, etc). And, their main feeds (e.g. [/events](https://galaxyproject.eu/events)) aggregates all the posts from all their subsites.

Since we'd like to support the existing .eu Hub as much as possible, we'd like to preserve this organization but also add on top of it "global" aggregation pages which list all posts under the `us` and `eu` subsites, which might themselves aggregate posts from sub-subsites.

So this lets us define a hierarchy in `config.json` like:
```json
    "subsites": {
        "us": {},
        "eu": {
            "freiburg": {},
            "pasteur": {},
            "belgium": {},
            "ifb": {},
            "genouest": {},
            "erasmusmc": {},
            "elixir-it": {}
        }
    },
```

And during build it inspects the subsites listed by the authors, and if they list a lower level subsite like `genouest`, it will also add its parent subsite (`eu`) to the list. Then the aggregator pages can just query for `eu` and get all those directly tagged `eu`, as well as any tagged with a subsite in the EU.

This also moves the path-based subsite tagging to `gridsome.server.js`, to consolidate all the subsite logic.