### PR TITLE
Add Gitter chat back to usegalaxy.eu middle pane.

### DIFF
--- a/content/bare/usegalaxy-eu/main/index.md
+++ b/content/bare/usegalaxy-eu/main/index.md
@@ -1,7 +1,5 @@
 ---
 title: Galaxy Europe
-main_subsite: eu
-show_footer: true
 ---
 
 <slot name="/bare/usegalaxy-eu/notices" />
@@ -22,3 +20,6 @@ show_footer: true
 <footer>
 <slot name="/footers/eu" />
 </footer>
+
+import Gitter from "@/components/Gitter";
+<Gitter />


### PR DESCRIPTION
Use #1367 to add Gitter chat to `/bare/usegalaxy-eu/main/` (but not its iframe).