### PR TITLE
Move Gitter chat embed from index.html to its own component.

### DIFF
--- a/src/components/Gitter.vue
+++ b/src/components/Gitter.vue
@@ -1,4 +1,5 @@
 <template>
+    <div></div>
 </template>
 
 <script>

--- a/src/components/Gitter.vue
+++ b/src/components/Gitter.vue
@@ -1,0 +1,14 @@
+<script>
+// This is in a component instead of a function so that static pages can use it by embedding it in their Markdown.
+export default {
+    mounted() {
+        ((window.gitter = {}).chat = {}).options = { room: "galaxyproject/Lobby" };
+        let head = document.querySelector("html > head");
+        let script = document.createElement("script");
+        script.async = true;
+        script.defer = true;
+        script.src = "https://sidecar.gitter.im/dist/sidecar.v1.js";
+        head.appendChild(script);
+    },
+}
+</script>

--- a/src/components/Gitter.vue
+++ b/src/components/Gitter.vue
@@ -1,3 +1,6 @@
+<template>
+</template>
+
 <script>
 // This is in a component instead of a function so that static pages can use it by embedding it in their Markdown.
 export default {

--- a/src/components/Gitter.vue
+++ b/src/components/Gitter.vue
@@ -1,18 +1,23 @@
 <template>
-    <div></div>
+    <div class="gitter-embed-body"></div>
 </template>
 
 <script>
 // This is in a component instead of a function so that static pages can use it by embedding it in their Markdown.
+function addGitter(window) {
+    ((window.gitter = {}).chat = {}).options = { room: "galaxyproject/Lobby" };
+    let body = document.querySelector("html > body");
+    let script = document.createElement("script");
+    script.async = true;
+    script.defer = true;
+    script.src = "https://sidecar.gitter.im/dist/sidecar.v1.js";
+    body.appendChild(script);
+}
 export default {
     mounted() {
-        ((window.gitter = {}).chat = {}).options = { room: "galaxyproject/Lobby" };
-        let head = document.querySelector("html > head");
-        let script = document.createElement("script");
-        script.async = true;
-        script.defer = true;
-        script.src = "https://sidecar.gitter.im/dist/sidecar.v1.js";
-        head.appendChild(script);
+        if (!window.gitter) {
+            addGitter(window);
+        }
     },
 };
 </script>

--- a/src/components/Gitter.vue
+++ b/src/components/Gitter.vue
@@ -10,5 +10,5 @@ export default {
         script.src = "https://sidecar.gitter.im/dist/sidecar.v1.js";
         head.appendChild(script);
     },
-}
+};
 </script>

--- a/src/index.html
+++ b/src/index.html
@@ -2,12 +2,6 @@
 <html ${htmlAttrs}>
     <head>
         ${head}
-        <script>
-            ((window.gitter = {}).chat = {}).options = {
-                room: "galaxyproject/Lobby",
-            };
-        </script>
-        <script async defer src="https://sidecar.gitter.im/dist/sidecar.v1.js"></script>
     </head>
     <body ${bodyAttrs}>
         ${app} ${scripts}

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -9,17 +9,20 @@
         <footer class="static-footer" v-if="$static.footer">
             <div class="markdown container" v-html="$static.footer.content" />
         </footer>
+        <Gitter />
     </div>
 </template>
 
 <script>
 import NavBar from "@/components/NavBar";
+import Gitter from "@/components/Gitter";
 import { getSingleKey } from "~/utils.js";
 import CONFIG from "~/../config.json";
 const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
 export default {
     components: {
         NavBar,
+        Gitter,
     },
     props: {
         subsite: { type: String, required: false, default: ROOT_SUBSITE },


### PR DESCRIPTION
This moves the Gitter chat embed out of the global index.html, so that we can avoid having it in certain pages (like BareArticles).

This addresses the double-gitter embed issue with #1365. Now, the BareArticle won't have it by default, so it won't appear in the inner BareArticle iframe (the news/events). But we *do* want it in the outer BareArticle, which can be done by including the `<Gitter />` component in its Markdown.

I think this avoids the race condition from #806, since it manually loads the Gitter JS only after setting the needed global variables. But it could certainly stand a second pair of eyes.