### PR TITLE
Remove subsites.hierarchy from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,20 +27,6 @@
         { "tag": "community-call", "path": "/community/community-calls/" }
     ],
     "subsites": {
-        "hierarchy": {
-            "global": {
-                "us": {},
-                "eu": {
-                    "freiburg": {},
-                    "pasteur": {},
-                    "belgium": {},
-                    "ifb": {},
-                    "genouest": {},
-                    "erasmusmc": {},
-                    "elixir-it": {}
-                }
-            }
-        },
         "shorthands": {
             "all": [
                 "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it", "eu", "us", "global"
@@ -49,9 +35,10 @@
                 "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it", "eu"
             ]
         },
-        "metadata": {
+        "all": {
             "global": {
                 "name": "Global",
+                "default": true,
                 "gitter": "galaxyproject/Lobby",
                 "order": 0
             },

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -12,14 +12,10 @@ var toArray = require("dayjs/plugin/toArray");
 dayjs.extend(toArray);
 const ics = require("ics");
 const { imageType } = require("gridsome/lib/graphql/types/image");
-const { repr, rmPrefix, rmSuffix, getType, matchesPrefixes, getSingleKey } = require("./src/lib/utils.js");
-const { subsiteFromPath, flattenSubsites } = require("./src/lib/site.js");
+const { repr, rmPrefix, rmSuffix, getType, matchesPrefixes } = require("./src/lib/utils.js");
+const { subsiteFromPath, getRootSubsite } = require("./src/lib/site.js");
 const CONFIG = require("./config.json");
-const SUBSITES_LIST = flattenSubsites(CONFIG.subsites.hierarchy);
-const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
-if (!ROOT_SUBSITE) {
-    console.error("Error: Subsites hierarchy in config.json must have a single root subsite.");
-}
+const ROOT_SUBSITE = getRootSubsite();
 const COLLECTION_TYPES = {
     Article: "md",
     VueArticle: "vue",
@@ -138,7 +134,7 @@ function getMainSubsite(rawMainSubsite, pagePath) {
     let mainSubsite = undefined;
     // Use any (valid) user-defined `main_subsite`.
     if (rawMainSubsite) {
-        if (SUBSITES_LIST.includes(rawMainSubsite)) {
+        if (CONFIG.subsites.all[rawMainSubsite]) {
             mainSubsite = rawMainSubsite;
         } else {
             console.error(pagePath + repr`: main_subsite ${rawMainSubsite} not recognized.`);
@@ -177,7 +173,7 @@ function getSubsites(rawSubsites, mainSubsite, pagePath) {
         if (shorthandSubsites) {
             // It's a shorthand. Add all the subsites it stands for.
             shorthandSubsites.forEach((translated) => subsitesSet.add(translated));
-        } else if (SUBSITES_LIST.includes(subsite)) {
+        } else if (CONFIG.subsites.all[subsite]) {
             // It's an actual subsite. Just add it to the list.
             subsitesSet.add(subsite);
         } else {
@@ -340,7 +336,7 @@ module.exports = function (api) {
             });
         }
         // Pages repeated across every subsite.
-        for (let subsite of SUBSITES_LIST) {
+        for (let subsite of Object.keys(CONFIG.subsites.all)) {
             let prefix;
             if (subsite === ROOT_SUBSITE) {
                 prefix = "";

--- a/src/components/Gitter.vue
+++ b/src/components/Gitter.vue
@@ -4,9 +4,9 @@
 
 <script>
 // This is in a component instead of a function so that static pages can use it by embedding it in their Markdown.
-import { getSingleKey } from "~/lib/utils.js";
+import { getRootSubsite } from "~/lib/site.js";
 import CONFIG from "~/../config.json";
-const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
+const ROOT_SUBSITE = getRootSubsite();
 function addGitter(window, room) {
     ((window.gitter = {}).chat = {}).options = { room: room };
     let body = document.querySelector("html > body");
@@ -22,7 +22,7 @@ export default {
     },
     mounted() {
         if (!window.gitter) {
-            let room = this.room || CONFIG.subsites.metadata[ROOT_SUBSITE]?.gitter;
+            let room = this.room || CONFIG.subsites.all[ROOT_SUBSITE]?.gitter;
             addGitter(window, room);
         }
     },

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -68,9 +68,10 @@
 </template>
 
 <script>
-import { rmPrefix, getSingleKey } from "~/lib/utils.js";
+import { rmPrefix } from "~/lib/utils.js";
+import { getRootSubsite } from "~/lib/site.js";
 import CONFIG from "~/../config.json";
-const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
+const ROOT_SUBSITE = getRootSubsite();
 const REPO_URL = "https://github.com/galaxyproject/galaxy-hub";
 const EDIT_PATH = "tree/master/content";
 export default {
@@ -91,7 +92,7 @@ export default {
             }
         },
         subsiteName() {
-            let nameRaw = CONFIG.subsites.metadata[this.subsite]?.name;
+            let nameRaw = CONFIG.subsites.all[this.subsite]?.name;
             if (nameRaw) {
                 return nameRaw.replace("/", " ");
             } else {
@@ -100,7 +101,7 @@ export default {
         },
         subsiteLinks() {
             let subsitesLinks = [];
-            for (let [subsite, metadata] of Object.entries(CONFIG.subsites.metadata)) {
+            for (let [subsite, metadata] of Object.entries(CONFIG.subsites.all)) {
                 if (subsite === this.subsite) {
                     continue;
                 }
@@ -120,7 +121,7 @@ export default {
             return subsitesLinks;
         },
         theme() {
-            if (CONFIG.subsites.metadata[this.subsite]?.lightBg) {
+            if (CONFIG.subsites.all[this.subsite]?.lightBg) {
                 return "light";
             } else {
                 return "dark";
@@ -128,20 +129,20 @@ export default {
         },
         classes() {
             let classes = [];
-            if (CONFIG.subsites.metadata[this.subsite]?.lightBg) {
+            if (CONFIG.subsites.all[this.subsite]?.lightBg) {
                 classes.push("light-bg");
             }
             return classes;
         },
         logoUrl() {
-            if (CONFIG.subsites.metadata[this.subsite]?.lightBg) {
+            if (CONFIG.subsites.all[this.subsite]?.lightBg) {
                 return "/images/galaxy_logo_hub.svg";
             } else {
                 return "/images/galaxy_logo_hub_white.svg";
             }
         },
         style() {
-            let color = CONFIG.subsites.metadata[this.subsite]?.color;
+            let color = CONFIG.subsites.all[this.subsite]?.color;
             if (color) {
                 return `background-color: ${color}`;
             } else {

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -16,9 +16,9 @@
 <script>
 import NavBar from "@/components/NavBar";
 import Gitter from "@/components/Gitter";
-import { getSingleKey } from "~/lib/utils.js";
+import { getRootSubsite } from "~/lib/site.js";
 import CONFIG from "~/../config.json";
-const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
+const ROOT_SUBSITE = getRootSubsite();
 export default {
     components: {
         NavBar,
@@ -36,7 +36,7 @@ export default {
             return classes;
         },
         gitter() {
-            return CONFIG.subsites.metadata[this.subsite]?.gitter || CONFIG.subsites.metadata[ROOT_SUBSITE]?.gitter;
+            return CONFIG.subsites.all[this.subsite]?.gitter || CONFIG.subsites.all[ROOT_SUBSITE]?.gitter;
         },
     },
     mounted() {

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,31 +1,22 @@
 // Functions specific to the structure of the Hub.
-const { repr, getType } = require("./utils.js");
+const { filterKeys } = require("./utils.js");
 const CONFIG = require("../../config.json");
 
-const SUBSITES_LIST = flattenSubsites(CONFIG.subsites.hierarchy);
-
-/** Take the value of the `subsites` key in config.json and flatten it into an array.
- * @param {Object} subsitesTree The value of the `subsites` key. Must be a tree of objects where
- *   the value for each key is another object.
- * @returns {Array} An array containing a list of all keys found in the tree.
- */
-function flattenSubsites(subsitesTree) {
-    let subsites = [];
-    for (let [subsite, subtree] of Object.entries(subsitesTree)) {
-        if (getType(subtree) !== "Object") {
-            throw repr`Value in subsites config tree not an object: ${subtree}`;
-        }
-        subsites.push(subsite);
-        let subsubsites = flattenSubsites(subtree);
-        subsites = subsites.concat(subsubsites);
+function getRootSubsite() {
+    let defaults = filterKeys(CONFIG.subsites.all, (subsite) => subsite.default);
+    if (defaults.length === 1) {
+        return defaults[0];
+    } else {
+        console.error(
+            `Error: subsites.list in config.json must have a single root subsite. Found ${defaults.length} instead.`
+        );
     }
-    return subsites;
 }
-module.exports.flattenSubsites = flattenSubsites;
+module.exports.getRootSubsite = getRootSubsite;
 
 function subsiteFromPath(path) {
     let pathParts = path.split("/");
-    for (let candidate of SUBSITES_LIST) {
+    for (let candidate of Object.keys(CONFIG.subsites.all)) {
         if (pathParts[0] === candidate || (pathParts[0] === "" && pathParts[1] === candidate)) {
             return candidate;
         }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -52,17 +52,21 @@ function splitlines(text) {
 }
 module.exports.splitlines = splitlines;
 
-/** Return an object's key if and only if it contains a single key.
- * @param {Object} object
- * @returns {String}
+/** Filter an object's contents and return matching keys.
+ * @param {Object}   object The object whose keys will be filtered.
+ * @param {Function} filter A function to apply to the values of the keys.
+ * @returns {Array} All keys whose values pass the filter (return true).
  */
-function getSingleKey(object) {
-    let keys = Object.keys(object);
-    if (keys.length === 1) {
-        return keys[0];
+function filterKeys(object, filter) {
+    let hits = [];
+    for (let [key, value] of Object.entries(object)) {
+        if (filter(value)) {
+            hits.push(key);
+        }
     }
+    return hits;
 }
-module.exports.getSingleKey = getSingleKey;
+module.exports.filterKeys = filterKeys;
 
 function mdToHtml(md, rmP = true) {
     //TODO: Fix links (E.g. `/src/main/index.md` -> `/main/`)

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -77,10 +77,10 @@ query Platform($path: String!) {
 </page-query>
 
 <script>
-import { mdToHtml, getSingleKey } from "~/lib/utils.js";
+import { mdToHtml } from "~/lib/utils.js";
 import { getImage } from "~/lib/pages.mjs";
-import CONFIG from "~/../config.json";
-const ROOT_SUBSITE = getSingleKey(CONFIG.subsites.hierarchy);
+import { getRootSubsite } from "~/lib/site.js";
+const ROOT_SUBSITE = getRootSubsite();
 export default {
     metaInfo() {
         return {


### PR DESCRIPTION
Implement #1421.

Only difference from what #1421 proposed: `subsites.metadata` is renamed to `subsites.all` (instead of `subsites.list`, which could be confusing, since it's an object, not an array).