### PR TITLE
Removing Moving Dataset between Galaxy Servers

### DIFF
--- a/content/support/download-data/index.md
+++ b/content/support/download-data/index.md
@@ -6,7 +6,7 @@
 Related topics
 
 * [Loading Data](/support/loading-data/)
-* [Moving data between Galaxy servers](/blog/2016-07-moving-data-between-galaxy-instances/)
+* [Moving datasets between Galaxy servers](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.html)
 
 Tutorials
 

--- a/content/support/index.md
+++ b/content/support/index.md
@@ -32,7 +32,7 @@ title: Galaxy Support
 * [Understanding the Analysis History](/tutorials/histories/)
 * [Managing Datasets](/learn/managing-datasets/)
 * [Datasets and how jobs execute](/support/how-jobs-execute/)
-* [More about moving Datasets and Histories](https://genomicsvirtuallab.wordpress.com/2016/07/13/moving-data-between-galaxy-instances/) (external GVL blog)
+* [More about moving Datasets](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.html)
 
 ### Data Options
 

--- a/content/support/index.md
+++ b/content/support/index.md
@@ -38,7 +38,7 @@ title: Galaxy Support
 
 * [Sharing and Publishing your work](/learn/share/)
 * [Data Privacy Features](/learn/privacy-features/)
-* [Moving data between Galaxy servers (any!)](https://genomicsvirtuallab.wordpress.com/2016/07/13/moving-data-between-galaxy-instances/)
+* [Moving datasets between Galaxy servers (any!)](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.html)
 
 ### Help Guides
 


### PR DESCRIPTION
I was confused about removing this FAQ because it was a link to an external blog and addressed moving datasets and histories which I only addressed the datasets part but after exploring the GTN FAQs I found a similar FAQ about [moving histories](https://training.galaxyproject.org/training-material/faqs/galaxy/histories_transfer_entire_histories_from_one_galaxy_server_to_another.html) that addressed what was in the history section of the external [blog](https://genomicsvirtuallab.wordpress.com/2016/07/13/moving-data-between-galaxy-instances/). So, I renamed it "moving datasets..." and only linked it to the moving datasets GTN FAQ page. 

However, The link has also been mentioned multiple times throughout the FAQ page which I'm not sure if its necessary (I included all of it just incase) and another concern I had was on one of the mentioned parts it was linked to [another page](https://galaxyproject.org/blog/2016-07-moving-data-between-galaxy-instances/) which had the authors name and everything. I also replaced that page with the GTN FAQ link but I'm not sure if its better to leave the page as it is and only replace the link that is mentioned on the page that links to the external blog page.