### PR TITLE
Fix links on subsite homepages to subsite News and Events.

### DIFF
--- a/content/belgium/cards.md
+++ b/content/belgium/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /belgium/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /belgium/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/elixir-it/cards.md
+++ b/content/elixir-it/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /elixir-it/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /elixir-it/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/erasmusmc/cards.md
+++ b/content/erasmusmc/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /erasmusmc/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /erasmusmc/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/eu/cards.md
+++ b/content/eu/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /eu/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /eu/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/freiburg/cards.md
+++ b/content/freiburg/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /freiburg/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /freiburg/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/genouest/cards.md
+++ b/content/genouest/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /genouest/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /genouest/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/ifb/cards.md
+++ b/content/ifb/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /ifb/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /ifb/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/pasteur/cards.md
+++ b/content/pasteur/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /pasteur/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /pasteur/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static

--- a/content/us/cards.md
+++ b/content/us/cards.md
@@ -3,12 +3,12 @@ list:
 - name: news
   type: dynamic
   title: News
-  link: /news/
+  link: /us/news/
   icon: fas fa-bullhorn
 - name: events
   type: dynamic
   title: Events
-  link: /events/
+  link: /us/events/
   icon: far fa-calendar-alt
 - name: twitter
   type: static


### PR DESCRIPTION
On subsite homepages, the "News" and "Events" headings at the top of the list of news/events posts linked to the global /news/ and /events/ pages, instead of the subsite pages.