### PR TITLE
Simplify homepages and deduplicate code between main & subsite homepages

### DIFF
--- a/content/belgium/cards.md
+++ b/content/belgium/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/belgium/lead.md
+++ b/content/belgium/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/belgium/main.md
+++ b/content/belgium/main.md
@@ -3,17 +3,3 @@ title: Galaxy VIB
 subtitle: The homepage of the VIB Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/content/cards.md
+++ b/content/cards.md
@@ -1,5 +1,5 @@
 ---
-cards:
+list:
 - name: news
   type: dynamic
   title: News

--- a/content/elixir-it/cards.md
+++ b/content/elixir-it/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/elixir-it/lead.md
+++ b/content/elixir-it/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/elixir-it/main.md
+++ b/content/elixir-it/main.md
@@ -3,17 +3,3 @@ title: Galaxy ELIXIR-IT/Laniakea
 subtitle: The homepage of the ELIXIR-IT/Laniakea Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/content/erasmusmc/cards.md
+++ b/content/erasmusmc/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/erasmusmc/lead.md
+++ b/content/erasmusmc/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/erasmusmc/main.md
+++ b/content/erasmusmc/main.md
@@ -3,17 +3,3 @@ title: Galaxy Erasmus MC
 subtitle: The homepage of the Erasmus MC Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/content/eu/cards.md
+++ b/content/eu/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/eu/twitter-card.md
+++ b/content/eu/twitter-card.md
@@ -1,0 +1,8 @@
+---
+title: "@galaxyproject"
+icon: fab fa-twitter
+link: https://twitter.com/galaxyproject
+---
+
+<a class="twitter-timeline" href="https://twitter.com/galaxyproject" data-dnt="true" height="400" data-chrome="noheader nofooter noscrollbar noborders transparent" data-widget-id="384667676347363329" aria-label="GalaxyProject Twitter"></a>
+

--- a/content/freiburg/cards.md
+++ b/content/freiburg/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/freiburg/lead.md
+++ b/content/freiburg/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/freiburg/main.md
+++ b/content/freiburg/main.md
@@ -3,17 +3,3 @@ title: Galaxy Freiburg
 subtitle: The homepage of the Freiburg Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/content/genouest/cards.md
+++ b/content/genouest/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/genouest/lead.md
+++ b/content/genouest/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/genouest/main.md
+++ b/content/genouest/main.md
@@ -3,17 +3,3 @@ title: Galaxy GenOuest
 subtitle: The homepage of the GenOuest Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/content/homecards.md
+++ b/content/homecards.md
@@ -1,0 +1,32 @@
+---
+cards:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: blog
+  type: dynamic
+  title: Blog
+  link: /blog/
+  icon: fas fa-pencil-alt
+- name: careers
+  type: dynamic
+  title: Careers
+  link: /careers/
+  icon: fas fa-user-astronaut
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/ifb/cards.md
+++ b/content/ifb/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/ifb/lead.md
+++ b/content/ifb/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/ifb/main.md
+++ b/content/ifb/main.md
@@ -3,17 +3,3 @@ title: Galaxy ELIXIR-FR/IFB
 subtitle: The homepage of the ELIXIR-FR/IFB Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/content/main.md
+++ b/content/main.md
@@ -3,4 +3,3 @@ title: Welcome to the Galaxy Community Hub
 subtitle: The meeting point where you can find curated documentation for all things Galaxy
 ---
 
-

--- a/content/pasteur/cards.md
+++ b/content/pasteur/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/pasteur/lead.md
+++ b/content/pasteur/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/pasteur/main.md
+++ b/content/pasteur/main.md
@@ -3,17 +3,3 @@ title: Galaxy Pasteur
 subtitle: The homepage of the Pasteur Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/content/us/cards.md
+++ b/content/us/cards.md
@@ -1,0 +1,22 @@
+---
+list:
+- name: news
+  type: dynamic
+  title: News
+  link: /news/
+  icon: fas fa-bullhorn
+- name: events
+  type: dynamic
+  title: Events
+  link: /events/
+  icon: far fa-calendar-alt
+- name: twitter
+  type: static
+- name: videos
+  type: static
+- name: platforms
+  type: static
+- name: pubs
+  type: static
+  width: 2
+---

--- a/content/us/lead.md
+++ b/content/us/lead.md
@@ -1,0 +1,15 @@
+
+**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
+
+- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
+- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
+- **manage data** by sharing and publishing results, workflows, and visualizations.
+- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
+
+The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+
+<div class="row justify-content-center">
+  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+    Get Started: First Steps with Galaxy
+  </a>
+</div>

--- a/content/us/main.md
+++ b/content/us/main.md
@@ -3,17 +3,3 @@ title: Galaxy US
 subtitle: The homepage of the US Galaxy community
 ---
 
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
-
-<div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
-    Get Started: First Steps with Galaxy
-  </a>
-</div>

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -371,6 +371,7 @@ module.exports = function (api) {
                     context: {
                         subsite: subsite,
                         insertRegex: `^/insert:${prefix}${path}[^/]+/$`,
+                        cardsPath: `/insert:${prefix}${path}cards/`,
                         mainPath: `/insert:${prefix}${path}main/`,
                         footerPath: `/insert:${prefix}${path}footer/`,
                     },

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -370,10 +370,9 @@ module.exports = function (api) {
                     component: `./src/components/pages/${vueName}.vue`,
                     context: {
                         subsite: subsite,
+                        insertRegex: `^/insert:${prefix}${path}[^/]+/$`,
                         mainPath: `/insert:${prefix}${path}main/`,
-                        jumboPath: `/insert:${prefix}${path}jumbotron/`,
-                        leadPath: `/insert:${prefix}${path}lead/`,
-                        extraPath: `/insert:${prefix}${path}extra/`,
+                        footerPath: `/insert:${prefix}${path}footer/`,
                     },
                 });
             }

--- a/src/components/HomeCard.vue
+++ b/src/components/HomeCard.vue
@@ -1,9 +1,10 @@
 <template>
     <div :class="['pseudo-card', `col-sm-${width}`]">
-        <h2>
-            <g-link :to="link"
-                ><span :class="`icon ${icon}`"></span><b>{{ title }}</b></g-link
-            >
+        <h2 class="title">
+            <g-link :to="link">
+                <span :class="`icon ${icon}`"></span>
+                {{ title }}
+            </g-link>
         </h2>
         <ItemListBrief v-for="(item, i) in items" :key="item.id || i" :item="item" />
         <div class="markdown content" v-if="content" v-html="content" />
@@ -36,8 +37,11 @@ export default {
     border: 4px solid white;
     border-radius: 8px;
 }
-h2 .icon {
-    margin-right: 0.7em;
+.title .icon {
+    margin-right: 0.4em;
+}
+.title {
+    font-weight: normal;
 }
 .content.markdown::v-deep p {
     font-size: 80%;

--- a/src/components/HomeTop.vue
+++ b/src/components/HomeTop.vue
@@ -28,7 +28,7 @@ export default {
                 return 12;
             }
         },
-    }
+    },
 };
 </script>
 

--- a/src/components/HomeTop.vue
+++ b/src/components/HomeTop.vue
@@ -1,0 +1,42 @@
+<template>
+    <div id="top-content" class="row">
+        <section id="lead" v-if="hasContent(lead)" :class="`col-sm-${topWidth}`">
+            <div class="lead markdown" v-html="lead.content" />
+        </section>
+        <section id="jumbotron" v-if="hasContent(jumbotron)" :class="`col-sm-${topWidth}`">
+            <h3 v-if="jumbotron.title" class="title text-center">{{ jumbotron.title }}</h3>
+            <div class="text-center markdown" v-html="jumbotron.content" />
+        </section>
+    </div>
+</template>
+
+<script>
+import { hasContent } from "~/utils.js";
+export default {
+    props: {
+        lead: { type: Object, required: false, default: null },
+        jumbotron: { type: Object, required: false, default: null },
+    },
+    methods: {
+        hasContent,
+    },
+    computed: {
+        topWidth() {
+            if (hasContent(this.lead) && hasContent(this.jumbotron)) {
+                return 6;
+            } else {
+                return 12;
+            }
+        },
+    }
+};
+</script>
+
+<style scoped>
+#top-content {
+    margin-bottom: 40px;
+}
+#jumbotron .title {
+    font-weight: bold;
+}
+</style>

--- a/src/components/pages/News.vue
+++ b/src/components/pages/News.vue
@@ -25,7 +25,7 @@ export default {
 </script>
 
 <page-query>
-query($subsite: String, $mainPath: String, $footerPath: String) {
+query($subsite: String, $mainPath: String) {
     main: insert(path: $mainPath) {
         id
         title
@@ -33,11 +33,6 @@ query($subsite: String, $mainPath: String, $footerPath: String) {
         fileInfo {
             path
         }
-    }
-    footer: insert(path: $footerPath) {
-        id
-        title
-        content
     }
     articles: allArticle(
             sortBy: "date", order: DESC, filter: {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -74,7 +74,6 @@ import {
     addTwitterWidget,
     addAltmetrics,
 } from "~/utils.js";
-const ROW_WIDTH = 3;
 export default {
     components: {
         HomeTop,
@@ -94,7 +93,7 @@ export default {
     },
     computed: {
         cardRows() {
-            return makeCardRows(this.$page.homecards.cards, this.latest, this.cards, ROW_WIDTH);
+            return makeCardRows(this.$page.cards.list, this.latest, this.cards);
         },
     },
     mounted() {
@@ -112,9 +111,9 @@ export default {
 
 <page-query>
 query {
-    homecards: insert(path: "/insert:/homecards/") {
+    cards: insert(path: "/insert:/cards/") {
         id
-        cards {
+        list {
             name
             type
             title

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -44,48 +44,16 @@
             />
         </b-row>
 
-        <div class="row">
-            <HomeCard title="News" link="/news/" icon="fas fa-bullhorn" :items="latest.news" />
-            <HomeCard title="Events" link="/events/" icon="far fa-calendar-alt" :items="latest.events" />
+        <div class="row" v-for="(cardRow, i) of cardRows" :key="i">
             <HomeCard
-                v-if="cards.twitter"
-                :title="cards.twitter.title"
-                :link="cards.twitter.link"
-                :icon="cards.twitter.icon"
-                :content="cards.twitter.content"
-            />
-        </div>
-
-        <div class="row">
-            <HomeCard
-                v-if="cards.videos"
-                :title="cards.videos.title"
-                :link="cards.videos.link"
-                :icon="cards.videos.icon"
-                :content="cards.videos.content"
-                :items="cards.videos.items"
-            />
-            <HomeCard title="Blog" link="/blog/" icon="fas fa-pencil-alt" :items="latest.blog" />
-            <HomeCard title="Careers" link="/careers/" icon="fas fa-user-astronaut" :items="latest.careers" />
-        </div>
-
-        <div class="row">
-            <HomeCard
-                v-if="cards.platforms"
-                :title="cards.platforms.title"
-                :link="cards.platforms.link"
-                :icon="cards.platforms.icon"
-                :content="cards.platforms.content"
-                :items="cards.platforms.items"
-            />
-            <HomeCard
-                v-if="cards.pubs"
-                :title="cards.pubs.title"
-                :link="cards.pubs.link"
-                :icon="cards.pubs.icon"
-                :content="cards.pubs.content"
-                :items="cards.pubs.items"
-                :width="8"
+                v-for="(card, j) of cardRow"
+                :key="j"
+                :title="card.title"
+                :link="card.link"
+                :icon="card.icon"
+                :width="card.width"
+                :items="card.items"
+                :content="card.content"
             />
         </div>
 
@@ -97,7 +65,16 @@
 import HomeTop from "@/components/HomeTop";
 import HomeCard from "@/components/HomeCard";
 import HomeProfile from "@/components/HomeProfile.vue";
-import { hasContent, gatherCollections, gatherInserts, gatherCards, addTwitterWidget, addAltmetrics } from "~/utils.js";
+import {
+    hasContent,
+    gatherCollections,
+    gatherInserts,
+    gatherCards,
+    makeCardRows,
+    addTwitterWidget,
+    addAltmetrics,
+} from "~/utils.js";
+const ROW_WIDTH = 3;
 export default {
     components: {
         HomeTop,
@@ -113,10 +90,11 @@ export default {
     created() {
         this.inserts = gatherInserts(this.$page.allInsert);
         this.cards = gatherCards(this.inserts);
+        this.latest = gatherCollections(this.$page);
     },
     computed: {
-        latest() {
-            return gatherCollections(this.$page);
+        cardRows() {
+            return makeCardRows(this.$page.homecards.cards, this.latest, this.cards, ROW_WIDTH);
         },
     },
     mounted() {
@@ -134,6 +112,17 @@ export default {
 
 <page-query>
 query {
+    homecards: insert(path: "/insert:/homecards/") {
+        id
+        cards {
+            name
+            type
+            title
+            link
+            icon
+            width
+        }
+    }
     allInsert(filter: {path: {regex: "^/insert:/[^/]+/$"}}) {
         totalCount
         edges {

--- a/src/utils.js
+++ b/src/utils.js
@@ -507,7 +507,7 @@ function gatherCards(inserts) {
 }
 module.exports.gatherCards = gatherCards;
 
-function makeCardRows(rawCards, latest, cardsData, rowWidth = 3) {
+function makeCardRows(rawCards, latest, cardsData, prefix = "", rowWidth = 3) {
     let rows = [];
     let row = [];
     let remaining = rowWidth;
@@ -518,6 +518,9 @@ function makeCardRows(rawCards, latest, cardsData, rowWidth = 3) {
             if (items) {
                 cardData = { items: items };
                 Object.assign(cardData, card);
+                if (!cardData.link && card.path) {
+                    cardData.link = prefix + card.path;
+                }
             } else {
                 console.error(repr`Dynamic card ${card.name} listed but no data found in GraphQL query.`);
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -474,10 +474,10 @@ function gatherInserts(allInsert) {
     let inserts = {};
     for (let insert of allInsert.edges.map((edge) => edge.node)) {
         let parts = insert.path.split("/");
-        if (parts.length < 4 || parts[0] !== "" || parts[1] !== "insert:" || parts[parts.length-1] !== "") {
+        if (parts.length < 4 || parts[0] !== "" || parts[1] !== "insert:" || parts[parts.length - 1] !== "") {
             throw repr`Error: Insert has invalid path ${insert.path}`;
         }
-        let name = parts[parts.length-2];
+        let name = parts[parts.length - 2];
         inserts[name] = insert;
     }
     return inserts;

--- a/src/utils.js
+++ b/src/utils.js
@@ -507,6 +507,44 @@ function gatherCards(inserts) {
 }
 module.exports.gatherCards = gatherCards;
 
+function makeCardRows(rawCards, latest, cardsData, rowWidth) {
+    let rows = [];
+    let row = [];
+    let remaining = rowWidth;
+    for (let card of rawCards) {
+        let cardData;
+        if (card.type === "dynamic") {
+            let items = latest[card.name];
+            if (items) {
+                cardData = { items: items };
+                Object.assign(cardData, card);
+            } else {
+                console.error(repr`Dynamic card ${card.name} listed but no data found in GraphQL query.`);
+            }
+        } else if (card.type === "static") {
+            cardData = cardsData[card.name];
+        }
+        if (!cardData) {
+            continue;
+        }
+        let width = card.width || 1;
+        // Standard Bootstrap row width is 12.
+        cardData.width = (width * 12) / rowWidth;
+        row.push(cardData);
+        remaining -= width;
+        if (remaining <= 0) {
+            rows.push(row);
+            row = [];
+            remaining = rowWidth;
+        }
+    }
+    if (row.length > 0) {
+        rows.push(row);
+    }
+    return rows;
+}
+module.exports.makeCardRows = makeCardRows;
+
 /** Search for an object key in an object, recursively.
  * Descend into every value whose `getType()` is "Object" or "Array".
  * @param {Object} obj       The object to search.

--- a/src/utils.js
+++ b/src/utils.js
@@ -443,6 +443,70 @@ function notifyParent(window) {
 }
 module.exports.notifyParent = notifyParent;
 
+function addTwitterWidget(document) {
+    !(function (d, s, id) {
+        var js,
+            fjs = d.getElementsByTagName(s)[0],
+            p = /^http:/.test(d.location) ? "http" : "https";
+        if (!d.getElementById(id)) {
+            js = d.createElement(s);
+            js.id = id;
+            js.src = p + "://platform.twitter.com/widgets.js";
+            fjs.parentNode.insertBefore(js, fjs);
+        }
+    })(document, "script", "twitter-wjs");
+}
+module.exports.addTwitterWidget = addTwitterWidget;
+
+function addAltmetrics(document) {
+    const altmetricScript = document.createElement("script");
+    altmetricScript.src = "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js";
+    document.head.appendChild(altmetricScript);
+}
+module.exports.addAltmetrics = addAltmetrics;
+
+function hasContent(item) {
+    return Boolean(item && item.content && item.content.trim());
+}
+module.exports.hasContent = hasContent;
+
+function gatherInserts(allInsert) {
+    let inserts = {};
+    for (let insert of allInsert.edges.map((edge) => edge.node)) {
+        let parts = insert.path.split("/");
+        if (parts.length < 4 || parts[0] !== "" || parts[1] !== "insert:" || parts[parts.length-1] !== "") {
+            throw repr`Error: Insert has invalid path ${insert.path}`;
+        }
+        let name = parts[parts.length-2];
+        inserts[name] = insert;
+    }
+    return inserts;
+}
+module.exports.gatherInserts = gatherInserts;
+
+function gatherCollections(page) {
+    let collections = {};
+    for (let [category, value] of Object.entries(page)) {
+        if (value.edges) {
+            collections[category] = value.edges.map((edge) => edge.node);
+        }
+    }
+    return collections;
+}
+module.exports.gatherCollections = gatherCollections;
+
+function gatherCards(inserts) {
+    let cards = {};
+    for (let [name, insert] of Object.entries(inserts)) {
+        if (name.endsWith("-card")) {
+            let cardName = rmSuffix(name, "-card");
+            cards[cardName] = insert;
+        }
+    }
+    return cards;
+}
+module.exports.gatherCards = gatherCards;
+
 /** Search for an object key in an object, recursively.
  * Descend into every value whose `getType()` is "Object" or "Array".
  * @param {Object} obj       The object to search.

--- a/src/utils.js
+++ b/src/utils.js
@@ -507,7 +507,7 @@ function gatherCards(inserts) {
 }
 module.exports.gatherCards = gatherCards;
 
-function makeCardRows(rawCards, latest, cardsData, rowWidth) {
+function makeCardRows(rawCards, latest, cardsData, rowWidth = 3) {
     let rows = [];
     let row = [];
     let remaining = rowWidth;
@@ -523,6 +523,9 @@ function makeCardRows(rawCards, latest, cardsData, rowWidth) {
             }
         } else if (card.type === "static") {
             cardData = cardsData[card.name];
+            if (!cardData) {
+                console.warn(repr`Static card ${card.name} listed but no Markdown file found for it.`);
+            }
         }
         if (!cardData) {
             continue;


### PR DESCRIPTION
This encapsulates most of the code and logic used in the main homepage (Index.vue) and subsite homepages (SubsiteHome.vue), so that it can be better encapsulated and shared between them.

This also automates the layout of homepage cards into rows, allowing for missing cards wherever. Card order and other metadata is controlled by editing the subsite's `cards.md`. As a bonus demonstration, this PR also uses this new system to add a Twitter card to `/eu/`.