### PR TITLE
Scope link color style in /bare/eu/latest/.

### DIFF
--- a/src/pages/bare/eu/Latest.vue
+++ b/src/pages/bare/eu/Latest.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <section class="posts row">
+        <section class="latest-posts row">
             <HomeCard title="News" link="/news/" icon="fas fa-bullhorn" :width="6" :items="latest.news" />
             <HomeCard title="Events" link="/events/" icon="far fa-calendar-alt" :width="6" :items="latest.events" />
         </section>
@@ -68,15 +68,14 @@ fragment articleFields on Article {
 <style lang="scss">
 @import "~/assets/styles.scss";
 
-a:not(.btn) {
-    color: $brand-primary;
-}
-a:hover {
-    text-decoration: underline;
-}
-
-.posts {
+.latest-posts {
     margin-left: 0;
     width: 100%;
+    a:not(.btn) {
+        color: $brand-primary;
+    }
+    a:hover {
+        text-decoration: underline;
+    }
 }
 </style>


### PR DESCRIPTION
Lack of `scoped` property on the `<style>` was causing the `<a>` font color to be global. This made, for example, the Gitter chat button text blue in Chrome.