### PR TITLE
Make hamburger menu on mobile NavBar more visible.

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -166,7 +166,7 @@ function getPath(page) {
 }
 </script>
 
-<style>
+<style scoped>
 #subsite-name {
     display: flex;
     align-items: center;
@@ -182,5 +182,9 @@ function getPath(page) {
 }
 #search-input {
     width: 175px;
+}
+/* Prevent hamburger menu from disappearing into a dark background in mobile mode (#1363). */
+.navbar-toggler {
+    background-color: rgba(255, 255, 255, 0.5);
 }
 </style>


### PR DESCRIPTION
It could be improved aesthetically, but this addresses the issue (#1363) and should work on any background color a subsite chooses (it uses transparency).

![image](https://user-images.githubusercontent.com/645773/167912527-fb562ea6-145f-43a8-9ef4-b33e4efb6921.png)

Fixes #1363.