### PR TITLE
Label each collection with a class

### DIFF
--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout :subsite="$page.article.main_subsite || undefined">
+    <Layout :subsite="$page.article.main_subsite || undefined" class="collection-article">
         <ArticleHeader :article="$page.article" />
         <div :class="['content', 'markdown', ...mdClasses]" v-html="$page.article.content" />
         <ArticleFooter :article="$page.article" />

--- a/src/templates/BareArticle.vue
+++ b/src/templates/BareArticle.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="collection-bare-article">
         <main id="maincontainer" :class="['container', 'markdown', ...mdClasses]">
             <VueRemarkContent>
                 <!--

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout :subsite="subsite">
+    <Layout :subsite="subsite" class="collection-platform">
         <g-link to="/use/" class="link"> &larr; Platform Directory</g-link>
         <header>
             <h1 class="pageTitle">{{ $page.platform.title }}</h1>

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -1,5 +1,5 @@
 <template>
-    <Layout :subsite="$page.article.main_subsite || undefined">
+    <Layout :subsite="$page.article.main_subsite || undefined" class="collection-vue-article">
         <ArticleHeader :article="$page.article" />
         <article :class="['content', 'markdown', ...mdClasses]">
             <VueRemarkContent>


### PR DESCRIPTION
Add a class at the root of each Collection template labeling which collection it is. This is helpful for development, to quickly identify which collection is displaying any particular page. It can also be used for styling.