### PR TITLE
Prevent error when visiting blank subsite homepage.

### DIFF
--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -1,8 +1,8 @@
 <template>
     <Layout :subsite="subsite">
         <header id="header">
-            <h1 class="title">{{ inserts.main.title }}</h1>
-            <h3 v-if="inserts.main.subtitle">{{ inserts.main.subtitle }}</h3>
+            <h1 class="title">{{ inserts.main ? inserts.main.title : subsite }}</h1>
+            <h3 v-if="inserts.main && inserts.main.subtitle">{{ inserts.main.subtitle }}</h3>
         </header>
 
         <HomeTop :lead="inserts.lead" :jumbotron="inserts.jumbotron" />
@@ -43,7 +43,7 @@ export default {
     },
     metaInfo() {
         return {
-            title: this.inserts.main.title,
+            title: this.inserts && this.inserts.main.title,
         };
     },
     created() {
@@ -56,7 +56,7 @@ export default {
             return this.$context.subsite;
         },
         cardRows() {
-            return makeCardRows(this.$page.cards.list, this.latest, this.cards, `/${this.$context.subsite}`);
+            return makeCardRows(this.$page.cards, this.latest, this.cards, `/${this.$context.subsite}`);
         },
     },
     mounted() {

--- a/src/lib/pages.mjs
+++ b/src/lib/pages.mjs
@@ -62,6 +62,9 @@ export function gatherCollections(page) {
 
 export function gatherCards(inserts) {
     let cards = {};
+    if (!inserts) {
+        return cards;
+    }
     for (let [name, insert] of Object.entries(inserts)) {
         if (name.endsWith("-card")) {
             let cardName = rmSuffix(name, "-card");
@@ -71,11 +74,14 @@ export function gatherCards(inserts) {
     return cards;
 }
 
-export function makeCardRows(rawCards, latest, cardsData, prefix = "", rowWidth = 3) {
+export function makeCardRows(cardsMetadata, latest, cardsData, prefix = "", rowWidth = 3) {
     let rows = [];
+    if (!cardsMetadata) {
+        return rows;
+    }
     let row = [];
     let remaining = rowWidth;
-    for (let card of rawCards) {
+    for (let card of cardsMetadata.list) {
         let cardData;
         if (card.type === "dynamic") {
             let items = latest[card.name];

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -86,7 +86,7 @@ export default {
     },
     computed: {
         cardRows() {
-            return makeCardRows(this.$page.cards.list, this.latest, this.cards);
+            return makeCardRows(this.$page.cards, this.latest, this.cards);
         },
     },
     mounted() {


### PR DESCRIPTION
Previously, if an author added a new subsite to config.json, then visited its homepage, they would get a 404 or an error.

This makes a blank homepage appear instead. It also prevents errors if some of the essential Inserts (main.md, cards.md, etc) are missing but not others.

This is sorta progress towards #1526.