### PR TITLE
Implement usegalaxy.eu middle pane

### DIFF
--- a/content/eu/data-policy.md
+++ b/content/eu/data-policy.md
@@ -1,0 +1,7 @@
+---
+title: Our Data Policy
+---
+
+| Registered Users | Unregistered Users | FTP Data | GDPR Compliance |
+|------------------|--------------------|----------|-----------------|
+| User data on UseGalaxy.eu (i.e. datasets, histories) will be available as long as they are not deleted by the user. Once marked as deleted the datasets will be permanently removed within 14 days. If the user "purges" the dataset in the Galaxy, it will be removed immediately, permanently. An [extended quota can be requested](https://docs.google.com/forms/d/e/1FAIpQLSf9w2MOS6KOlu9XdhRSDqWnCDkzoVBqHJ3zH_My4p8D8ZgkIQ/viewform){: target="_blank"} for a limited time period in special cases. | Processed data will only be accessible during one browser session, using a cookie to identify your data. This cookie is not used for any other purposes (e.g. tracking or analytics). If UseGalaxy.eu service is not accessed for 90 days, those datasets will be permanently deleted. | Any user data uploaded to our [FTP server](https://galaxyproject.eu/ftp/) should be imported into Galaxy as soon as possible. Data left in FTP folders for more than 3 months, will be deleted. | The Galaxy service complies with the EU General Data Protection Regulation (GDPR). You can read more about this on our [Terms and Conditions](https://usegalaxy.eu/terms/). |

--- a/content/footers/eu.md
+++ b/content/footers/eu.md
@@ -1,0 +1,9 @@
+<div class="text-center">
+
+UseGalaxy.eu is maintained largely by the [Freiburg Galaxy Team](/freiburg/) but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.  
+For **acknowledgement**, please refer to the [About](/about) section.
+All content on this site is available under [CC0-1.0](https://creativecommons.org/share-your-work/public-domain/cc0/) unless otherwise specified.
+
+[contact@usegalaxy.eu](mailto:contact@usegalaxy.eu){: .fa .fa-envelope} [usegalaxy-eu](https://github.com/usegalaxy-eu){: .fab .fa-github} [@galaxyproject](https://twitter.com/galaxyproject){: .fab .fa-twitter} [Subscribe via RSS (UseGalaxy.eu Feed)](/feed.xml){: .fa .fa-rss}
+
+</div>

--- a/content/footers/eu.md
+++ b/content/footers/eu.md
@@ -1,9 +1,9 @@
-<div class="text-center">
+<div class="text-center" style="font-family: arial, helvetica, sans-serif">
 
 UseGalaxy.eu is maintained largely by the [Freiburg Galaxy Team](/freiburg/) but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.  
 For **acknowledgement**, please refer to the [About](/about) section.
 All content on this site is available under [CC0-1.0](https://creativecommons.org/share-your-work/public-domain/cc0/) unless otherwise specified.
 
-[contact@usegalaxy.eu](mailto:contact@usegalaxy.eu){: .fa .fa-envelope} [usegalaxy-eu](https://github.com/usegalaxy-eu){: .fab .fa-github} [@galaxyproject](https://twitter.com/galaxyproject){: .fab .fa-twitter} [Subscribe via RSS (UseGalaxy.eu Feed)](/feed.xml){: .fa .fa-rss}
+[](){: .fa .fa-envelope style="color: #777"} [contact@usegalaxy.eu](mailto:contact@usegalaxy.eu) &nbsp; [](){: .fab .fa-github style="color: #777"} [usegalaxy-eu](https://github.com/usegalaxy-eu) &nbsp; [](){: .fab .fa-twitter style="color: #777"} [@galaxyproject](https://twitter.com/galaxyproject) &nbsp; [](){: .fa .fa-rss style="color: #777"} Subscribe [via RSS (UseGalaxy.eu Feed)](/feed.xml)
 
 </div>

--- a/content/hosted/usegalaxy-eu/jobs.md
+++ b/content/hosted/usegalaxy-eu/jobs.md
@@ -1,0 +1,1 @@
+<iframe style="border: 0px" width="100%" height="150px" src="https://stats.galaxyproject.eu/d-solo/000000034/jobs-dashboard?orgId=1&refresh=1m&panelId=1"></iframe>

--- a/content/hosted/usegalaxy-eu/main/jumbotron.md
+++ b/content/hosted/usegalaxy-eu/main/jumbotron.md
@@ -1,0 +1,1 @@
+[![The Galaxy Community Conference is an annual gathering of the Galaxy community includes training, talks, posters, demos, Birds of a Feather meetups, and many other opportunities for collaboration and networking.](/images/events/gcc2022/gcc2022-key-dates.png)](/events/gcc2022/)

--- a/content/hosted/usegalaxy-eu/main/main.md
+++ b/content/hosted/usegalaxy-eu/main/main.md
@@ -1,0 +1,5 @@
+---
+title: Galaxy Europe
+---
+
+"Anyone, anywhere in the world should have free, unhindered access to not just my research, but to the research of every great and enquiring mind across the spectrum of human understanding." – Prof. Stephen Hawking

--- a/content/hosted/usegalaxy-eu/notices/ukraine.md
+++ b/content/hosted/usegalaxy-eu/notices/ukraine.md
@@ -1,0 +1,11 @@
+---
+title: Peace to Ukraine!
+display: danger # one of [success, info, warning, danger]
+order: 1
+---
+
+🇺🇦 The global community has created a [continuously updated list](https://bit.ly/ua-table){:target="_blank"} of laboratories that can host Ukrainian scientists at all career levels. If your lab can host a scientist -- add your name to the list [here](https://bit.ly/ua-form){:target="_blank"}. In addition, Galaxy Project has a number of positions at its EU and US sites. Contact us at Contact us at [ukraine@galaxyproject.org](mailto:ukraine@galaxyproject.org). German organisations are organising accommodation [here](https://elinor.network/gastfreundschaft-ukraine/){:target="_blank"}.
+
+Світова наукова спільнота створила [список лабораторій](https://bit.ly/ua-table){:target="_blank"}, що постійно оновлюється та які можуть прийняти українських науковців усіх рівнів, у тому числі й аспірантів. Якщо ваша лабораторія має можливість запросити -- ви можете додати ваше ім’я до списку тут. Окрім того, Galaxy Project має відкриті вакансії у своīх європейських та американських осередках. Пишіть нам на [ukraine@galaxyproject.org](mailto:ukraine@galaxyproject.org)
+
+Научное сообщество создало постоянно обновляемый [список лабораторий](https://bit.ly/ua-table){:target="_blank"}, которые могут принять украинских ученых (включая аспирантов). К тому же, Galaxy Project имеет открытые позиции на своих европейских и американских сайтах.  Контактируйте нас используя [ukraine@galaxyproject.org](mailto:ukraine@galaxyproject.org) 🇺🇦

--- a/src/pages/hosted/usegalaxy-eu/Main.vue
+++ b/src/pages/hosted/usegalaxy-eu/Main.vue
@@ -1,0 +1,171 @@
+<template>
+    <div>
+        <main id="maincontainer" class="container">
+            <section id="notices" v-if="notices.length > 0">
+                <div v-for="notice of notices" :key="notice.order" :class="notice.classes">
+                    <h4 v-if="notice.title" class="title">{{ notice.title }}</h4>
+                    <div class="markdown" v-html="notice.content" />
+                </div>
+            </section>
+            <section id="jumbotron" class="col-sm-7" v-if="hasJumbotron">
+                <h3 v-if="$page.jumbotron.title" class="title text-center">{{ $page.jumbotron.title }}</h3>
+                <div class="markdown" v-html="$page.jumbotron.content" />
+            </section>
+            <section class="markdown" v-html="$page.main.content" />
+            <section class="posts row">
+                <HomeCard title="News" link="/news/" icon="fas fa-bullhorn" :items="latest.news" />
+                <HomeCard title="Events" link="/events/" icon="far fa-calendar-alt" :items="latest.events" />
+            </section>
+            <section class="jobs row" v-if="$page.jobs" v-html="$page.jobs.content" />
+            <section class="data-policy" v-if="$page.dataPolicy">
+                <h3 v-if="$page.dataPolicy.title" class="title">{{ $page.dataPolicy.title }}</h3>
+                <div class="markdown" v-html="$page.dataPolicy.content" />
+            </section>
+            <footer class="footer" v-if="$page.footer" v-html="$page.footer.content" />
+        </main>
+    </div>
+</template>
+
+<script>
+import HomeCard from "@/components/HomeCard";
+export default {
+    components: {
+        HomeCard,
+    },
+    metaInfo() {
+        return {
+            title: this.$page.main.title,
+        };
+    },
+    computed: {
+        latest() {
+            return {
+                news: this.$page.news.edges.map((edge) => edge.node),
+                events: this.$page.events.edges.map((edge) => edge.node),
+            };
+        },
+        notices() {
+            let notices = [];
+            let i = 1;
+            for (let edge of this.$page.notices.edges) {
+                let node = edge.node;
+                let notice = {
+                    title: node.title,
+                    order: node.order || 1000 * i,
+                    content: node.content,
+                };
+                notice.classes = ["alert"];
+                if (node.display) {
+                    notice.classes.push("alert-" + node.display);
+                }
+                notices.push(notice);
+            }
+            notices.sort((node1, node2) => node1.order > node2.order);
+            return notices;
+        },
+        hasJumbotron() {
+            return this.$page.jumbotron && this.$page.jumbotron.content.trim();
+        },
+    },
+};
+</script>
+
+<page-query>
+query {
+    notices: allInsert(filter: {path: {regex: "^/insert:/hosted/usegalaxy-eu/notices/[^/]+/$"}}) {
+        totalCount
+        edges {
+            node {
+                id
+                path
+                title
+                display
+                order
+                content
+            }
+        }
+    }
+    main: insert(path: "/insert:/hosted/usegalaxy-eu/main/main/") {
+        id
+        title
+        content
+        fileInfo {
+            path
+        }
+    }
+    jumbotron: insert(path: "/insert:/hosted/usegalaxy-eu/main/jumbotron/") {
+        id
+        title
+        content
+    }
+    jobs: insert(path: "/insert:/hosted/usegalaxy-eu/jobs/") {
+        id
+        title
+        content
+    }
+    dataPolicy: insert(path: "/insert:/eu/data-policy/") {
+        id
+        title
+        content
+    }
+    footer: insert(path: "/insert:/hosted/usegalaxy-eu/main/footer/") {
+        id
+        title
+        content
+    }
+    news: allArticle(
+        limit: 5, filter: {category: {eq: "news" }, subsites: {contains: ["eu"]}, draft: {ne: true}}
+    ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+            }
+        }
+    }
+    events: allArticle(
+        limit: 5, sortBy: "date", order: ASC,
+        filter: {
+            category: {eq: "events"}, subsites: {contains: ["eu"]}, has_date: {eq: true}, days_ago: {lte: 0},
+            draft: {ne: true}
+        }
+    ) {
+        totalCount
+        edges {
+            node {
+                ...articleFields
+                date (format: "MMM D")
+            }
+        }
+    }
+}
+fragment articleFields on Article {
+    id
+    title
+    tease
+    external_url
+    path
+}
+</page-query>
+
+<style lang="scss">
+@import "~/assets/styles.scss";
+
+#maincontainer {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    a:not(.btn) {
+        color: $brand-primary;
+    }
+    a:hover {
+        text-decoration: underline;
+    }
+}
+
+.title {
+    font-weight: bold;
+}
+#maincontainer > section {
+    margin-bottom: 10px;
+}
+</style>

--- a/src/pages/hosted/usegalaxy-eu/Main.vue
+++ b/src/pages/hosted/usegalaxy-eu/Main.vue
@@ -21,9 +21,9 @@
                 <h3 v-if="$page.dataPolicy.title" class="title">{{ $page.dataPolicy.title }}</h3>
                 <div class="markdown" v-html="$page.dataPolicy.content" />
             </section>
-            <section class="footer" v-if="$page.footer" v-html="$page.footer.content" />
-            <footer class="footer" v-if="$page.siteFooter" v-html="$page.siteFooter.content" />
+            <section class="footer row" v-if="$page.footer" v-html="$page.footer.content" />
         </main>
+        <footer id="site-footer" v-if="$page.siteFooter" v-html="$page.siteFooter.content" />
     </div>
 </template>
 
@@ -157,21 +157,25 @@ fragment articleFields on Article {
 <style lang="scss">
 @import "~/assets/styles.scss";
 
+a:not(.btn) {
+    color: $brand-primary;
+}
+a:hover {
+    text-decoration: underline;
+}
+
 #maincontainer {
     padding-top: 1rem;
     padding-bottom: 1rem;
-    a:not(.btn) {
-        color: $brand-primary;
-    }
-    a:hover {
-        text-decoration: underline;
-    }
-}
-
-.title {
-    font-weight: bold;
 }
 #maincontainer > section {
     margin-bottom: 10px;
+}
+.title {
+    font-weight: bold;
+}
+.fa,
+.fab {
+    font-size: 125%;
 }
 </style>

--- a/src/pages/hosted/usegalaxy-eu/Main.vue
+++ b/src/pages/hosted/usegalaxy-eu/Main.vue
@@ -21,7 +21,8 @@
                 <h3 v-if="$page.dataPolicy.title" class="title">{{ $page.dataPolicy.title }}</h3>
                 <div class="markdown" v-html="$page.dataPolicy.content" />
             </section>
-            <footer class="footer" v-if="$page.footer" v-html="$page.footer.content" />
+            <section class="footer" v-if="$page.footer" v-html="$page.footer.content" />
+            <footer class="footer" v-if="$page.siteFooter" v-html="$page.siteFooter.content" />
         </main>
     </div>
 </template>
@@ -109,6 +110,11 @@ query {
         content
     }
     footer: insert(path: "/insert:/hosted/usegalaxy-eu/main/footer/") {
+        id
+        title
+        content
+    }
+    siteFooter: insert(path: "/insert:/footers/eu/") {
         id
         title
         content


### PR DESCRIPTION
This replicates the middle pane of usegalaxy.eu, currently hosted by the EU Hub at https://usegalaxy-eu.github.io/galaxy/

I decided on the path `/hosted/usegalaxy-eu/main/`, so we can host the other EU middle panes under `/hosted/usegalaxy-eu/` and the usegalaxy.org middle pane under `/hosted/usegalaxy-org/`.

The only thing missing is the carousel, which we're probably replacing anyway.

Also I just couldn't get the footer to be flush with the bottom of the page, so I omitted the `background-color` since that highlighted the gap.