### PR TITLE
Start a page documenting Hub development history.

### DIFF
--- a/content/hub/history/index.md
+++ b/content/hub/history/index.md
@@ -1,0 +1,25 @@
+---
+title: Community Hub History
+---
+
+This page keeps track of some institutional knowledge about this site (the Galaxy Community Hub) itself.
+
+Gridsome version
+----------------
+
+This is the [Gridsome](https://gridsome.org/) rewrite of the Hub.
+
+This went live on 13 Sep 2021: [PR #772](https://github.com/galaxyproject/galaxy-hub/pull/772) (commit [6d7ee41](https://github.com/galaxyproject/galaxy-hub/commit/6d7ee41062cbdca52588dd35fc3a3983575f8443)) merged the branch with the Gridsome code (commit [4592c7a](https://github.com/galaxyproject/galaxy-hub/commit/4592c7a28a953d82a2cea227dbe8d71ebbadab78)) with the Metalsmith site (commit [9807ac1](https://github.com/galaxyproject/galaxy-hub/commit/9807ac1bf8880fc7fac20b1809774796d0305cc2)). The last Metalsmith version is tagged [`hub1`](https://github.com/galaxyproject/galaxy-hub/releases/tag/hub1).
+
+
+Metalsmith version
+------------------
+
+This was the first version powered by a static site generator ([Metalsmith](https://metalsmith.io)).
+
+The content was seeded by scraping the Moin Moin version (not without some [errors](https://github.com/galaxyproject/galaxy-hub/issues/690)).
+
+Wiki version
+------------
+
+This version was a wiki powered by [MoinMoin](https://moinmo.in).


### PR DESCRIPTION
I wanted to record some development history of this project that isn't captured in existing PRs, issues, and documentation. Why not keep it on the Hub itself?