### PR TITLE
Implement EU RSS feed

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
         "/careers": "careers",
         "/projects/covid19": "covid19"
     },
+    "rssCategories": ["blog", "news", "careers"],
     "build": {
         "dirs": {
             "md": "build/content-md",

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -56,7 +56,7 @@ const RSS_PLUGIN = {
             }
             let item = {
                 title: node.title,
-                content: node.content
+                content: node.content,
             };
             let dateType = getType(node.date);
             if (dateType === "Date") {
@@ -74,15 +74,15 @@ const RSS_PLUGIN = {
                 item.image = node.image;
             }
             if (node.contact) {
-                item.author = [ { name: node.contact } ];
+                item.author = [{ name: node.contact }];
             } else if (node.authors) {
-                item.author = [ { name: node.authors } ];
+                item.author = [{ name: node.authors }];
             }
             //TODO: Remove the table-of-contents/end-table-of-contents headings from node.content
             return item;
-        }
-    }
-}
+        },
+    },
+};
 
 const EU_RSS_OPTIONS = {
     feedOptions: {
@@ -98,8 +98,8 @@ const EU_RSS_OPTIONS = {
 
 const EU_RSS_PLUGIN = {
     use: "gridsome-plugin-feed",
-    options: Object.assign(Object.assign({}, RSS_PLUGIN.options), EU_RSS_OPTIONS)
-}
+    options: Object.assign(Object.assign({}, RSS_PLUGIN.options), EU_RSS_OPTIONS),
+};
 
 function mkPlugins(collections) {
     // Path globbing rules: https://www.npmjs.com/package/globby#user-content-globbing-patterns

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -84,6 +84,23 @@ const RSS_PLUGIN = {
     }
 }
 
+const EU_RSS_OPTIONS = {
+    feedOptions: {
+        description: "The European Galaxy Instance",
+        id: `https://${CONFIG.host}/eu/feed.atom`,
+    },
+    atom: {
+        enabled: true,
+        output: "/eu/feed.atom",
+    },
+    filterNodes: (node) => node && node.date && node.category === "news" && node.subsites.includes("eu"),
+};
+
+const EU_RSS_PLUGIN = {
+    use: "gridsome-plugin-feed",
+    options: Object.assign(Object.assign({}, RSS_PLUGIN.options), EU_RSS_OPTIONS)
+}
+
 function mkPlugins(collections) {
     // Path globbing rules: https://www.npmjs.com/package/globby#user-content-globbing-patterns
     let plugins = [
@@ -200,7 +217,7 @@ module.exports = {
     siteUrl: `https://${CONFIG.host}`,
     icon: "./src/favicon.png",
     templates: mkTemplates(CONFIG["collections"]),
-    plugins: [RSS_PLUGIN, ...mkPlugins(CONFIG["collections"])],
+    plugins: [RSS_PLUGIN, EU_RSS_PLUGIN, ...mkPlugins(CONFIG["collections"])],
     css: {
         loaderOptions: {
             scss: {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "commander": "^8.2.0",
     "dayjs": "^1.10.7",
     "gridsome": "^0.7.0",
+    "gridsome-plugin-feed": "^1.0.2",
     "ics": "^2.35.0",
     "jiti": "^1.12.0",
     "markdownlint": "^0.24.0",

--- a/src/build/toc-add.mjs
+++ b/src/build/toc-add.mjs
@@ -118,3 +118,55 @@ function makeHeading(text) {
         ],
     };
 }
+
+export function rmToc(inputLines) {
+    let outputLines = [];
+    let state = "start";
+    let omit = false;
+    for (let line of inputLines) {
+        switch (state) {
+            case "start":
+                if (line.startsWith(HEADING_TEXT)) {
+                    state = "in start heading";
+                    omit = true;
+                } else {
+                    omit = false;
+                }
+                break;
+            case "in start heading":
+                if (line.startsWith("===")) {
+                    state = "after start heading";
+                    omit = true;
+                } else {
+                    //TODO: Go back and include the previous line if we don't see a "===" after the start heading.
+                    //      Just in case a page coincidentally includes the start heading text.
+                    omit = false;
+                }
+                break;
+            case "after start heading":
+                if (line.startsWith(HEADING_ENDING)) {
+                    state = "in end heading";
+                    omit = true;
+                } else {
+                    omit = false;
+                }
+                break;
+            case "in end heading":
+                if (line.startsWith("===")) {
+                    state = "after end heading";
+                    omit = true;
+                } else {
+                    omit = false;
+                    //TODO: Go back and include previous line here too.
+                }
+                break;
+            case "after end heading":
+                omit = false;
+                break;
+        }
+        if (!omit) {
+            outputLines.push(line);
+        }
+    }
+    return outputLines;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -183,7 +183,7 @@ function getTreeBranch(tree, query) {
 }
 module.exports.getTreeBranch = getTreeBranch;
 
-function mdToHtml(md) {
+function mdToHtml(md, rmP = true) {
     //TODO: Fix links (E.g. `/src/main/index.md` -> `/main/`)
     let rawHtml;
     remark()
@@ -192,10 +192,14 @@ function mdToHtml(md) {
             if (err) {
                 console.error(err);
             } else {
-                rawHtml = String(file);
+                rawHtml = String(file).trim();
             }
         });
-    return rmPrefix(rmSuffix(rawHtml.trim(), "</p>"), "<p>");
+    if (rmP) {
+        return rmPrefix(rmSuffix(rawHtml, "</p>"), "<p>");
+    } else {
+        return rawHtml;
+    }
 }
 module.exports.mdToHtml = mdToHtml;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6702,6 +6702,13 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+feed@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/feed/-/feed-4.2.2.tgz#865783ef6ed12579e2c44bbef3c9113bc4956a7e"
+  integrity sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==
+  dependencies:
+    xml-js "^1.6.11"
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -7010,6 +7017,15 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -7434,6 +7450,16 @@ gray-matter@^4.0.2:
     kind-of "^6.0.2"
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
+
+gridsome-plugin-feed@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/gridsome-plugin-feed/-/gridsome-plugin-feed-1.0.2.tgz#d991cd761435bbc2643ac2f402e3e60983741c9c"
+  integrity sha512-jmN7X++5JjIiWldplMUTozny/GFR6BFrq4HpU+Qc+KQKB+wilM9IG0MxnVeIOBXVQ2Pu5Wz7evaL5x9/FWqrRQ==
+  dependencies:
+    feed "^4.0.0"
+    fs-extra "^8.1.0"
+    micromatch "^4.0.2"
+    moment "^2.24.0"
 
 gridsome@^0.7.0:
   version "0.7.23"
@@ -12801,7 +12827,7 @@ sass@^1.39.2:
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
-sax@~1.2.4:
+sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -15740,6 +15766,13 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xml-js@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
+  dependencies:
+    sax "^1.2.4"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This recreates the EU [RSS feed](https://galaxyproject.eu/feed.xml) as closely as possible, using [gridsome-plugin-feed](https://gridsome.org/plugins/gridsome-plugin-feed).

The resulting feed is located at https://galaxyproject.org/eu/feed.atom (the .eu one is actually Atom, not RSS).

The resulting XML isn't an exact replica of the .eu one, due to limitations of gridsome-plugin-feed, but it's very close. Basically, there are a handful of tags and attributes that I wasn't able to include. I figure the plugin knows enough to produce a valid feed (it's using the [feed](https://www.npmjs.com/package/feed) npm package), but once it's live I'll test it in an RSS reader (if I can unearth one).

### Missing tags
| parent | tag |
|--------|-----|
| `<entry>` | `<published>` |
| `<entry>` | `<category>`  |

### Missing attributes
| parent | tag | attribute |
|--------|-----|-----------|
| `<feed>`  | `<generator>` | `uri`     |
| `<feed>`  | `<generator>` | `version` |
| `<feed>`  | `<link>` | `type`     |
| `<entry>` | `<link>` | `type`     |
| `<entry>` | `<link>` | `rel`      |
| `<entry>` | `<link>` | `title`    |
| `<entry>` | `<link>` | `xml:base` |