### PR TITLE
Fix to left side of latest posts BareArticle getting cut off.

### DIFF
--- a/src/pages/bare/eu/Latest.vue
+++ b/src/pages/bare/eu/Latest.vue
@@ -68,7 +68,7 @@ fragment articleFields on Article {
 <style lang="scss">
 @import "~/assets/styles.scss";
 
-.latest-posts {
+section.latest-posts {
     margin-left: 0;
     width: 100%;
     a:not(.btn) {


### PR DESCRIPTION
Make our CSS rule take precedence.
Before it was at the same level as bootstrap's.
\- Depended on who got loaded last, which changes between develop/build.