### PR TITLE
Let authors set a primary subsite.

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -134,6 +134,60 @@ async function addImage(imgPath, args, context) {
     return images;
 }
 
+function getMainSubsite(rawMainSubsite, pagePath) {
+    let mainSubsite = undefined;
+    // Use any (valid) user-defined `main_subsite`.
+    if (rawMainSubsite) {
+        if (SUBSITES_LIST.includes(rawMainSubsite)) {
+            mainSubsite = rawMainSubsite;
+        } else {
+            console.error(repr`${pagePath}: main_subsite ${rawMainSubsite} not recognized.`);
+        }
+    }
+    // Otherwise, use any path-derived subsite.
+    if (!mainSubsite) {
+        mainSubsite = subsiteFromPath(pagePath);
+    }
+    return mainSubsite;
+}
+
+function getSubsites(rawSubsites, mainSubsite, pagePath) {
+    let type = getType(rawSubsites);
+    let subsites;
+    if (type === "Array") {
+        subsites = rawSubsites;
+    } else if (type === "String") {
+        // If there's a single subsite, allow authors to forget the enclosing braces (leaving it a String).
+        console.warn(repr`${pagePath}: Subsite ${rawSubsites} better written as [${rawSubsites}]`);
+        subsites = [rawSubsites];
+    } else if (rawSubsites) {
+        console.error(repr`${pagePath}: Invalid type for "subsites" key ${rawSubsites}`);
+        return [];
+    } else {
+        // For files with no "subsites" key, `node.subsites` will be `undefined`. Translate this to an empty list.
+        subsites = [];
+    }
+    let subsitesSet = new Set();
+    if (mainSubsite) {
+        subsitesSet.add(mainSubsite);
+    }
+    // Add any subsites from the author-written `subsites` yaml key. Translate any shorthands first.
+    for (let subsite of subsites) {
+        let shorthandSubsites = CONFIG.subsites.shorthands[subsite];
+        if (shorthandSubsites) {
+            // It's a shorthand. Add all the subsites it stands for.
+            shorthandSubsites.forEach((translated) => subsitesSet.add(translated));
+        } else if (SUBSITES_LIST.includes(subsite)) {
+            // It's an actual subsite. Just add it to the list.
+            subsitesSet.add(subsite);
+        } else {
+            console.error(repr`${pagePath}: Subsite ${subsite} in 'subsites' list not recognized.`);
+        }
+    }
+    // Store the Set of unique subsites to the `subsites` field as an Array.
+    return Array.from(subsitesSet);
+}
+
 class nodeModifier {
     static processNewNode(node, collection, typeName) {
         if (this.collectionProcessors[typeName]) {
@@ -164,51 +218,10 @@ class nodeModifier {
                 node.closed = false;
             }
         }
+        // Assign a main subsite (if any).
+        node.main_subsite = getMainSubsite(node.main_subsite, node.path);
         // Assign subsites.
-        let type = getType(node.subsites);
-        let subsitesRaw = node.subsites;
-        if (type === "Array") {
-            subsitesRaw = node.subsites;
-        } else if (type === "String") {
-            subsitesRaw = [node.subsites];
-        } else if (node.subsites) {
-            console.error(repr`Invalid type for "subsites" key in ${node.path}: ${node.subsites}`);
-        } else {
-            // For files with no "subsites" key, `node.subsites` will be `undefined`. Translate this to an empty list.
-            subsitesRaw = [];
-        }
-        let subsitesSet = new Set();
-        // Validate any user-defined `main_subsite`.
-        if (node.main_subsite) {
-            if (!SUBSITES_LIST.includes(node.main_subsite)) {
-                console.error(repr`main_subsite ${node.main_subsite} not recognized.`);
-                node.main_subsite = undefined;
-            }
-        }
-        // Add any path-derived subsite.
-        if (!node.main_subsite) {
-            node.main_subsite = subsiteFromPath(node.path);
-        }
-        if (node.main_subsite) {
-            subsitesSet.add(node.main_subsite);
-        }
-        // Add any subsites from the author-written `subsites` yaml key. Translate any shorthands first.
-        for (let subsite of subsitesRaw) {
-            let shorthandSubsites = CONFIG.subsites.shorthands[subsite];
-            if (shorthandSubsites) {
-                // It's a shorthand. Add all the subsites it stands for.
-                for (let shorthandSubsite of shorthandSubsites) {
-                    subsitesSet.add(shorthandSubsite);
-                }
-            } else if (SUBSITES_LIST.includes(subsite)) {
-                // It's an actual subsite. Just add it to the list.
-                subsitesSet.add(subsite);
-            } else {
-                console.error(repr`Subsite ${subsite} in 'subsites' list not recognized.`);
-            }
-        }
-        // Store the Set of unique subsites to the `subsites` field as an Array.
-        node.subsites = Array.from(subsitesSet);
+        node.subsites = getSubsites(node.subsites, node.main_subsite, node.path);
         // Label ones with dates.
         // This gets around the inability of the GraphQL schema to query on null/empty dates.
         if (node.date) {

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -178,8 +178,17 @@ class nodeModifier {
             subsitesRaw = [];
         }
         let subsitesSet = new Set();
+        // Validate any user-defined `main_subsite`.
+        if (node.main_subsite) {
+            if (!SUBSITES_LIST.includes(node.main_subsite)) {
+                console.error(repr`main_subsite ${node.main_subsite} not recognized.`);
+                node.main_subsite = undefined;
+            }
+        }
         // Add any path-derived subsite.
-        node.main_subsite = subsiteFromPath(node.path);
+        if (!node.main_subsite) {
+            node.main_subsite = subsiteFromPath(node.path);
+        }
         if (node.main_subsite) {
             subsitesSet.add(node.main_subsite);
         }
@@ -191,9 +200,11 @@ class nodeModifier {
                 for (let shorthandSubsite of shorthandSubsites) {
                     subsitesSet.add(shorthandSubsite);
                 }
-            } else {
+            } else if (SUBSITES_LIST.includes(subsite)) {
                 // It's an actual subsite. Just add it to the list.
                 subsitesSet.add(subsite);
+            } else {
+                console.error(repr`Subsite ${subsite} in 'subsites' list not recognized.`);
             }
         }
         // Store the Set of unique subsites to the `subsites` field as an Array.

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -88,12 +88,12 @@ async function resolveImages(node, args, context, info) {
         }
     }
     if (!imgPath) {
-        console.error(repr`Image not found: ${node.image}`);
+        console.error(node.path + repr`: Image not found: ${node.image}`);
         return {};
     }
     let relImgPathFromContent = path.relative(buildDir, imgPath);
     if (IMAGE_REGISTRY.has(relImgPathFromContent)) {
-        console.log(repr`Image ${relImgPathFromContent} already in asset store.`);
+        console.log(node.path + repr`: Image ${relImgPathFromContent} already in asset store.`);
     }
     let images = addImage(imgPath, args, context);
     if (images) {
@@ -141,7 +141,7 @@ function getMainSubsite(rawMainSubsite, pagePath) {
         if (SUBSITES_LIST.includes(rawMainSubsite)) {
             mainSubsite = rawMainSubsite;
         } else {
-            console.error(repr`${pagePath}: main_subsite ${rawMainSubsite} not recognized.`);
+            console.error(pagePath + repr`: main_subsite ${rawMainSubsite} not recognized.`);
         }
     }
     // Otherwise, use any path-derived subsite.
@@ -158,10 +158,10 @@ function getSubsites(rawSubsites, mainSubsite, pagePath) {
         subsites = rawSubsites;
     } else if (type === "String") {
         // If there's a single subsite, allow authors to forget the enclosing braces (leaving it a String).
-        console.warn(repr`${pagePath}: Subsite ${rawSubsites} better written as [${rawSubsites}]`);
+        console.warn(`${pagePath}: Subsite \`${rawSubsites}\` better written as \`["${rawSubsites}"]\``);
         subsites = [rawSubsites];
     } else if (rawSubsites) {
-        console.error(repr`${pagePath}: Invalid type for "subsites" key ${rawSubsites}`);
+        console.error(`${pagePath}: Invalid type (${type}) for "subsites" key "${repr(rawSubsites)}"`);
         return [];
     } else {
         // For files with no "subsites" key, `node.subsites` will be `undefined`. Translate this to an empty list.
@@ -181,7 +181,7 @@ function getSubsites(rawSubsites, mainSubsite, pagePath) {
             // It's an actual subsite. Just add it to the list.
             subsitesSet.add(subsite);
         } else {
-            console.error(repr`${pagePath}: Subsite ${subsite} in 'subsites' list not recognized.`);
+            console.error(pagePath + repr`: Subsite ${subsite} in subsites list not recognized.`);
         }
     }
     // Store the Set of unique subsites to the `subsites` field as an Array.
@@ -262,7 +262,7 @@ class nodeModifier {
                 if (insert) {
                     node.inserts.push(store.createReference(insert));
                 } else {
-                    console.error(repr`Failed to find Insert for path ${path} in ${node.path}`);
+                    console.error(node.path + repr`: Failed to find Insert ${path}`);
                 }
             }
             return node;


### PR DESCRIPTION
This implements Option 2 of #1334.

In brief, this surfaces the `main_subsite` key to users. This lets an author define a primary subsite to display in the UI for a post, even if it's not under that subsite's url path.

It also cleans up some of the mess that `nodeModifier.processNonInsert()` has become by moving some of it to separate functions.