### PR TITLE
Add fontawesome shim for compatibility

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -45,6 +45,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "~@fortawesome/fontawesome-free/scss/solid.scss";
 @import "~@fortawesome/fontawesome-free/scss/regular.scss";
 @import "~@fortawesome/fontawesome-free/scss/brands.scss";
+@import "~@fortawesome/fontawesome-free/scss/v4-shims.scss";
 
 @import "overrides.scss";
 


### PR DESCRIPTION
@NickSto This is what I mentioned; the shim works for maintaining compatibiltiy when importing and we can update selections over time.