### PR TITLE
Fix homepage news/event filtering, simplify HomeCard logic.

### DIFF
--- a/src/components/ItemListBrief.vue
+++ b/src/components/ItemListBrief.vue
@@ -1,9 +1,9 @@
 <template>
     <p>
-        <g-link class="title" :to="item.link">{{ item.title }}</g-link>
-        <span class="tease" v-if="item.tease">
-            –
-            <span class="markdown" v-html="mdToHtml(item.tease)"></span>
+        <g-link class="title" :to="fields.link">{{ fields.title }}</g-link>
+        <span class="tease" v-if="fields.tease">
+            &ndash;
+            <span class="markdown" v-html="mdToHtml(fields.tease)"></span>
         </span>
     </p>
 </template>
@@ -12,10 +12,34 @@
 import { mdToHtml } from "~/utils.js";
 export default {
     props: {
+        // Can be an Article, a VueArticle, or any object with a `title`, `link`, and (optionally) a `tease` field.
         item: { type: Object, required: true },
     },
     methods: {
         mdToHtml,
+    },
+    computed: {
+        fields() {
+            /** Normalize the input object into a standard set of fields.
+             *  This will parse the metadata from an Article into the standard set of "item" fields.
+             */
+            let fields = {
+                title: this.item.title,
+                link: this.item.link || this.item.external_url || this.item.path,
+                tease: this.item.tease || "",
+            };
+            if (this.item.date) {
+                fields.tease = `*${this.item.date}.* ${fields.tease}`;
+            }
+            if (this.item.location) {
+                fields.tease += ` ${this.item.location} `;
+            }
+            if (this.item.closes) {
+                // The date a job opening closes.
+                fields.tease += `*Apply by ${this.item.closes}.*`;
+            }
+            return fields;
+        },
     },
 };
 </script>

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -39,7 +39,7 @@ export default {
         latest() {
             let latest = {};
             for (let category of ["news", "events"]) {
-                latest[category] = this.$page[category].edges.map((edge) => articleToItem(edge.node));
+                latest[category] = this.$page[category].edges.map((edge) => edge.node);
             }
             return latest;
         },
@@ -51,19 +51,6 @@ export default {
         },
     },
 };
-/** Convert an Article to an "item", with the title, link, and tease fields expected by ItemListBrief. */
-function articleToItem(article) {
-    let item = {
-        id: article.id,
-        title: article.title,
-        link: article.external_url || article.path,
-        tease: article.tease || "",
-    };
-    if (article.date) {
-        item.tease = `*${article.date}.* ${item.tease}`;
-    }
-    return item;
-}
 </script>
 
 <page-query>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -185,7 +185,9 @@ query {
         title
         content
     }
-    news: allArticle(limit: 5, filter: {category: {eq: "news" }, draft: {ne: true}}) {
+    news: allArticle(
+        limit: 5, filter: {category: {eq: "news" }, subsites: {contains: ["global"]}, draft: {ne: true}}
+    ) {
         totalCount
         edges {
             node {
@@ -195,7 +197,10 @@ query {
     }
     events: allArticle(
         limit: 5, sortBy: "date", order: ASC,
-        filter: {category: {eq: "events"}, has_date: {eq: true}, days_ago: {lte: 0}, draft: {ne: true}}
+        filter: {
+            category: {eq: "events"}, subsites: {contains: ["global"]}, has_date: {eq: true}, days_ago: {lte: 0},
+            draft: {ne: true}
+        }
     ) {
         totalCount
         edges {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -117,7 +117,7 @@ export default {
         latest() {
             let latest = {};
             for (let category of ["blog", "news", "events", "careers"]) {
-                latest[category] = this.$page[category].edges.map((edge) => articleToItem(edge.node));
+                latest[category] = this.$page[category].edges.map((edge) => edge.node);
             }
             return latest;
         },
@@ -144,25 +144,6 @@ export default {
         document.head.appendChild(altmetricScript);
     },
 };
-/** Convert an Article to an "item", with the title, link, and tease fields expected by ItemListBrief. */
-function articleToItem(article) {
-    let item = {
-        id: article.id,
-        title: article.title,
-        link: article.external_url || article.path,
-        tease: article.tease || "",
-    };
-    if (article.date) {
-        item.tease = `*${article.date}.* ${item.tease}`;
-    }
-    if (article.location) {
-        item.tease += ` ${article.location} `;
-    }
-    if (article.closes) {
-        item.tease += ` *Apply by ${article.closes}.*`;
-    }
-    return item;
-}
 </script>
 
 <page-query>


### PR DESCRIPTION
Accidentally left the homepage showing news and events from all subsites, instead of just `global`.

This also hides and deduplicates some of the logic for showing Articles in a HomeCard.