### PR TITLE
Add a Projects menu to the NavBar

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -45,8 +45,11 @@
                         <b-dropdown-item to="/citing-galaxy/">Citing Galaxy</b-dropdown-item>
                         <b-dropdown-item to="/images/galaxy-logos/">Branding</b-dropdown-item>
                     </b-nav-item-dropdown>
+                    <b-nav-item-dropdown text="Projects">
+                        <b-dropdown-item to="/projects/covid19/">Covid19</b-dropdown-item>
+                        <b-dropdown-item to="/projects/mpxv/">Monkeypox</b-dropdown-item>
+                    </b-nav-item-dropdown>
                     <b-nav-item to="/events/gcc2022/">GCC2022</b-nav-item>
-                    <b-nav-item to="/projects/covid19/">Covid19</b-nav-item>
                     <b-nav-item to="/jxtx/">@jxtx</b-nav-item>
                 </b-navbar-nav>
                 <b-navbar-nav id="global-tools" class="ml-2">


### PR DESCRIPTION
For now add the Covid19 and the MPXV efforts to it.
The idea is that projects listed under https://galaxyproject.org/community/wg/#current-set-of-projects should all have hub pages, then be added to the menu.