### PR TITLE
Add the ToC back to the GCC 2022 childcare page.

### DIFF
--- a/content/events/gcc2022/childcare/index.md
+++ b/content/events/gcc2022/childcare/index.md
@@ -1,6 +1,3 @@
----
-autotoc: false
----
 <slot name="/events/gcc2022/header" />
 
 # Childcare will be offered at GCC2022!


### PR DESCRIPTION
True, the table of contents isn't useful on that page, but keeping it prevents the layout from jumping around as you browse between the different links in the GCC 2022 header.