### PR TITLE
Add an `all-eu` subsite shorthand.

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,7 +43,10 @@
         },
         "shorthands": {
             "all": [
-                "global", "us", "eu", "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it"
+                "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it", "eu", "us", "global"
+            ],
+            "all-eu": [
+                "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it", "eu"
             ]
         },
         "metadata": {


### PR DESCRIPTION
We'll probably want to post things to all the EU subsites but not the US one relatively often. This saves typing out all the EU subsites.