### PR TITLE
Fix issue with partitioning user-defined Collections

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -129,18 +129,18 @@ function mkPlugins(collections) {
                 use: "@gridsome/source-filesystem",
                 options: {
                     typeName: name,
-                    path: globPath,
+                    path: [globPath],
                 },
             };
         } else if (meta.type === "vue") {
             let bareUrlPath = rmPrefix(rmSuffix(meta.path, "/"), "/");
-            vueArticlePlugin.options.ignore.push(bareUrlPath);
+            vueArticlePlugin.options.ignore.push(`${VUE_CONTENT_DIR}/${bareUrlPath}`);
             plugin = {
                 use: "@gridsome/vue-remark",
                 options: {
                     typeName: name,
-                    baseDir: `${VUE_CONTENT_DIR}/${meta.path}`,
-                    pathPrefix: `/${meta.path}`,
+                    baseDir: `${VUE_CONTENT_DIR}/${bareUrlPath}`,
+                    pathPrefix: meta.path,
                     ignore: [],
                     template: `src/templates/${name}.vue`,
                     plugins: REMARK_VUE_PLUGINS,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -102,6 +102,15 @@ function matchesPrefixes(string, prefixes) {
 }
 module.exports.matchesPrefixes = matchesPrefixes;
 
+function ensurePrefix(string, prefix) {
+    if (string.startsWith(prefix)) {
+        return string;
+    } else {
+        return prefix + string;
+    }
+}
+module.exports.ensurePrefix = ensurePrefix;
+
 function ensureSuffix(string, suffix) {
     if (string.endsWith(suffix)) {
         return string;


### PR DESCRIPTION
#1365 made it possible for collections defined in `config.json` to use `vue-remark`. But the Partitioner in `partition-content.mjs` still used the old rules for placing Markdown files in `build/content-md` or `build/content-vue`. These rules were based on inspecting the Markdown file, not where it's placed. So it was possible to define a `vue-remark` collection but one of the pages wouldn't appear because it doesn't contain any Vue components, so the Partitioner put it in `build/content-md` instead of `build/content-vue`, where the collections looks for its content.

The immediate effect was that pages in `/bare/` would become `Article`s instead of `BareArticle`s if they didn't contain any Vue components.

This updates the Partitioner so it checks the path of the `index.md` file against the custom collections in `config.json`, making sure any pages in a custom collections get placed correctly.