### PR TITLE
Allow specifying a different Gitter room

### DIFF
--- a/config.json
+++ b/config.json
@@ -52,51 +52,61 @@
         "metadata": {
             "global": {
                 "name": "Global",
+                "gitter": "galaxyproject/Lobby",
                 "order": 0
             },
             "us": {
                 "name": "US",
                 "color": "#4e7152",
+                "gitter": "galaxyproject/Lobby",
                 "order": 1
             },
             "eu": {
                 "name": "Europe",
                 "color": "#203e5f",
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 2
             },
             "freiburg": {
                 "name": "Freiburg",
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 3
             },
             "erasmusmc": {
                 "name": "Erasmus MC",
                 "color": "#f17925",
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 4
             },
             "belgium": {
                 "name": "VIB",
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 5
             },
             "pasteur": {
                 "name": "Pasteur",
                 "color": "#7591be",
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 6
             },
             "genouest": {
                 "name": "GenOuest",
                 "color": "white",
                 "lightBg": true,
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 7
             },
             "elixir-it": {
                 "name": "ELIXIR-IT/Laniakea",
                 "color": "#2c81bb",
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 8
             },
             "ifb": {
                 "name": "ELIXIR-FR/IFB",
                 "color": "white",
                 "lightBg": true,
+                "gitter": "usegalaxy-eu/Lobby",
                 "order": 9
             }
         }

--- a/content/bare/eu/usegalaxy/main/index.md
+++ b/content/bare/eu/usegalaxy/main/index.md
@@ -21,7 +21,7 @@ title: Galaxy Europe
 
 <slot name="/bare/eu/usegalaxy/jobs" />
 
-<!-- carousel content -->
+<!-- TODO: carousel content -->
 
 <slot name="/eu/data-policy" />
 
@@ -30,4 +30,4 @@ title: Galaxy Europe
 </footer>
 
 import Gitter from "@/components/Gitter";
-<Gitter />
+<Gitter room="usegalaxy-eu/Lobby" />

--- a/content/bare/eu/usegalaxy/metabolomics/index.md
+++ b/content/bare/eu/usegalaxy/metabolomics/index.md
@@ -93,7 +93,7 @@ Other metabolomics specialized Galaxy servers:
 
 # News and Events
 
-<!-- carousel content -->
+<!-- TODO: carousel content -->
 
 <iframe title="Recent Galaxy Europe news"
  class="resize-y" src="/bare/eu/latest/news/" scrolling="no"
@@ -128,5 +128,5 @@ Other metabolomics specialized Galaxy servers:
 </footer>
 
 import Gitter from "@/components/Gitter";
-<Gitter />
+<Gitter room="usegalaxy-eu/Lobby" />
 

--- a/content/bare/eu/usegalaxy/proteomics/index.md
+++ b/content/bare/eu/usegalaxy/proteomics/index.md
@@ -128,4 +128,4 @@ MetaQuantome | Quantitative analysis of the function and taxonomy of microbiomes
 </footer>
 
 import Gitter from "@/components/Gitter";
-<Gitter />
+<Gitter room="usegalaxy-eu/Lobby" />

--- a/src/components/Gitter.vue
+++ b/src/components/Gitter.vue
@@ -4,8 +4,11 @@
 
 <script>
 // This is in a component instead of a function so that static pages can use it by embedding it in their Markdown.
-function addGitter(window) {
-    ((window.gitter = {}).chat = {}).options = { room: "galaxyproject/Lobby" };
+import { getSingleKey } from "~/lib/utils.js";
+import CONFIG from "~/../config.json";
+const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
+function addGitter(window, room) {
+    ((window.gitter = {}).chat = {}).options = { room: room };
     let body = document.querySelector("html > body");
     let script = document.createElement("script");
     script.async = true;
@@ -14,9 +17,13 @@ function addGitter(window) {
     body.appendChild(script);
 }
 export default {
+    props: {
+        room: { type: String, required: false, default: "" },
+    },
     mounted() {
         if (!window.gitter) {
-            addGitter(window);
+            let room = this.room || CONFIG.subsites.metadata[ROOT_SUBSITE]?.gitter;
+            addGitter(window, room);
         }
     },
 };

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -9,7 +9,7 @@
         <footer class="static-footer" v-if="$static.footer">
             <div class="markdown container" v-html="$static.footer.content" />
         </footer>
-        <Gitter />
+        <Gitter :room="gitter" />
     </div>
 </template>
 
@@ -34,6 +34,9 @@ export default {
                 classes.push(this.subsite);
             }
             return classes;
+        },
+        gitter() {
+            return CONFIG.subsites.metadata[this.subsite]?.gitter || CONFIG.subsites.metadata[ROOT_SUBSITE]?.gitter;
         },
     },
     mounted() {


### PR DESCRIPTION
Previously, the Gitter component always opened the main "galaxyproject/Lobby" room. But EU has its own room (usegalaxy-eu/Lobby), and that's what they use on their Galaxy middle panes.

This adds a `room` prop to the `<Gitter>` component, and uses it to specify the EU room in the current middle panes. This also uses the appropriate room on all subsite pages. Each subsite can set its own room through config.json's subsites.metadata list.