### PR TITLE
Updated Unsharing Unwanted Histories

### DIFF
--- a/content/support/account-quotas/index.md
+++ b/content/support/account-quotas/index.md
@@ -62,17 +62,7 @@ If the account usage is showing that quota is exceeded -[over 250 GB](/main/):
 
 ### Find Histories that have been shared with you, and unshare those not needed
 
-* All account Histories owned by others, but shared with you, can be reviewed under **User > Histories shared with me**.
-* Review the list. There may be none!
-* Only a small fraction of the data content in "Histories shared with me" are part of your own quota usage, and *unsharing* will not significantly reduce quota usage for most end-users. However, if there are hundreds (or more!), or many large histories shared with you, clearing these up periodically (*unsharing*) could be worth it.
-* The other person does not need to *unshare* a history for you. *Unshare histories yourself* on this page using the pull-down menu per-history.
-* **View** is a review feature. The data cannot be worked with but many details, including tool and dataset metadata/parameters are included.
-* **Copy** those you want to work with. This will *increase your quota usage* since that history copy is now one of your histories, but that will also allow you manipulate the datasets or the history itself, independently from the original owner. All History/Dataset functions are available if the other person granted full access to the datasets to you. Dataset sharing is a distinct option on the *Share or Publish* form. Only the original History owner can set the level of sharing (History only, or also Datasets). If you need Dataset access and it wasn't granted, you might need to ask the other person to *reshare* with the box for "Also make all objects within the History accessible." checked. The other person can toggle sharing to "off" for review/changes, then toggled back to "on" after.
-* **Unshare** any on the list not needed anymore. After a history is copied, you will still have your own version of the history, even if later unshared or the other person who shared it with you makes changes to their own version of the history later on. Meaning, each account's version of a History, and the Datasets in it, are distinct (unless the Datasets were not shared -- then you will still only be able to "view" Datasets, but not work with or download them).
-* Dataset and History privacy options, including sharing, can be set under **User > Preferences**. The automatic default is that none of your account data is shared. You must actively choose to share your work -- both the privacy level AND how -- for any Galaxy Object (Dataset, History, Workflow, Visualization).  
-* **A small fraction of space from "Histories shared with me" in a *shared* state are still part of your quota usage.**
-* **Shared Histories must be *unshared* to not count toward quota usage.**
-* If you *share* a History with someone else, that does not increase OR decrease *your* own quota usage.
+To know more about unsharing unwanted histories, follow [this FAQ](https://training.galaxyproject.org/training-material/faqs/galaxy/histories_unsharing_histories.html). 
 
 ### Reduce quota usage while still retaining prior work (data, tools, methods)
 


### PR DESCRIPTION
Through this Pull Request, I'm updating the content of [Find Histories that have been shared with you, and unshare those not needed](https://galaxyproject.org/support/account-quotas/#find-histories-that-have-been-shared-with-you-and-unshare-those-not-needed) in the Hub with that of [Unsharing unwanted histories](https://training.galaxyproject.org/training-material/faqs/galaxy/histories_unsharing_histories.html) in the GTN.

Kindly suggest any improvements or amendments.