### PR TITLE
Update Twitter timeline widget, add component

### DIFF
--- a/content/eu/twitter-card.md
+++ b/content/eu/twitter-card.md
@@ -4,5 +4,4 @@ icon: fab fa-twitter
 link: https://twitter.com/galaxyproject
 ---
 
-<a class="twitter-timeline" href="https://twitter.com/galaxyproject" data-dnt="true" height="400" data-chrome="noheader nofooter noscrollbar noborders transparent" data-widget-id="384667676347363329" aria-label="GalaxyProject Twitter"></a>
-
+<a class="twitter-timeline" data-height="400" data-dnt="true" href="https://twitter.com/galaxyproject" aria-label="GalaxyProject Twitter">GalaxyProject Twitter</a>

--- a/content/twitter-card.md
+++ b/content/twitter-card.md
@@ -4,5 +4,4 @@ icon: fab fa-twitter
 link: https://twitter.com/galaxyproject
 ---
 
-<a class="twitter-timeline" href="https://twitter.com/galaxyproject" data-dnt="true" height="400" data-chrome="noheader nofooter noscrollbar noborders transparent" data-widget-id="384667676347363329" aria-label="GalaxyProject Twitter"></a>
-
+<a class="twitter-timeline" data-height="400" data-dnt="true" href="https://twitter.com/galaxyproject" aria-label="GalaxyProject Twitter">GalaxyProject Twitter</a>

--- a/src/components/Twitter.vue
+++ b/src/components/Twitter.vue
@@ -1,0 +1,20 @@
+<template>
+    <a class="twitter-timeline" :data-width="`${width}`" :data-height="`${height}`" data-dnt="true" :href="link"
+        ><slot></slot
+    ></a>
+</template>
+
+<script>
+// This is in a component instead of a function so that static pages can use it by embedding it in their Markdown.
+import { addTwitterScript } from "~/lib/client.mjs";
+export default {
+    props: {
+        link: { type: String, required: true },
+        height: { type: String, required: true },
+        width: { type: String, required: true },
+    },
+    mounted() {
+        addTwitterScript(window);
+    },
+};
+</script>

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -32,7 +32,7 @@
 import HomeTop from "@/components/HomeTop";
 import HomeCard from "@/components/HomeCard";
 import { hasContent, gatherInserts, gatherCollections, gatherCards, makeCardRows } from "~/lib/pages.mjs";
-import { addTwitterWidget, addAltmetrics } from "~/lib/client.mjs";
+import { addTwitterScript, addAltmetricsScript } from "~/lib/client.mjs";
 export default {
     components: {
         HomeTop,
@@ -62,11 +62,11 @@ export default {
     mounted() {
         // Insert Twitter feed.
         if (this.cards.twitter) {
-            addTwitterWidget(document);
+            addTwitterScript(window);
         }
         // Add altmetrics stats badges to publications.
         if (this.cards.pubs) {
-            addAltmetrics(document);
+            addAltmetricsScript(window);
         }
     },
 };

--- a/src/lib/client.mjs
+++ b/src/lib/client.mjs
@@ -55,22 +55,22 @@ export function notifyParent(window) {
     }
 }
 
-export function addTwitterWidget(document) {
-    !(function (d, s, id) {
-        var js,
-            fjs = d.getElementsByTagName(s)[0],
-            p = /^http:/.test(d.location) ? "http" : "https";
-        if (!d.getElementById(id)) {
-            js = d.createElement(s);
-            js.id = id;
-            js.src = p + "://platform.twitter.com/widgets.js";
-            fjs.parentNode.insertBefore(js, fjs);
-        }
-    })(document, "script", "twitter-wjs");
+export function addAltmetrics(window) {
+    const altmetricScript = window.document.createElement("script");
+    altmetricScript.src = "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js";
+    window.document.head.appendChild(altmetricScript);
 }
 
-export function addAltmetrics(document) {
-    const altmetricScript = document.createElement("script");
-    altmetricScript.src = "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js";
-    document.head.appendChild(altmetricScript);
+export function addTwitterScript(window) {
+    addScript(window, "https://platform.twitter.com/widgets.js", { async: true, charset: "utf-8" });
+}
+
+/** Add a <script> to the head of the current document. */
+export function addScript(window, src, attributes = {}) {
+    let script = window.document.createElement("script");
+    script.src = src;
+    for (let [name, value] of Object.entries(attributes)) {
+        script[name] = value;
+    }
+    window.document.head.appendChild(script);
 }

--- a/src/lib/client.mjs
+++ b/src/lib/client.mjs
@@ -55,10 +55,8 @@ export function notifyParent(window) {
     }
 }
 
-export function addAltmetrics(window) {
-    const altmetricScript = window.document.createElement("script");
-    altmetricScript.src = "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js";
-    window.document.head.appendChild(altmetricScript);
+export function addAltmetricsScript(window) {
+    addScript(window, "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js");
 }
 
 export function addTwitterScript(window) {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -66,7 +66,7 @@ import HomeTop from "@/components/HomeTop";
 import HomeCard from "@/components/HomeCard";
 import HomeProfile from "@/components/HomeProfile.vue";
 import { hasContent, gatherCollections, gatherInserts, gatherCards, makeCardRows } from "~/lib/pages.mjs";
-import { addTwitterScript, addAltmetrics } from "~/lib/client.mjs";
+import { addTwitterScript, addAltmetricsScript } from "~/lib/client.mjs";
 export default {
     components: {
         HomeTop,
@@ -96,7 +96,7 @@ export default {
         }
         // Add altmetrics stats badges to publications.
         if (this.cards.pubs) {
-            addAltmetrics(window);
+            addAltmetricsScript(window);
         }
     },
 };

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -66,7 +66,7 @@ import HomeTop from "@/components/HomeTop";
 import HomeCard from "@/components/HomeCard";
 import HomeProfile from "@/components/HomeProfile.vue";
 import { hasContent, gatherCollections, gatherInserts, gatherCards, makeCardRows } from "~/lib/pages.mjs";
-import { addTwitterWidget, addAltmetrics } from "~/lib/client.mjs";
+import { addTwitterScript, addAltmetrics } from "~/lib/client.mjs";
 export default {
     components: {
         HomeTop,
@@ -92,11 +92,11 @@ export default {
     mounted() {
         // Insert Twitter feed.
         if (this.cards.twitter) {
-            addTwitterWidget(document);
+            addTwitterScript(window);
         }
         // Add altmetrics stats badges to publications.
         if (this.cards.pubs) {
-            addAltmetrics(document);
+            addAltmetrics(window);
         }
     },
 };


### PR DESCRIPTION
The method we were using to embed the Twitter timeline on the homepage was long deprecated. This updates it to use the current method.

This also adds a `<Twitter>` component to allow embedding timelines in Markdown pages (or anywhere).