### PR TITLE
Fix malformed Youtube embed in some Dev Roundtable pages.

### DIFF
--- a/content/events/2021-05-27-dev-roundtable/index.md
+++ b/content/events/2021-05-27-dev-roundtable/index.md
@@ -20,8 +20,7 @@ subsites: [global, us]
 ---
 
 <div class="video-variable">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/b35qKpahQYw" frameborder="0" allow="accelerome
-ter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/b35qKpahQYw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <br />
 

--- a/content/events/2021-06-10-dev-roundtable/index.md
+++ b/content/events/2021-06-10-dev-roundtable/index.md
@@ -18,8 +18,7 @@ subsites: [global, us]
 ---
 
 <div class="video-variable">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/3e71DFg3gsw" frameborder="0" allow="accelerome
-ter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/3e71DFg3gsw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <br />
 

--- a/content/events/2021-07-22-dev-roundtable/index.md
+++ b/content/events/2021-07-22-dev-roundtable/index.md
@@ -18,8 +18,7 @@ subsites: [global, us]
 ---
 
 <div class="video-variable">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/n2uwDaU-L8s" frameborder="0" allow="accelerome
-ter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/n2uwDaU-L8s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <br />
 

--- a/content/events/2021-08-19-dev-roundtable/index.md
+++ b/content/events/2021-08-19-dev-roundtable/index.md
@@ -20,8 +20,7 @@ subsites: [global, us]
 ---
 
 <div class="video-variable">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/DkGrrbaTPN8" frameborder="0" allow="accelerome
-ter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/DkGrrbaTPN8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <br />
 

--- a/content/events/2021-10-28-dev-roundtable/index.md
+++ b/content/events/2021-10-28-dev-roundtable/index.md
@@ -20,8 +20,7 @@ subsites: [global, us]
 ---
 
 <div class="video-variable">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/o3GZBfdKu8A" frameborder="0" allow="accelerome
-ter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/o3GZBfdKu8A" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <br />
 


### PR DESCRIPTION
Looks like there's an accidental newline breaking up an attribute string.