### PR TITLE
Add subsite homepages

### DIFF
--- a/content/belgium/main.md
+++ b/content/belgium/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy VIB
+subtitle: The homepage of the VIB Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/elixir-it/main.md
+++ b/content/elixir-it/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy ELIXIR-IT/Laniakea
+subtitle: The homepage of the ELIXIR-IT/Laniakea Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/erasmusmc/main.md
+++ b/content/erasmusmc/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy Erasmus MC
+subtitle: The homepage of the Erasmus MC Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/eu/main.md
+++ b/content/eu/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy Europe
+subtitle: The homepage of the European Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/freiburg/main.md
+++ b/content/freiburg/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy Freiburg
+subtitle: The homepage of the Freiburg Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/genouest/main.md
+++ b/content/genouest/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy GenOuest
+subtitle: The homepage of the GenOuest Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/ifb/main.md
+++ b/content/ifb/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy ELIXIR-FR/IFB
+subtitle: The homepage of the ELIXIR-FR/IFB Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/pasteur/main.md
+++ b/content/pasteur/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy Pasteur
+subtitle: The homepage of the Pasteur Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/us/main.md
+++ b/content/us/main.md
@@ -1,0 +1,19 @@
+---
+title: Galaxy US
+subtitle: The homepage of the US Galaxy community
+---
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -20,13 +20,13 @@ const {
     matchesPrefixes,
     subsiteFromPath,
     flattenSubsites,
-    getSingleKey
+    getSingleKey,
 } = require("./src/utils.js");
 const CONFIG = require("./config.json");
 const SUBSITES_LIST = flattenSubsites(CONFIG.subsites.hierarchy);
 const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
-if (! ROOT_SUBSITE) {
-    console.error('Error: Subsites hierarchy in config.json must have a single root subsite.');
+if (!ROOT_SUBSITE) {
+    console.error("Error: Subsites hierarchy in config.json must have a single root subsite.");
 }
 
 const COMPILE_DATE = dayjs();

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -355,15 +355,21 @@ module.exports = function (api) {
                 prefix = `/${subsite}`;
             }
             for (let [vueName, path] of [
+                ["SubsiteHome", "/"],
                 ["Events", "/events/"],
                 ["News", "/news/"],
             ]) {
+                if (subsite === ROOT_SUBSITE && path === "/") {
+                    // The site-wide homepage is manually written, not auto-generated.
+                    continue;
+                }
                 createPage({
                     path: `${prefix}${path}`,
                     component: `./src/components/pages/${vueName}.vue`,
                     context: {
                         subsite: subsite,
                         mainPath: `/insert:${prefix}${path}main/`,
+                        jumboPath: `/insert:${prefix}${path}jumbotron/`,
                         footerPath: `/insert:${prefix}${path}footer/`,
                     },
                 });

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -20,9 +20,14 @@ const {
     matchesPrefixes,
     subsiteFromPath,
     flattenSubsites,
+    getSingleKey
 } = require("./src/utils.js");
 const CONFIG = require("./config.json");
 const SUBSITES_LIST = flattenSubsites(CONFIG.subsites.hierarchy);
+const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
+if (! ROOT_SUBSITE) {
+    console.error('Error: Subsites hierarchy in config.json must have a single root subsite.');
+}
 
 const COMPILE_DATE = dayjs();
 const IMAGE_REGISTRY = new Set();
@@ -342,17 +347,17 @@ module.exports = function (api) {
     // Pages repeated across every subsite.
     api.createPages(({ createPage }) => {
         // Using the Pages API: https://gridsome.org/docs/pages-api/
-        for (let [vueName, path] of [
-            ["Events", "/events/"],
-            ["News", "/news/"],
-        ]) {
-            for (let subsite of SUBSITES_LIST) {
-                let prefix;
-                if (subsite === "global") {
-                    prefix = "";
-                } else {
-                    prefix = `/${subsite}`;
-                }
+        for (let subsite of SUBSITES_LIST) {
+            let prefix;
+            if (subsite === ROOT_SUBSITE) {
+                prefix = "";
+            } else {
+                prefix = `/${subsite}`;
+            }
+            for (let [vueName, path] of [
+                ["Events", "/events/"],
+                ["News", "/news/"],
+            ]) {
                 createPage({
                     path: `${prefix}${path}`,
                     component: `./src/components/pages/${vueName}.vue`,

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -6,7 +6,7 @@
             </b-navbar-brand>
             <b-navbar-brand
                 class="subsite-name"
-                v-if="subsite && subsite !== 'global'"
+                v-if="subsite && subsite !== rootSubsite"
                 :to="`${pathPrefix}/`"
                 v-html="subsiteName"
             />
@@ -65,17 +65,23 @@
 </template>
 
 <script>
-import { rmPrefix } from "~/utils.js";
+import { rmPrefix, getSingleKey } from "~/utils.js";
 import CONFIG from "~/../config.json";
+const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
 const REPO_URL = "https://github.com/galaxyproject/galaxy-hub";
 const EDIT_PATH = "tree/master/content";
 export default {
     props: {
         subsite: { type: String, required: false, default: null },
     },
+    data() {
+        return {
+            rootSubsite: ROOT_SUBSITE
+        }
+    },
     computed: {
         pathPrefix() {
-            if (!this.subsite || this.subsite === "global") {
+            if (!this.subsite || this.subsite === ROOT_SUBSITE) {
                 return "";
             } else {
                 return `/${this.subsite}`;

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -76,8 +76,8 @@ export default {
     },
     data() {
         return {
-            rootSubsite: ROOT_SUBSITE
-        }
+            rootSubsite: ROOT_SUBSITE,
+        };
     },
     computed: {
         pathPrefix() {

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -1,0 +1,138 @@
+<template>
+    <Layout :subsite="subsite">
+        <header id="header">
+            <h1 class="title">{{ $page.main.title }}</h1>
+            <h3 v-if="$page.main.subtitle">{{ $page.main.subtitle }}</h3>
+        </header>
+
+        <div id="static-content" :class="hasJumbotron ? 'row' : 'row no-jumbo'">
+            <section :class="hasJumbotron ? 'col-sm-5' : ''">
+                <div class="lead markdown" v-html="$page.main.content" />
+            </section>
+            <section id="jumbotron" class="col-sm-7" v-if="hasJumbotron">
+                <h3 v-if="$page.jumbotron.title" class="title text-center">{{ $page.jumbotron.title }}</h3>
+                <div class="text-center markdown" v-html="$page.jumbotron.content" />
+            </section>
+        </div>
+
+        <div class="row">
+            <HomeCard title="News" :link="`/${subsite}/news/`" icon="fas fa-bullhorn" :items="latest.news" />
+            <HomeCard title="Events" :link="`/${subsite}/events/`" icon="far fa-calendar-alt" :items="latest.events" />
+        </div>
+
+        <footer class="page-footer markdown" v-if="$page.footer" v-html="$page.footer.content" />
+    </Layout>
+</template>
+
+<script>
+import HomeCard from "@/components/HomeCard";
+export default {
+    components: {
+        HomeCard,
+    },
+    metaInfo() {
+        return {
+            title: this.$page.main.title,
+        };
+    },
+    computed: {
+        latest() {
+            let latest = {};
+            for (let category of ["news", "events"]) {
+                latest[category] = this.$page[category].edges.map((edge) => articleToItem(edge.node));
+            }
+            return latest;
+        },
+        subsite() {
+            return this.$context.subsite;
+        },
+        hasJumbotron() {
+            return this.$page.jumbotron && this.$page.jumbotron.content.trim();
+        },
+    },
+};
+/** Convert an Article to an "item", with the title, link, and tease fields expected by ItemListBrief. */
+function articleToItem(article) {
+    let item = {
+        id: article.id,
+        title: article.title,
+        link: article.external_url || article.path,
+        tease: article.tease || "",
+    };
+    if (article.date) {
+        item.tease = `*${article.date}.* ${item.tease}`;
+    }
+    return item;
+}
+</script>
+
+<page-query>
+query($subsite: String, $mainPath: String, $jumboPath: String, $footerPath: String) {
+    main: insert(path: $mainPath) {
+        id
+        title
+        subtitle
+        content
+        fileInfo {
+            path
+        }
+    }
+    jumbotron: insert(path: $jumboPath) {
+        id
+        title
+        content
+    }
+    footer: insert(path: $footerPath) {
+        id
+        title
+        content
+    }
+    news: allArticle(
+        limit: 5, filter: {category: {eq: "news" }, subsites: {contains: [$subsite]}, draft: {ne: true}}
+    ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
+    }
+    events: allArticle(
+        limit: 5, sortBy: "date", order: ASC,
+        filter: {
+            category: {eq: "events"}, subsites: {contains: [$subsite]}, has_date: {eq: true}, days_ago: {lte: 0},
+            draft: {ne: true}
+        }
+    ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+                date (format: "MMM D")
+            }
+        }
+    }
+}
+fragment articleFields on Article {
+    id
+    title
+    tease
+    external_url
+    path
+}
+</page-query>
+
+<style scoped>
+#header {
+    margin-bottom: 2.5rem;
+}
+#header .title {
+    font-size: 3rem;
+}
+#static-content {
+    margin-bottom: 40px;
+}
+#jumbotron .title {
+    font-weight: bold;
+}
+</style>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,16 +1,16 @@
 <template>
     <Layout>
-        <header class="header">
+        <header id="header">
             <h1 class="display-4">{{ $page.main.title }}</h1>
             <h3 v-if="$page.main.subtitle">{{ $page.main.subtitle }}</h3>
         </header>
 
-        <div class="row">
-            <section class="col-sm-5" v-if="$page.jumbotron && $page.jumbotron.content.trim()">
+        <div id="static-content" class="row">
+            <section :class="hasJumbotron ? 'col-sm-5' : ''">
                 <div class="lead markdown" v-html="$page.main.content" />
             </section>
-            <section class="col-sm-7 jumbotron" v-if="$page.jumbotron && $page.jumbotron.content.trim()">
-                <h3 v-if="$page.jumbotron.title" class="jumbo-title text-center">{{ $page.jumbotron.title }}</h3>
+            <section id="jumbotron" class="col-sm-7" v-if="hasJumbotron">
+                <h3 v-if="$page.jumbotron.title" class="title text-center">{{ $page.jumbotron.title }}</h3>
                 <div class="text-center markdown" v-html="$page.jumbotron.content" />
             </section>
         </div>
@@ -121,6 +121,9 @@ export default {
             }
             return latest;
         },
+        hasJumbotron() {
+            return this.$page.jumbotron && this.$page.jumbotron.content.trim();
+        }
     },
     mounted() {
         // Insert Twitter feed.
@@ -135,7 +138,7 @@ export default {
                 fjs.parentNode.insertBefore(js, fjs);
             }
         })(document, "script", "twitter-wjs");
-
+        // Add altmetrics stats badges to publications.
         const altmetricScript = document.createElement("script");
         altmetricScript.src = "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js";
         document.head.appendChild(altmetricScript);
@@ -256,20 +259,14 @@ fragment articleFields on Article {
 </page-query>
 
 <style scoped>
-.header {
+#header {
     margin-bottom: 2.5rem;
 }
-.jumbotron {
-    padding-top: 0;
-    margin-bottom: 0rem;
+#static-content {
+    margin-bottom: 40px;
 }
-.jumbo-title {
+#jumbotron .title {
     font-weight: bold;
-}
-.jumbo-image {
-    background-color: lightyellow;
-    padding-top: 100px;
-    border: 4px solid black;
 }
 #profiles {
     margin-bottom: 45px;

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -123,7 +123,7 @@ export default {
         },
         hasJumbotron() {
             return this.$page.jumbotron && this.$page.jumbotron.content.trim();
-        }
+        },
     },
     mounted() {
         // Insert Twitter feed.

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout subsite="global">
+    <Layout :subsite="subsite">
         <g-link to="/use/" class="link"> &larr; Platform Directory</g-link>
         <header>
             <h1 class="pageTitle">{{ $page.platform.title }}</h1>
@@ -77,7 +77,9 @@ query Platform($path: String!) {
 </page-query>
 
 <script>
-import { mdToHtml, getImage } from "~/utils.js";
+import { mdToHtml, getImage, getSingleKey } from "~/utils.js";
+import CONFIG from "~/../config.json";
+const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
 export default {
     metaInfo() {
         return {
@@ -92,6 +94,7 @@ export default {
     },
     data() {
         return {
+            subsite: ROOT_SUBSITE,
             groupNames: new Map([
                 ["public-server", "Public server"],
                 ["commercial-cloud", "Commercial Cloud"],

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,6 +119,18 @@ function getImage(imagePath, images) {
 }
 module.exports.getImage = getImage;
 
+/** Return an object's key if and only if it contains a single key.
+ * @param {Object} object
+ * @returns {String}
+ */
+function getSingleKey(object) {
+    let keys = Object.keys(object);
+    if (keys.length === 1) {
+        return keys[0];
+    }
+}
+module.exports.getSingleKey = getSingleKey;
+
 /** Take the value of the `subsites` key in config.json and flatten it into an array.
  * @param {Object} subsitesTree The value of the `subsites` key. Must be a tree of objects where
  *   the value for each key is another object.


### PR DESCRIPTION
This adds a basic homepage for each subsite. It lists the news and events for each subsite and has some boilerplate static text. Intended to be a starting point for customization and a non-404 destination for the subsite navbar links.