### PR TITLE
Remove extra </div> from covid19 homepage.

### DIFF
--- a/content/projects/covid19/index.md
+++ b/content/projects/covid19/index.md
@@ -63,7 +63,6 @@ The current knowledge about the evolutionary dynamics of SARS-CoV-2 comes primar
     </div>
   </div>
 </div>
-</div>
 
 ------
 


### PR DESCRIPTION
The extra `</div>` was closing the `.body-wrapper` div, messing up the layout and causing a return of #1467.