### PR TITLE
Replace /bare/eu/latest/ in the metabolomics middle pane too

### DIFF
--- a/content/bare/usegalaxy-eu/metabolomics/index.md
+++ b/content/bare/usegalaxy-eu/metabolomics/index.md
@@ -95,7 +95,13 @@ Other metabolomics specialized Galaxy servers:
 
 <!-- carousel content -->
 
-<iframe class="resize-y" src="/bare/eu/latest/" scrolling="no" style="width: 100%; border: none" title="Recent Galaxy Europe news and events">
+<iframe title="Recent Galaxy Europe news"
+ class="resize-y" src="/bare/eu/latest/news/" scrolling="no"
+ style="width: 50%; border: none; vertical-align: top">
+</iframe>
+<iframe title="Recent Galaxy Europe events"
+ class="resize-y" src="/bare/eu/latest/events/" scrolling="no"
+ style="width: 50%; border: none; vertical-align: top">
 </iframe>
 
 --------------------------------------------------------------------


### PR DESCRIPTION
#1491 removed /bare/eu/latest/ and added /bare/eu/latest/news/ and /bare/eu/latest/events/. It replaced the former in the usegalaxy.eu middle pane, but left one reference to it in metabolomics.usegalaxy.eu.