### PR TITLE
Restore link to pre-2016 events archive.

### DIFF
--- a/content/events/archive/main.md
+++ b/content/events/archive/main.md
@@ -3,3 +3,5 @@ title: Beyond the Galaxy Event Horizon
 ---
 
 Old events relevant to the Galaxy community.
+
+See the [events page](/events/) for upcoming and recent events, and the [Way Beyond the Galaxy Event Horizon](/events/archive/wayback/) page for a full list of events from 2016 and before.


### PR DESCRIPTION
Somehow the link to [/events/archive/wayback/](https://galaxyproject.org/events/archive/wayback/) had gotten deleted.