### PR TITLE
Center subsite names in the NavBar.

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -181,12 +181,12 @@ function getPath(page) {
 <style scoped>
 #subsite-name {
     display: flex;
-    align-items: center;
     margin-right: 10px;
 }
 #subsite-name > p {
     line-height: 100%;
     white-space: normal;
+    text-align: center;
     font-size: 1.1rem;
     max-width: 95px;
     margin: 0;


### PR DESCRIPTION
Before:
[![image](https://user-images.githubusercontent.com/645773/184006143-d1d033d8-fcf2-4e3c-a3b2-af052f6f3e3e.png)](https://galaxyproject.org/erasmusmc/)

After:
![image](https://user-images.githubusercontent.com/645773/184007388-37d39df7-168a-4bdd-905c-9cf7e307a2de.png)