### PR TITLE
Removing FAQ- Where is my Tool Help?

### DIFF
--- a/content/support/tool-help/index.md
+++ b/content/support/tool-help/index.md
@@ -3,7 +3,7 @@ title: Support Tool Help
 ---
 [Back to Support Hub](/support/)
 
-## [Where is the tool help?](https://training.galaxyproject.org/training-material/faqs/galaxy/tools_help.html)
+## [Documentation is on the tool form itself](https://training.galaxyproject.org/training-material/faqs/galaxy/tools_help.html)
 
 
 

--- a/content/support/tool-help/index.md
+++ b/content/support/tool-help/index.md
@@ -3,26 +3,7 @@ title: Support Tool Help
 ---
 [Back to Support Hub](/support/)
 
-## Documentation is on the tool form itself
-
-
-* Parameters
-* Expected format for input [dataset(s)](/learn/managing-datasets/)
-* Links to publications and [Tool Shed](/toolshed/) source repositories
-* Tool and wrapper version(s)
-* 3rd party author web sites and documentation
-
-## Many tools include "most common" and "full parameter" run-time options
-
-* Scroll down on the tool form to locate information about expected inputs/outputs, expanded definitions, sample data, example use cases, and graphics.
-
-## Galaxy Resources
-
-* [Galaxy Search](/search/) will locate help across Galaxy's resources.
-* [Galaxy Tutorials](/learn/)
-* [Galaxy Support FAQs](/support/)
-* [Galaxy Help](https://help.galaxyproject.org/) - current Q&A
-* [Galaxy Biostars](https://biostar.usegalaxy.org) - archived Q&A
+## [Where is the tool help?](https://training.galaxyproject.org/training-material/faqs/galaxy/tools_help.html)
 
 
 


### PR DESCRIPTION
Removing this FAQ and replacing with the GTN link