### PR TITLE
Standardize `tags` values a bit.

### DIFF
--- a/content/events/2021-08-metaproteomics/index.md
+++ b/content/events/2021-08-metaproteomics/index.md
@@ -10,6 +10,6 @@ location_url: "https://hupo2021.org/pre-congress-webinar-series/"
 external_url: "https://hupo2021.org/webinar-registration/"
 gtn: false
 contact: "Pratik Jagtap"
-tags: "webinar"
+tags: [webinar]
 subsites: [global, us]
 ---

--- a/content/events/2021-10-21-anz-pacbio/index.md
+++ b/content/events/2021-10-21-anz-pacbio/index.md
@@ -10,6 +10,6 @@ external_url: "https://us02web.zoom.us/webinar/register/WN_wa9jSq9sSbS2vZ9uZi0jd
 gtn: false
 contact: "Gareth Price"
 image: 
-tags: "webinar"
+tags: [webinar]
 subsites: [global, us]
 ---

--- a/content/events/2021-10-28-anz-pacbio/index.md
+++ b/content/events/2021-10-28-anz-pacbio/index.md
@@ -10,6 +10,6 @@ external_url: "https://us02web.zoom.us/webinar/register/WN_wa9jSq9sSbS2vZ9uZi0jd
 gtn: false
 contact: "Gareth Price"
 image: 
-tags: "webinar"
+tags: [webinar]
 subsites: [global, us]
 ---

--- a/content/events/2021-10-eosc-gtn/index.md
+++ b/content/events/2021-10-eosc-gtn/index.md
@@ -10,6 +10,6 @@ location_url: "https://docs.google.com/document/d/1DefGMmcBkH0jv89lx9E-CIcvqvDJo
 external_url: "https://docs.google.com/document/d/1DefGMmcBkH0jv89lx9E-CIcvqvDJoT5cdjONKOP94bY/edit#heading=h.k4a1o3eqwsd4"
 gtn: false
 contact: "Helena Rasche"
-tags: "webinar"
+tags: [webinar]
 subsites: [global, us]
 ---

--- a/content/events/2021-10-proteomics/index.md
+++ b/content/events/2021-10-proteomics/index.md
@@ -10,6 +10,6 @@ location_url: "https://docs.google.com/document/d/10lECIsd9tqC4IXWjqcINZDSduKn-1
 external_url: "https://docs.google.com/document/d/10lECIsd9tqC4IXWjqcINZDSduKn-1afoN9Q5r7IW8vg/edit"
 gtn: false
 contact: "Johan Gustafsson, Grace Hall, Pratik Jagtap"
-tags: "webinar"
+tags: [webinar]
 subsites: [global, us]
 ---

--- a/content/events/2021-11-ausbiocommons/index.md
+++ b/content/events/2021-11-ausbiocommons/index.md
@@ -10,6 +10,6 @@ external_url: "https://www.biocommons.org.au/2021-showcase"
 gtn: false
 contact: "Andrew Lonie, Christina Hall"
 image: 
-tags:
+tags: []
 subsites: [global, us]
 ---

--- a/content/events/2022-01-abims/index.md
+++ b/content/events/2022-01-abims/index.md
@@ -10,6 +10,6 @@ external_url: "http://abims.sb-roscoff.fr/sites/abims.sb-roscoff.fr/files/format
 gtn: true
 contact: "Loraine Guéguen, Erwan Corre"
 image: ""
-tags: 
+tags: []
 subsites: [global, us]
 ---

--- a/content/events/2022-01-small-scale/index.md
+++ b/content/events/2022-01-small-scale/index.md
@@ -10,7 +10,7 @@ location_url:
 external_url:
 gtn: false
 contact: "Hans-Rudolf Hotz"
-tags: 
+tags: []
 subsites: [global, us]
 ---
 

--- a/content/events/2022-02-proteomics-lfqanalyst/index.md
+++ b/content/events/2022-02-proteomics-lfqanalyst/index.md
@@ -10,6 +10,6 @@ external_url: "https://www.biocommons.org.au/events/galaxy-proteomics-community"
 gtn: false
 contact: "johan@biocommons.org.au"
 image: 
-tags:
+tags: []
 subsites: [global, us]
 ---

--- a/content/events/2022-03-small-scale/index.md
+++ b/content/events/2022-03-small-scale/index.md
@@ -10,7 +10,7 @@ location_url:
 external_url:
 gtn: false
 contact: "Hans-Rudolf Hotz"
-tags: 
+tags: []
 subsites: [global, us]
 ---
 

--- a/content/events/2022-04-Misconceptions-Writeathon/index.md
+++ b/content/events/2022-04-Misconceptions-Writeathon/index.md
@@ -10,7 +10,7 @@ location_url:
 external_url:
 gtn: false
 contact: "Hans-Rudolf Hotz"
-tags: 
+tags: []
 subsites: [global, us]
 ---
 

--- a/content/events/2022-05-small-scale/index.md
+++ b/content/events/2022-05-small-scale/index.md
@@ -10,7 +10,7 @@ location_url:
 external_url:
 gtn: false
 contact: "Hans-Rudolf Hotz"
-tags: 
+tags: []
 subsites: [global, us]
 ---
 


### PR DESCRIPTION
Some pages with only one tag listed it without brackets, which led to it being parsed as a string, not a list. It still worked, but it's not bad to be more explicit.

Also, some pages with no tags left the value blank instead of empty brackets. Again, no big deal but why not fix it while I'm at it?