### PR TITLE
Remove redundant .markdown class from Insert containers

### DIFF
--- a/cypress/integration/main.spec.js
+++ b/cypress/integration/main.spec.js
@@ -44,7 +44,7 @@ describe("Test Markdown rendering", () => {
 describe("Test insert functionality", () => {
     it("Visits 2012 GCC event page and ensures footer insert is visible", () => {
         cy.visit("/events/gcc2012/");
-        cy.get(".markdown > p > a").findByText("Ask the organizers").should("be.visible");
+        cy.get(".insert > p > a").findByText("Ask the organizers").should("be.visible");
     });
 });
 

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -10,7 +10,9 @@
                     `insert.name` variable: https://vuejs.org/v2/guide/components-slots.html#Dynamic-Slot-Names
                 -->
                 <template v-for="insert of $page.article.inserts" #[insert.name]>
-                    <div class="insert" :data-name="insert.name" :key="insert.name + ':md'" v-html="insert.content">&nbsp;</div>
+                    <div class="insert" :data-name="insert.name" :key="insert.name + ':md'" v-html="insert.content">
+                        &nbsp;
+                    </div>
                 </template>
             </VueRemarkContent>
         </article>

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -10,7 +10,7 @@
                     `insert.name` variable: https://vuejs.org/v2/guide/components-slots.html#Dynamic-Slot-Names
                 -->
                 <template v-for="insert of $page.article.inserts" #[insert.name]>
-                    <div class="markdown" :key="insert.name + ':md'" v-html="insert.content">&nbsp;</div>
+                    <div class="insert" :data-name="insert.name" :key="insert.name + ':md'" v-html="insert.content">&nbsp;</div>
                 </template>
             </VueRemarkContent>
         </article>


### PR DESCRIPTION
Instead, use .insert class to label them.