### PR TITLE
Fix layout of ToC/body on Events.vue.

### DIFF
--- a/src/components/pages/Events.vue
+++ b/src/components/pages/Events.vue
@@ -10,6 +10,7 @@
         <div class="body-wrapper col-md-9">
             <div class="content markdown" v-html="$page.main.content" />
         </div>
+        <div class="clearfix"></div>
         <h2 id="upcoming-events">
             <a href="#upcoming-events" aria-hidden="true"><span class="icon icon-link"></span></a>
             Upcoming Events


### PR DESCRIPTION
#1467 fixed the layout of the table of contents with a global CSS style, but that also requires a clearfix in the HTML to work properly. I did that in the body of Markdown pages, but I also used the ToC classes in a dynamic page (Events.vue). This adds the clearfix to that.