### PR TITLE
Improve behavior when a new subsite is added to config.json

### DIFF
--- a/src/components/pages/Events.vue
+++ b/src/components/pages/Events.vue
@@ -1,13 +1,13 @@
 <template>
     <Layout :subsite="$context.subsite">
-        <h1 class="page-title">{{ $page.main.title }}</h1>
+        <h1 class="page-title">{{ $page.main ? $page.main.title : `${subsiteData.name} Events` }}</h1>
         <div class="toc-wrapper col-md-3">
             <ul>
                 <li><a href="#upcoming-events">Upcoming Events</a></li>
                 <li><a href="#recent-events">Recent Events</a></li>
             </ul>
         </div>
-        <div class="body-wrapper col-md-9">
+        <div v-if="hasContent($page.main)" class="body-wrapper col-md-9">
             <div class="content markdown" v-html="$page.main.content" />
         </div>
         <div class="clearfix"></div>
@@ -52,14 +52,24 @@
 
 <script>
 import ArticleTableEvents from "@/components/ArticleTableEvents";
+import { hasContent } from "~/lib/pages.mjs";
+import CONFIG from "~/../config.json";
 export default {
     components: {
         ArticleTableEvents,
     },
+    methods: {
+        hasContent,
+    },
     metaInfo() {
         return {
-            title: this.$page.main.title,
+            title: this.$page.main ? this.$page.main.title : `${this.subsiteData.name} Events`,
         };
+    },
+    computed: {
+        subsiteData() {
+            return CONFIG.subsites.all[this.$context.subsite];
+        },
     },
 };
 </script>

--- a/src/components/pages/EventsArchive.vue
+++ b/src/components/pages/EventsArchive.vue
@@ -1,9 +1,7 @@
 <template>
     <Layout :subsite="$context.subsite">
-        <template v-if="$page.main">
-            <h1 class="page-title">{{ $page.main.title }}</h1>
-            <div class="markdown" v-html="$page.main.content" />
-        </template>
+        <h1 class="page-title">{{ $page.main ? $page.main.title : `${subsiteData.name} Events Archive` }}</h1>
+        <div class="markdown" v-if="hasContent($page.main)" v-html="$page.main.content" />
         <table class="table table-striped">
             <thead>
                 <tr>
@@ -23,14 +21,24 @@
 
 <script>
 import ArticleTableEvents from "@/components/ArticleTableEvents";
+import { hasContent } from "~/lib/pages.mjs";
+import CONFIG from "~/../config.json";
 export default {
     components: {
         ArticleTableEvents,
     },
+    methods: {
+        hasContent,
+    },
     metaInfo() {
         return {
-            title: this.$page.main.title,
+            title: this.$page.main ? this.$page.main.title : `${this.subsiteData.name} Events Archive`,
         };
+    },
+    computed: {
+        subsiteData() {
+            return CONFIG.subsites.all[this.$context.subsite];
+        },
     },
 };
 </script>

--- a/src/components/pages/News.vue
+++ b/src/components/pages/News.vue
@@ -1,7 +1,7 @@
 <template>
     <Layout :subsite="$context.subsite">
-        <h1 class="page-title">{{ $page.main.title }}</h1>
-        <div class="markdown" v-html="$page.main.content" />
+        <h1 class="page-title">{{ $page.main ? $page.main.title : `${subsiteData.name} News` }}</h1>
+        <div class="markdown" v-if="hasContent($page.main)" v-html="$page.main.content" />
         <table class="table table-striped">
             <tbody>
                 <ArticleTable v-for="edge in $page.articles.edges" :key="edge.node.id" :article="edge.node" />
@@ -12,14 +12,24 @@
 
 <script>
 import ArticleTable from "@/components/ArticleTable";
+import { hasContent } from "~/lib/pages.mjs";
+import CONFIG from "~/../config.json";
 export default {
     components: {
         ArticleTable,
     },
+    methods: {
+        hasContent,
+    },
     metaInfo() {
         return {
-            title: this.$page.main.title,
+            title: this.$page.main ? this.$page.main.title : `${this.subsiteData.name} News`,
         };
+    },
+    computed: {
+        subsiteData() {
+            return CONFIG.subsites.all[this.$context.subsite];
+        },
     },
 };
 </script>

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -1,7 +1,7 @@
 <template>
     <Layout :subsite="subsite">
         <header id="header">
-            <h1 class="title">{{ inserts.main ? inserts.main.title : subsite }}</h1>
+            <h1 class="title">{{ inserts.main ? inserts.main.title : subsiteData.name }}</h1>
             <h3 v-if="inserts.main && inserts.main.subtitle">{{ inserts.main.subtitle }}</h3>
         </header>
 
@@ -33,6 +33,7 @@ import HomeTop from "@/components/HomeTop";
 import HomeCard from "@/components/HomeCard";
 import { hasContent, gatherInserts, gatherCollections, gatherCards, makeCardRows } from "~/lib/pages.mjs";
 import { addTwitterScript, addAltmetricsScript } from "~/lib/client.mjs";
+import CONFIG from "~/../config.json";
 export default {
     components: {
         HomeTop,
@@ -43,7 +44,7 @@ export default {
     },
     metaInfo() {
         return {
-            title: this.inserts && this.inserts.main.title,
+            title: this.inserts.main ? this.inserts.main.title : this.subsiteData.name,
         };
     },
     created() {
@@ -52,6 +53,9 @@ export default {
         this.latest = gatherCollections(this.$page);
     },
     computed: {
+        subsiteData() {
+            return CONFIG.subsites.all[this.$context.subsite];
+        },
         subsite() {
             return this.$context.subsite;
         },

--- a/src/lib/pages.mjs
+++ b/src/lib/pages.mjs
@@ -51,7 +51,7 @@ export function gatherInserts(allInsert) {
 export function gatherCollections(page) {
     let collections = {};
     for (let [category, value] of Object.entries(page)) {
-        if (value.edges) {
+        if (value && value.edges) {
             collections[category] = value.edges.map((edge) => edge.node);
         }
     }


### PR DESCRIPTION
This follows up on #1527 by also making sure the other auto-generated subsite pages besides the homepages will work out of the box: `/{subsite}/news/`, `/{subsite}/events/`, and `/{subsite}/events/archive/`.

This also uses better defaults for missing data. Namely, the page title will use the human-readable subsite name instead of the raw key.