### PR TITLE
Remove leftover config.json key added briefly during RSS development.

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,6 @@
         "/careers": "careers",
         "/projects/covid19": "covid19"
     },
-    "rssCategories": ["blog", "news", "careers"],
     "build": {
         "dirs": {
             "md": "build/content-md",


### PR DESCRIPTION
Added during development of #1397, but didn't end up using it.