### PR TITLE
Better fix for hamburger button visibility.

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="classes" :style="style">
-        <b-navbar class="container justify-content-center" toggleable="lg" variant="transparent">
+        <b-navbar class="container justify-content-center" toggleable="lg" :type="theme" variant="transparent">
             <b-navbar-brand to="/">
                 <img id="masthead-logo" :src="logoUrl" alt="Galaxy Community Hub" height="30" />
             </b-navbar-brand>
@@ -114,6 +114,13 @@ export default {
             subsitesLinks.sort((a, b) => a.order > b.order);
             return subsitesLinks;
         },
+        theme() {
+            if (CONFIG.subsites.metadata[this.subsite]?.lightBg) {
+                return "light";
+            } else {
+                return "dark";
+            }
+        },
         classes() {
             let classes = [];
             if (CONFIG.subsites.metadata[this.subsite]?.lightBg) {
@@ -182,9 +189,5 @@ function getPath(page) {
 }
 #search-input {
     width: 175px;
-}
-/* Prevent hamburger menu from disappearing into a dark background in mobile mode (#1363). */
-.navbar-toggler {
-    background-color: rgba(255, 255, 255, 0.5);
 }
 </style>


### PR DESCRIPTION
A much better fix than #1378 for #1363.

Uses the native `type` property of `<b-navbar>` to set the theme to dark or light, based on subsite metadata (`lightBg`). This results in a hamburger button that perfectly fits in:

![image](https://user-images.githubusercontent.com/645773/167922206-5e56e90d-6c53-43fc-9d14-dd02406aee8d.png)
![image](https://user-images.githubusercontent.com/645773/167922440-d720c3a2-5081-407d-bfbb-b884bb0157cb.png)
