### PR TITLE
FTP decomission notice: emphasize that it's only the FTP service.

### DIFF
--- a/content/usegalaxy/welcome/main.md
+++ b/content/usegalaxy/welcome/main.md
@@ -4,7 +4,7 @@ title: usegalaxy.org
 
 <div class="alert alert-danger trim-p mt-2">
 
-<h2>The usegalaxy.org FTP service will be decommissioned on August 12, 2022</h2>
+## The usegalaxy.org **FTP** service will be decommissioned on August 12, 2022
 
 For more details, alternatives, and help, please **[read the announcement on Galaxy Help](https://help.galaxyproject.org/t/the-usegalaxy-org-ftp-service-will-be-decommissioned-on-august-12-2022/8318)**.
 

--- a/content/usegalaxy/welcome/main.md
+++ b/content/usegalaxy/welcome/main.md
@@ -2,7 +2,7 @@
 title: usegalaxy.org
 ---
 
-<div class="alert alert-danger trim-p mt-2">
+<div class="alert alert-info trim-p mt-2">
 
 ## The usegalaxy.org **FTP** service will be decommissioned on August 12, 2022
 


### PR DESCRIPTION
When I went to Galaxy, for a second my brain saw the big red notice and it looked like it was saying Galaxy itself was being shut down.

This bolds the word "FTP" as a feeble attempt to reduce the likelihood of that happening.