### PR TITLE
Assign correct subsite metadata to a couple articles

### DIFF
--- a/content/events/2022-05-19-elixir-belgium/index.md
+++ b/content/events/2022-05-19-elixir-belgium/index.md
@@ -10,5 +10,5 @@ external_url: "https://elixir-belgium.org/events/elixir-belgium-fair-data-life-s
 gtn: false
 contact: "Liesbet Peeters, Wim Vranken, Alexander Botzki, Flora D’Anna, Frederik Coppens, Kim De Ruyck"
 image:
-subsites: [global, eu]
+subsites: [global, eu, belgium]
 ---

--- a/content/events/2022-05-25-biodiversity/index.md
+++ b/content/events/2022-05-25-biodiversity/index.md
@@ -10,5 +10,5 @@ external_url: "https://www.biodiversity.be/4443"
 gtn: false
 contact: "Frederik Coppens"
 image:
-subsites: [global, eu]
+subsites: [global, eu, belgium]
 ---


### PR DESCRIPTION
#1433 attempted to fix an issue where two articles got tagged with the nonexistent subsite `vib` by removing the tag, since it was already tagged with `eu`. I forgot that meant it wouldn't actually show up on the VIB subsite, as was clearly intended. This adds the proper subsite, `belgium` back to them.