### PR TITLE
adding zoom link, modifying one phrase

### DIFF
--- a/content/events/2022-05-26-community-call/index.md
+++ b/content/events/2022-05-26-community-call/index.md
@@ -14,9 +14,9 @@ tags: ["community-call"]
 subsites: [global, us]
 ---
 
-We will have a presentation on **Galaxy on AnVIL** by **Mike Schatz**, followed by a discussion and community updates. If you'd like to discuss particular topics, please add them to the [agenda](https://docs.google.com/document/d/1PYUnO_td7f-l0fxRYDn8D6ER7W6eY-E9mUx8ErT8kJ4/edit?usp=sharing) or bring them to the call!
+We will have a presentation on **Galaxy on AnVIL** by **Mike Schatz**, along with a discussion and some community updates. If you'd like to discuss particular topics, please add them to the [agenda](https://docs.google.com/document/d/1PYUnO_td7f-l0fxRYDn8D6ER7W6eY-E9mUx8ErT8kJ4/edit?usp=sharing) or bring them to the call!
 
-**Please [join us]() at 3 pm UTC** ([see in your timezone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Galaxy+community+call&iso=20220526T15)) for an open discussion.
+**Please [join us](https://psu.zoom.us/j/99284059506?pwd=RnEvK0R0MG9JZTFSNEIrTjk5cmI2Zz09) at 3 pm UTC** ([see in your timezone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Galaxy+community+call&iso=20220526T15)) for an open discussion.
 
 ---
 


### PR DESCRIPTION
Justification for changing phrase: The first time the content came first and the updates second, but that felt odd. The second time we presented community updates first, then content. This allows some flexibility in how it's handled.  It seems I'll be chairing this meeting, and will probably do the community updates first. 