### PR TITLE
GCC2022 Call for BoFs: fix a couple references to GCC 2021

### DIFF
--- a/content/news/2022-05-gcc2022-call-for-bofs/index.md
+++ b/content/news/2022-05-gcc2022-call-for-bofs/index.md
@@ -7,7 +7,7 @@ subsites: [global, us]
 
 <a href="/events/gcc2022/"><img src="/images/events/gcc2022/gcc2022-spoonbridge.png" alt="GCC2022" class="float-right" style="max-width: 20rem" /></a>
 
-There is no better place than the [GCC2022 Conference](/events/gcc2021/) to meet and learn from others doing data-intensive science.  *[Birds of a Feather (BoF)](https://en.wiktionary.org/wiki/birds-of-a-feather_session)* meetups are informal gatherings where participants group together to discuss common interests.
+There is no better place than the [GCC2022 Conference](/events/gcc2022/) to meet and learn from others doing data-intensive science.  *[Birds of a Feather (BoF)](https://en.wiktionary.org/wiki/birds-of-a-feather_session)* meetups are informal gatherings where participants group together to discuss common interests.
 
 There are [4 sessions for BoFs](https://gcc2022.sched.com/overview/type/D.+Break+%2F+Social+%2F+Networking+%2F+Meal/BoFs), one at the end of each day of the conference **The [current list of BoFs is available on the conference web site](https://gcc2022.sched.com/overview/type/D.+Break+%2F+Social+%2F+Networking+%2F+Meal/BoFs).**
 


### PR DESCRIPTION
The url and one link still accidentally said GCC 202**1**.

This does change the url but it hasn't been up for long so I assume we don't need to redirect.

CC @tnabtaf