### PR TITLE
Removing FAQ - Mismatched Chromosome identifiers and how to avoid them (2)

### DIFF
--- a/content/support/chrom-identifiers/index.md
+++ b/content/support/chrom-identifiers/index.md
@@ -5,9 +5,6 @@ title: Chromosome Identifiers in Reference Genomes (and other -omes)
 **[Back to Support Hub](/support/)**
 **[Troubleshooting Help](/support/#troubleshooting)**
 
-Methods described help to identify and correct errors or unexpected results linked to inputs having non-identical chromosome identifiers and/or different chromosome sequence content.
-
-**If using a Custom Reference genome**, the methods below also apply, but the first step is to make certain that the [Custom Genome is formatted correctly](/learn/custom-genomes/). Improper formating is the most common root cause of CG related errors.
 
 ## Find BAM dataset identifiers
 
@@ -120,14 +117,6 @@ The inputs are a match for sequence content but simply adding "chr" will not mak
 1. [Custom Reference Genome help](/learn/custom-genomes/)
 1. Be aware that if the genome is large, this option may result in a memory failure. Try *Method 2* or consider moving to a local or cloud Galaxy where you can control the resources
 
-## A Note on Built-in Reference Genomes
+## [A Note on Built-in Reference Genomes](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_chromosome_identifiers.html)
 
-The default variant for all genomes is "Full", defined as all primary chromosomes (or scaffolds/contigs) including mitochondrial plus associated unmapped, plasmid, and other segments.
-
-When only one version of a genome is available for a tool, it represents the default "Full" variant.
-
-Some genomes will have more than one variant available.
-
-- The "Canonical Male" or sometimes simply "Canonical" variant contains the primary chromosomes for a genome. For example a human "Canonical" variant contains chr1-chr22, chrX, chrY, and chrM.
-- The "Canonical Female" variant contains the primary chromosomes excluding chrY.
 


### PR DESCRIPTION
I'm not sure how to remove [this FAQ](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_chromosome_identifiers.html) on the Hub because

1. The FAQs in this page ([the Hub](https://galaxyproject.org/support/chrom-identifiers/)) has their own links on the GTN see PR [#1327](https://github.com/galaxyproject/galaxy-hub/pull/1327) and method 3 and 4 added on the [GTN FAQ]( https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_chromosome_identifiers.html) lead to the FAQ page on the Hub so I'm not sure if adding this GTN FAQ link will be the best choice. What do you think ?

2. Other than the methods I mentioned on point 1, [the FAQ](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_chromosome_identifiers.html) includes Intro section (Which has no link on the Hub) and the [Note Section](https://galaxyproject.org/support/chrom-identifiers/#a-note-on-built-in-reference-genomes) mentioned on the Hub. If adding the link is necessary, should I replace the note section with the GTN FAQ link (Which I did in this PR in order not to break any links if any) or should I add a title at the intro section with the GTN FAQ link and remove the note section (Since the FAQ includes intro section and mentions the methods. Feel like putting it at the end will not make sense) ?

**What do you think? Should this be removed?**