### PR TITLE
No more automatic propagation and crossposting between subsites.

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,7 +28,7 @@
     ],
     "subsites": {
         "hierarchy": {
-            "root": {
+            "global": {
                 "us": {},
                 "eu": {
                     "freiburg": {},
@@ -41,7 +41,15 @@
                 }
             }
         },
+        "shorthands": {
+            "all": [
+                "global", "us", "eu", "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it"
+            ]
+        },
         "metadata": {
+            "global": {
+                "name": "Global"
+            },
             "us": {
                 "name": "US",
                 "color": "#4e7152"

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -6,7 +6,7 @@
             </b-navbar-brand>
             <b-navbar-brand
                 class="subsite-name"
-                v-if="subsite && subsite !== 'root'"
+                v-if="subsite && subsite !== 'global'"
                 :to="`${pathPrefix}/`"
                 v-html="subsiteName"
             />
@@ -71,11 +71,11 @@ const REPO_URL = "https://github.com/galaxyproject/galaxy-hub";
 const EDIT_PATH = "tree/master/content";
 export default {
     props: {
-        subsite: { type: String, required: false, default: "root" },
+        subsite: { type: String, required: false, default: null },
     },
     computed: {
         pathPrefix() {
-            if (!this.subsite || this.subsite === "root") {
+            if (!this.subsite || this.subsite === "global") {
                 return "";
             } else {
                 return `/${this.subsite}`;

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -19,7 +19,7 @@ export default {
         NavBar,
     },
     props: {
-        subsite: { type: String, required: false, default: "root" },
+        subsite: { type: String, required: false, default: null },
     },
     computed: {
         rootClasses() {

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout>
+    <Layout subsite="global">
         <g-link to="/use/" class="link"> &larr; Platform Directory</g-link>
         <header>
             <h1 class="pageTitle">{{ $page.platform.title }}</h1>

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,11 +148,6 @@ function subsiteFromPath(path) {
 }
 module.exports.subsiteFromPath = subsiteFromPath;
 
-function getSubsiteAncestry(subsite) {
-    return getTreeBranch(CONFIG.subsites.hierarchy, subsite);
-}
-module.exports.getSubsiteAncestry = getSubsiteAncestry;
-
 /** Find the `query` in the tree and return a list containing it and its ancestors.
  * @param {Object} tree  A tree represented as an object where each key is a string and each value
  *                       is an object of the same format. Leaf nodes are keys whose values are empty


### PR DESCRIPTION
Previously, we made some assumptions that, say, the EU subsite would want to list every event happening in any of its lower-level subsites like Freiburg. And the same for Global vs. EU (or US). But, as discussed in #1317, that's not always what we might want.

So instead, this implements a new, simpler system where a post will only appear on the subsites it explicitly lists. To make it less tedious, you can use shorthands for certain sets of subsites instead of having to list every one. Currently there's just the `all` shorthand, which will expand to every current subsite. Shorthands are configurable in `config.json`.

Side note: This also renames the top-level subsite from `root` to `global`, which I think is a better name, especially since authors will now have to use it more often.

Closes #1317.