### PR TITLE
Fetch pubs from zotero on home instead of manual curation

### DIFF
--- a/content/home/research.yml
+++ b/content/home/research.yml
@@ -1,19 +1,5 @@
 heading: Galactic pulse
 
-research1:
-    title: Recent publications
-    content: "Galaxy can be installed locally, fine-tuned with a tailored toolset and no usage quotas."
-    url: "https://www.zotero.org/groups/1732893/galaxy"
-    links:
-        - title: 'Dantan, L. et al. "Microbial education plays a crucial role in harnessing the beneficial properties of microbiota for infectious disease protection in Crassostrea gigas"  Sci Rep 14, 26914 (2024)'
-          url: "https://doi.org/10.1038/s41598-024-76096-4"
-        - title: 'Yujing Ren et al. "Effects of microplastics on litter decomposition in wetland soil" Environmental Pollution, Volume 343, (2024)'
-          url: "https://doi.org/10.1016/j.envpol.2023.123145"
-        - title: 'Mathieu-Bégné, E et al. "Schistosoma haematobium and Schistosoma bovis first generation hybrids undergo gene expressions changes consistent with species compatibility and heterosis" PLOS Neglected Tropical Diseases (2024)'
-          url: "https://doi.org/10.1371/journal.pntd.0012267"
-        - title: 'Sarmah, P. et al. "The functional and structural characterisation of the bZIP transcription factors from Myristica fragrans Houtt. associated to plant disease-resistant defence: An insight from transcriptomics and computational modelling" International Journal of Biological Macromolecules, Vol 268, Part 2 (2024)'
-          url: "https://doi.org/10.1016/j.ijbiomac.2024.131817"
-
 research3:
     title: Popular tutorials
     url: "https://training.galaxyproject.org"

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -18,6 +18,8 @@ describe("Accessibility Testing", () => {
         // Ensure masthead has loaded
         cy.get("#masthead-logo").should("be.visible");
         // Only check for #app; ignores twitter and sidecar.
+        // This wait is not great; testing if this is something in deferred load of pubs.
+        cy.wait(2500);
         cy.checkA11y("#app", CYPRESS_ACCESSIBILITY_CONFIG);
     });
     it("Use page has no detectable a11y violations on load", () => {

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -9,7 +9,7 @@
         <b-row class="mb-2" v-for="(item, i) in this.items" :key="i">
             <b-col cols="11">
                 <g-link class="title" :to="item.data.url">{{ item.data.title }}</g-link>
-                <br/>
+                <br />
                 <div class="tease">
                     {{ item.meta.creatorSummary }}
                     {{ item.data.extra }}
@@ -46,14 +46,12 @@ export default {
             setTimeout(() => {
                 if (typeof window._altmetric_embed_init !== "undefined") {
                     window._altmetric_embed_init();
-                }
-                else {
+                } else {
                     this.initAltmetric();
                 }
             }, 100);
         },
         fetchPubs() {
-            //fetch data from https://api.zotero.org/groups/1732893/items/top?start=0&limit=5, and then render the data
             axios
                 .get(`https://api.zotero.org/groups/1732893/items/top?start=0&limit=${this.limit}`)
                 .then((response) => {
@@ -66,12 +64,11 @@ export default {
         },
     },
     mounted() {
-        this.fetchPubs();
-        // if altmetric is loaded, call init
-        //_altmetric_embed_init('#new-container');
+        // Inject altmetric scripts and kick off pub fetch
         const altmetricScript = document.createElement("script");
         altmetricScript.src = "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js";
         document.head.appendChild(altmetricScript);
+        this.fetchPubs();
     },
 };
 </script>

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -1,0 +1,82 @@
+<template>
+    <HomeCard
+        title="Recent Publications"
+        link="https://www.zotero.org/groups/galaxy"
+        icon="fas fa-book-open"
+        :items="itemsToShow"
+        :width="12" />
+</template>
+
+<script>
+import HomeCard from "@/components/HomeCard";
+import axios from "axios";
+
+const TEASE_TEMPLATE = (
+    item
+) => `<span class='altmetric-embed float-right' data-badge-type='donut' data-doi='${item.data.DOI}'></span>
+${item.meta.creatorSummary}
+*${item.data.extra}*`;
+
+// Journal -- if no publicationTitle, use 'preprint'
+// Add year, volume (if available)
+// Use donut for altmetric.
+// Add a loading spinner
+
+export default {
+    props: {
+        limit: {
+            type: Number,
+            default: 5,
+        },
+    },
+    data() {
+        return {
+            items: [],
+        };
+    },
+    computed: {
+        itemsToShow() {
+            if (this.items) {
+                return this.items.map((item) => {
+                    return {
+                        title: item.data.title,
+                        link: item.data.url,
+                        tease: TEASE_TEMPLATE(item),
+                    };
+                });
+            } else {
+                return [];
+            }
+        },
+    },
+    components: {
+        HomeCard,
+    },
+    methods: {
+        fetchPubs() {
+            //fetch data from https://api.zotero.org/groups/1732893/items/top?start=0&limit=5, and then render the data
+            axios
+                .get(`https://api.zotero.org/groups/1732893/items/top?start=0&limit=${this.limit}`)
+                .then((response) => {
+                    this.items = response.data;
+                })
+                .catch((error) => {
+                    console.log(error);
+                });
+            if (typeof _altmetric_embed_init !== "undefined") {
+                _altmetric_embed_init.embeds.init();
+            }
+        },
+    },
+    mounted() {
+        this.fetchPubs();
+        // if altmetric is loaded, call init
+        //_altmetric_embed_init('#new-container');
+        const altmetricScript = document.createElement("script");
+        altmetricScript.src = "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js";
+        document.head.appendChild(altmetricScript);
+    },
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -11,8 +11,9 @@
                 <g-link class="title" :to="item.data.url">{{ item.data.title }}</g-link>
                 <br />
                 <div class="tease">
-                    {{ item.meta.creatorSummary }}
-                    {{ item.data.extra }}
+                    {{ item.meta.creatorSummary }}, 
+                    {{ item.data.journalAbbreviation ? item.data.journalAbbreviation : "preprint" }},
+                    {{ item.data.date }}.
                 </div>
             </b-col>
             <b-col cols="1">
@@ -24,10 +25,6 @@
 
 <script>
 import axios from "axios";
-
-// Journal -- if no publicationTitle, use 'preprint'
-// Add year, volume (if available)
-// Add a loading spinner
 
 export default {
     props: {

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -11,7 +11,7 @@
                 <g-link class="title" :to="item.data.url">{{ item.data.title }}</g-link>
                 <br />
                 <div class="tease">
-                    {{ item.meta.creatorSummary }}, 
+                    {{ item.meta.creatorSummary }},
                     {{ item.data.journalAbbreviation ? item.data.journalAbbreviation : "preprint" }},
                     {{ item.data.date }}.
                 </div>

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -1,25 +1,17 @@
 <template>
-    <div class="pseudo-card col-sm-12">
-        <h2>
-            <g-link to="https://www.zotero.org/groups/galaxy">
-                <span :class="`icon fas fa-book-open`"></span>
-                <b>Recent Publications</b>
-            </g-link>
-        </h2>
-        <b-row class="mb-2" v-for="(item, i) in this.items" :key="i">
-            <b-col cols="11">
-                <g-link class="title" :to="item.data.url">{{ item.data.title }}</g-link>
-                <br />
-                <div class="tease">
-                    {{ item.meta.creatorSummary }},
-                    {{ item.data.journalAbbreviation ? item.data.journalAbbreviation : "preprint" }},
-                    {{ item.data.date }}.
-                </div>
-            </b-col>
-            <b-col cols="1">
-                <span class="altmetric-embed" data-badge-type="donut" :data-doi="item.data.DOI"></span>
-            </b-col>
-        </b-row>
+    <div>
+        <g-link to="https://www.zotero.org/groups/galaxy">
+            <h3 class="text-white">Recent Publications</h3>
+        </g-link>
+        <div class="mb-2" v-for="(item, i) in this.items" :key="i">
+            <g-link class="mb-3 text-white small" :to="item.data.url">{{ item.data.title }}</g-link>
+            <br />
+            <div class="mb-3 text-white small">
+                {{ item.meta.creatorSummary }},
+                {{ item.data.journalAbbreviation ? item.data.journalAbbreviation : "preprint" }},
+                {{ item.data.date }}.
+            </div>
+        </div>
     </div>
 </template>
 

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -9,7 +9,7 @@
             <div class="mb-3 text-white small">
                 {{ item.meta.creatorSummary }},
                 {{ item.data.journalAbbreviation ? item.data.journalAbbreviation : "preprint" }},
-                {{ item.data.date }}.
+                {{ formatDate(item.data.dateAdded) }}.
             </div>
         </div>
     </div>
@@ -50,6 +50,9 @@ export default {
                 .catch((error) => {
                     console.log(error);
                 });
+        },
+        formatDate(dateString) {
+            return new Date(dateString).toISOString().split('T')[0] ?? dateString;
         },
     },
     mounted() {

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -42,22 +42,27 @@ export default {
         };
     },
     methods: {
+        initAltmetric() {
+            setTimeout(() => {
+                if (typeof window._altmetric_embed_init !== "undefined") {
+                    window._altmetric_embed_init();
+                }
+                else {
+                    this.initAltmetric();
+                }
+            }, 100);
+        },
         fetchPubs() {
             //fetch data from https://api.zotero.org/groups/1732893/items/top?start=0&limit=5, and then render the data
             axios
                 .get(`https://api.zotero.org/groups/1732893/items/top?start=0&limit=${this.limit}`)
                 .then((response) => {
                     this.items = response.data;
+                    this.initAltmetric();
                 })
                 .catch((error) => {
                     console.log(error);
                 });
-            // set a repeated timeout to call embed init until it's done
-            setTimeout(() => {
-                if (typeof window._altmetric_embed_init !== "undefined") {
-                    window._altmetric_embed_init();
-                }
-            }, 1000);
         },
     },
     mounted() {

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -1,25 +1,32 @@
 <template>
-    <HomeCard
-        title="Recent Publications"
-        link="https://www.zotero.org/groups/galaxy"
-        icon="fas fa-book-open"
-        :items="itemsToShow"
-        :width="12" />
+    <div class="pseudo-card col-sm-12">
+        <h2>
+            <g-link to="https://www.zotero.org/groups/galaxy">
+                <span :class="`icon fas fa-book-open`"></span>
+                <b>Recent Publications</b>
+            </g-link>
+        </h2>
+        <b-row class="mb-2" v-for="(item, i) in this.items" :key="i">
+            <b-col cols="11">
+                <g-link class="title" :to="item.data.url">{{ item.data.title }}</g-link>
+                <br/>
+                <div class="tease">
+                    {{ item.meta.creatorSummary }}
+                    {{ item.data.extra }}
+                </div>
+            </b-col>
+            <b-col cols="1">
+                <span class="altmetric-embed" data-badge-type="donut" :data-doi="item.data.DOI"></span>
+            </b-col>
+        </b-row>
+    </div>
 </template>
 
 <script>
-import HomeCard from "@/components/HomeCard";
 import axios from "axios";
-
-const TEASE_TEMPLATE = (
-    item
-) => `<span class='altmetric-embed float-right' data-badge-type='donut' data-doi='${item.data.DOI}'></span>
-${item.meta.creatorSummary}
-*${item.data.extra}*`;
 
 // Journal -- if no publicationTitle, use 'preprint'
 // Add year, volume (if available)
-// Use donut for altmetric.
 // Add a loading spinner
 
 export default {
@@ -34,24 +41,6 @@ export default {
             items: [],
         };
     },
-    computed: {
-        itemsToShow() {
-            if (this.items) {
-                return this.items.map((item) => {
-                    return {
-                        title: item.data.title,
-                        link: item.data.url,
-                        tease: TEASE_TEMPLATE(item),
-                    };
-                });
-            } else {
-                return [];
-            }
-        },
-    },
-    components: {
-        HomeCard,
-    },
     methods: {
         fetchPubs() {
             //fetch data from https://api.zotero.org/groups/1732893/items/top?start=0&limit=5, and then render the data
@@ -63,9 +52,12 @@ export default {
                 .catch((error) => {
                     console.log(error);
                 });
-            if (typeof _altmetric_embed_init !== "undefined") {
-                _altmetric_embed_init.embeds.init();
-            }
+            // set a repeated timeout to call embed init until it's done
+            setTimeout(() => {
+                if (typeof window._altmetric_embed_init !== "undefined") {
+                    window._altmetric_embed_init();
+                }
+            }, 1000);
         },
     },
     mounted() {
@@ -79,4 +71,27 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+@import "~/assets/styles.scss";
+
+.pseudo-card {
+    background-color: $gray-200;
+    border: 4px solid white;
+    border-radius: 8px;
+}
+h2 .icon {
+    margin-right: 0.7em;
+}
+.content.markdown::v-deep p {
+    font-size: 80%;
+}
+.content.markdown::v-deep a {
+    font-size: 120%;
+}
+.title {
+    font-weight: bold;
+}
+.tease {
+    font-size: 80%;
+}
+</style>

--- a/src/components/Publications.vue
+++ b/src/components/Publications.vue
@@ -52,7 +52,7 @@ export default {
                 });
         },
         formatDate(dateString) {
-            return new Date(dateString).toISOString().split('T')[0] ?? dateString;
+            return new Date(dateString).toISOString().split("T")[0] ?? dateString;
         },
     },
     mounted() {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -221,24 +221,7 @@
             <div class="row">
                 <div class="col-xl-4 mb-3">
                     <div class="area research publications h-100">
-                        <a
-                            :href="this.$static.datasetResearch.research1.url"
-                            rel="noopener"
-                            target="_blank"
-                            class="text-white"
-                        >
-                            <h3>{{ this.$static.datasetResearch.research1.title }}</h3>
-                        </a>
-                        <a
-                            :href="p.url"
-                            class="mb-3 text-white small"
-                            v-for="p in this.$static.datasetResearch.research1.links"
-                            :key="p.title"
-                            role="button"
-                            rel="noopener"
-                            target="_blank"
-                            >{{ p.title }}</a
-                        >
+                        <Publications />
                         <a href="https://doi.org/10.1093/nar/gkae410" target="_blank" rel="noopener" class="text-white">
                             <h3>Cite Galaxy</h3>
                             <div>
@@ -344,8 +327,12 @@
 <script>
 import slugify from "@sindresorhus/slugify";
 import CONFIG from "~/../config.json";
+import Publications from "@/components/Publications";
 
 export default {
+    components: {
+        Publications,
+    },
     data() {
         return {
             cancelled: false,

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -221,7 +221,9 @@
             <div class="row">
                 <div class="col-xl-4 mb-3">
                     <div class="area research publications h-100">
-                        <Publications />
+                        <ClientOnly>
+                            <Publications />
+                        </ClientOnly>
                         <a href="https://doi.org/10.1093/nar/gkae410" target="_blank" rel="noopener" class="text-white">
                             <h3>Cite Galaxy</h3>
                             <div>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -441,15 +441,6 @@ query {
 
     datasetResearch: dataset(path: "/dataset:/home/research/") {
         heading,
-        research1 {
-            title,
-            content,
-            url,
-            links {
-                title,
-                url
-            }
-        },
         research3 {
             title,
             content,


### PR DESCRIPTION
Before this is merged, we probably need to clean up publication details a bit on zotero and pick precisely which ones we'll use.

Right now I'm using:
```
                    {{ item.meta.creatorSummary }}, 
                    {{ item.data.journalAbbreviation ? item.data.journalAbbreviation : "preprint" }},
                    {{ item.data.date }}.
```

So, creatorSummary, journalAbbreviation, and date should be carefully added.  We can add more if we want.  It looks like journalAbbreviation isn't always correct or is sometimes missing currently, so we'll need to update those records.

Another option is to just hit crossref for each doi and request a proper citation format, as mentioned before.  This wouldn't be a lot of extra work, but I think we wanted to use this current approach to force zotero to be curated more.

Drops 'New Platforms' box as well, since we've decided to roll that into news when appropriate.