### PR TITLE
Make external links to posts on other sites open in a new tab.

### DIFF
--- a/src/components/ArticleTable.vue
+++ b/src/components/ArticleTable.vue
@@ -4,7 +4,7 @@
         <td class="summary">
             <div v-if="article.external_url" class="title">
                 <p class="outlink">
-                    <a :href="article.external_url">{{ article.title }}</a>
+                    <a :href="article.external_url" target="_blank">{{ article.title }}</a>
                 </p>
                 <div class="link-icon"><a class="fas fa-external-link-alt"></a></div>
                 <div class="clearfix"></div>

--- a/src/components/ArticleTable.vue
+++ b/src/components/ArticleTable.vue
@@ -1,9 +1,15 @@
 <template>
     <tr>
         <td class="date text-nowrap">{{ article.date }}</td>
-        <td class="title">
-            <a v-if="article.external_url" :href="article.external_url">{{ article.title }}</a>
-            <g-link v-else :to="article.path" class="read">{{ article.title }}</g-link>
+        <td class="summary">
+            <div v-if="article.external_url" class="title">
+                <p class="outlink">
+                    <a :href="article.external_url">{{ article.title }}</a>
+                </p>
+                <div class="link-icon"><a class="fas fa-external-link-alt"></a></div>
+                <div class="clearfix"></div>
+            </div>
+            <g-link v-else :to="article.path" class="title">{{ article.title }}</g-link>
         </td>
         <td class="tease">{{ article.tease }}</td>
     </tr>
@@ -16,3 +22,17 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+p {
+    margin: 0;
+}
+.outlink {
+    float: left;
+    width: calc(100% - 15px);
+}
+.link-icon {
+    font-size: 80%;
+    float: right;
+}
+</style>

--- a/src/components/ArticleTableBlog.vue
+++ b/src/components/ArticleTableBlog.vue
@@ -1,7 +1,7 @@
 <template>
     <tr>
         <td class="date text-nowrap">{{ article.date }}</td>
-        <td class="title">
+        <td class="summary">
             {{ article.authors }}
             <p class="from">
                 from
@@ -10,8 +10,14 @@
             </p>
         </td>
         <td>
-            <a v-if="article.external_url" :href="article.external_url">{{ article.title }}</a>
-            <g-link v-else :to="article.path" class="read">{{ article.title }}</g-link>
+            <div v-if="article.external_url" class="title">
+                <p class="outlink">
+                    <a :href="article.external_url">{{ article.title }}</a>
+                </p>
+                <div class="link-icon"><a class="fas fa-external-link-alt"></a></div>
+                <div class="clearfix"></div>
+            </div>
+            <g-link v-else :to="article.path" class="title">{{ article.title }}</g-link>
             <p class="tease">
                 {{ article.tease }}
             </p>
@@ -28,8 +34,19 @@ export default {
 </script>
 
 <style scoped>
+p {
+    margin: 0;
+}
 .from {
     font-style: italic;
     margin-left: 1em;
+}
+.outlink {
+    float: left;
+    width: calc(100% - 15px);
+}
+.link-icon {
+    font-size: 80%;
+    float: right;
 }
 </style>

--- a/src/components/ArticleTableBlog.vue
+++ b/src/components/ArticleTableBlog.vue
@@ -12,7 +12,7 @@
         <td>
             <div v-if="article.external_url" class="title">
                 <p class="outlink">
-                    <a :href="article.external_url">{{ article.title }}</a>
+                    <a :href="article.external_url" target="_blank">{{ article.title }}</a>
                 </p>
                 <div class="link-icon"><a class="fas fa-external-link-alt"></a></div>
                 <div class="clearfix"></div>

--- a/src/components/ArticleTableEvents.vue
+++ b/src/components/ArticleTableEvents.vue
@@ -1,9 +1,15 @@
 <template>
     <tr>
         <td class="date text-nowrap">{{ article.date }}</td>
-        <td class="title">
-            <a v-if="article.external_url" :href="article.external_url">{{ article.title }}</a>
-            <g-link v-else :to="article.path" class="read">{{ article.title }}</g-link>
+        <td class="summary">
+            <div v-if="article.external_url" class="title">
+                <p class="outlink">
+                    <a :href="article.external_url">{{ article.title }}</a>
+                </p>
+                <div class="link-icon"><a class="fas fa-external-link-alt"></a></div>
+                <div class="clearfix"></div>
+            </div>
+            <g-link v-else :to="article.path" class="title">{{ article.title }}</g-link>
             <p class="tease small">
                 {{ article.tease }}
                 <template v-if="article.links.length">
@@ -54,5 +60,13 @@ td {
 }
 p {
     margin: 0;
+}
+.outlink {
+    float: left;
+    width: calc(100% - 15px);
+}
+.link-icon {
+    font-size: 80%;
+    float: right;
 }
 </style>

--- a/src/components/ArticleTableEvents.vue
+++ b/src/components/ArticleTableEvents.vue
@@ -4,7 +4,7 @@
         <td class="summary">
             <div v-if="article.external_url" class="title">
                 <p class="outlink">
-                    <a :href="article.external_url">{{ article.title }}</a>
+                    <a :href="article.external_url" target="_blank">{{ article.title }}</a>
                 </p>
                 <div class="link-icon"><a class="fas fa-external-link-alt"></a></div>
                 <div class="clearfix"></div>


### PR DESCRIPTION
And add an icon indicating which posts are external.

This just affects events, news, and blog posts.