### PR TITLE
Handle undefined/null urls in fix-links.mjs.

### DIFF
--- a/src/build/fix-links.mjs
+++ b/src/build/fix-links.mjs
@@ -59,7 +59,10 @@ export default function attacher(options) {
                     }
                 } catch (error) {
                     console.error(error);
-                    console.error(`Error fixing url in Markdown ${nodeType} in ${file.path}:\n`, trunc(repr(node), 200));
+                    console.error(
+                        `Error fixing url in Markdown ${nodeType} in ${file.path}:\n`,
+                        trunc(repr(node), 200)
+                    );
                 }
             });
         }

--- a/src/build/fix-links.mjs
+++ b/src/build/fix-links.mjs
@@ -9,7 +9,7 @@ import { unified } from "unified";
 import rehypeParse from "rehype-parse";
 import { visit } from "unist-util-visit";
 import urlParse from "url-parse";
-import { rmPrefix, rmSuffix, matchesPrefixes } from "../lib/utils.js";
+import { repr, trunc, rmPrefix, rmSuffix, matchesPrefixes } from "../lib/utils.js";
 
 // `verbose: true` makes the parser include position information for each property of each element.
 // This is required for `editProperty()` to work.
@@ -20,7 +20,7 @@ let debug = false;
 //      Check if that happens in the codebase.
 const PREFIX_WHITELIST = ["http://", "https://", "mailto:", "/images/", "//", "#"];
 const LINK_PROPS = { img: "src", a: "href" };
-const LINK_FIXERS = { img: fixImageLink, a: fixHyperLink };
+const LINK_FIXERS = { image: fixImageLink, img: fixImageLink, link: fixHyperLink, a: fixHyperLink };
 
 /**
  * The unified plugin to transform links in parsed Markdown trees.
@@ -48,13 +48,21 @@ export default function attacher(options) {
         } else {
             console.error("No `bases` option received. Will not be able to convert image src paths to relative paths.");
         }
-        visit(tree, "link", (node) => {
-            node.url = fixHyperLink(node.url);
-        });
-        visit(tree, "image", (node) => {
-            node.url = fixImageLink(node.url, dirPath);
-        });
-        visit(tree, "html", (node) => fixHtmlLinks(node, dirPath));
+        // Fix the urls in the 3 types of nodes we're targeting.
+        for (let nodeType of ["link", "image", "html"]) {
+            visit(tree, nodeType, (node) => {
+                try {
+                    if (nodeType === "link" || nodeType === "image") {
+                        node.url = LINK_FIXERS[nodeType](node.url, dirPath);
+                    } else if (nodeType === "html") {
+                        fixHtmlLinks(node, dirPath);
+                    }
+                } catch (error) {
+                    console.error(error);
+                    console.error(`Error fixing url in Markdown ${nodeType} in ${file.path}:\n`, trunc(repr(node), 200));
+                }
+            });
+        }
     }
     return transformer;
 }
@@ -152,6 +160,9 @@ function getElementsByTagNames(elem, tagNames) {
 
 /** Perform all the editing appropriate for a hyperlink url (whether in HTML or Markdown). */
 export function fixHyperLink(rawUrl) {
+    if (typeof rawUrl !== "string") {
+        throw repr`Error: rawUrl must be a String. Received: ${rawUrl}`;
+    }
     // Skip certain types of links like external (https?://), static (/images/), intrapage (#).
     if (matchesPrefixes(rawUrl, PREFIX_WHITELIST)) {
         return rawUrl;
@@ -184,6 +195,9 @@ export function fixHyperLink(rawUrl) {
  *                           events/gcc2013.
  */
 export function fixImageLink(rawPath, dirPath = null) {
+    if (typeof rawPath !== "string") {
+        throw repr`Error: rawPath must be a String. Received: ${rawPath}`;
+    }
     let path = rmPrefix(rawPath, "/src");
     if (dirPath) {
         path = toRelImagePath(dirPath, path, PREFIX_WHITELIST);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -36,6 +36,17 @@ function repr(strParts, ...values) {
 }
 module.exports.repr = repr;
 
+/** Truncate long strings with an ellipsis, and leave alone strings that are already short enough.
+ */
+function trunc(str, maxLen, endChar="…") {
+    if (str.length > maxLen) {
+        return str.slice(0, maxLen)+endChar;
+    } else {
+        return str;
+    }
+}
+module.exports.trunc = trunc;
+
 function splitlines(text) {
     return text.split(/\r\n|\r|\n/);
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -38,9 +38,9 @@ module.exports.repr = repr;
 
 /** Truncate long strings with an ellipsis, and leave alone strings that are already short enough.
  */
-function trunc(str, maxLen, endChar="…") {
+function trunc(str, maxLen, endChar = "…") {
     if (str.length > maxLen) {
-        return str.slice(0, maxLen)+endChar;
+        return str.slice(0, maxLen) + endChar;
     } else {
         return str;
     }


### PR DESCRIPTION
This addresses an error which can arise in fix-links.mjs in the unusual situation where the url on a [node](https://github.com/syntax-tree/mdast) is undefined. Now, instead of crashing the build, this will print a useful warning, leave the link unaltered, and continue.

This error was discovered in #1437, being caused by something in the large svg blob in [content/projects/ppandemic/s1e1/index.md](https://raw.githubusercontent.com/galaxyproject/galaxy-hub/d1a2ccb4e12d23570f1be56952b32e7e712e56f6/content/projects/ppandemic/s1e1/index.md).