### PR TITLE
Fix links to /news/ and /events/ in /bare/eu/latest/ pages.

### DIFF
--- a/src/pages/bare/eu/latest/Events.vue
+++ b/src/pages/bare/eu/latest/Events.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <section class="latest-posts row">
-            <HomeCard title="Events" link="/events/" icon="far fa-calendar-alt" :width="12" :items="events" />
+            <HomeCard title="Events" link="/eu/events/" icon="far fa-calendar-alt" :width="12" :items="events" />
         </section>
     </div>
 </template>

--- a/src/pages/bare/eu/latest/News.vue
+++ b/src/pages/bare/eu/latest/News.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <section class="latest-posts row">
-            <HomeCard title="News" link="/news/" icon="far fa-calendar-alt" :width="12" :items="news" />
+            <HomeCard title="News" link="/eu/news/" icon="far fa-calendar-alt" :width="12" :items="news" />
         </section>
     </div>
 </template>


### PR DESCRIPTION
Similar to #1485 but for /bare/eu/latest/news/ and /bare/eu/latest/events/