### PR TITLE
Customizable navbars

### DIFF
--- a/navbars.json
+++ b/navbars.json
@@ -1,0 +1,52 @@
+{
+    "global": {
+        "left": [
+            { "label": "News", "relativeTo": "subsite", "target": "news/" },
+            { "label": "Events", "relativeTo": "subsite", "target": "events/" }
+        ],
+        "right": [
+            {
+                "label": "Support",
+                "contents": [
+                    { "label": "Get started", "target": "/get-started/" },
+                    { "label": "Training", "target": "/learn/" },
+                    { "label": "FAQ", "target": "/support/" },
+                    { "label": "Galaxy Help Forum", "target": "https://help.galaxyproject.org/" }
+                ]
+            },
+            {
+                "label": "Community",
+                "contents": [
+                    { "label": "The Galaxy Community", "target": "/community/" },
+                    { "label": "Blog", "target": "/blog/" },
+                    { "label": "Working Groups", "target": "/community/wg/" },
+                    { "label": "Governance", "target": "/community/governance/" },
+                    { "label": "How to contribute", "target": "/community/contributing/" },
+                    { "label": "Galaxy Mentor Network", "target": "https://galaxy-mentor-network.netlify.app/" },
+                    { "label": "Code of Conduct", "target": "/community/coc/" }
+                ]
+            },
+            {
+                "label": "About",
+                "contents": [
+                    { "label": "Platforms", "target": "/use/" },
+                    { "label": "Careers", "target": "/careers/" },
+                    { "label": "Stats", "target": "/galaxy-project/statistics/" },
+                    { "label": "Mailing lists", "target": "/mailing-lists" },
+                    { "label": "Publications", "target": "/publication-library/" },
+                    { "label": "Citing Galaxy", "target": "/citing-galaxy/" },
+                    { "label": "Branding", "target": "/images/galaxy-logos/" }
+                ]
+            },
+            {
+                "label": "Projects",
+                "contents": [
+                    { "label": "COVID-19", "target": "/projects/covid19/" },
+                    { "label": "Monkeypox", "target": "/projects/mpxv/" },
+                    { "label": "VGP", "target": "/projects/vgp/" }
+                ]
+            },
+            { "label": "@jxtx", "target": "/jxtx/" }
+        ]
+    }
+}

--- a/src/components/NavBarItem.vue
+++ b/src/components/NavBarItem.vue
@@ -1,0 +1,22 @@
+<template>
+    <b-nav-item v-if="item.type === 'link' && item.to" :to="item.to">{{ item.label }}</b-nav-item>
+    <b-nav-item v-else-if="item.type === 'link' && item.href" :href="item.href">{{ item.label }}</b-nav-item>
+    <b-nav-item-dropdown v-else-if="item.type === 'dropdown'" :text="item.label">
+        <template v-for="subitem of item.contents">
+            <b-dropdown-item v-if="subitem.to" :to="subitem.to" :key="subitem.key">
+                {{ subitem.label }}
+            </b-dropdown-item>
+            <b-dropdown-item v-else-if="subitem.href" :href="subitem.href" :key="subitem.key">
+                {{ subitem.label }}
+            </b-dropdown-item>
+        </template>
+    </b-nav-item-dropdown>
+</template>
+
+<script>
+export default {
+    props: {
+        item: { type: Object, required: true },
+    },
+};
+</script>


### PR DESCRIPTION
This changes the NavBar from being entirely hardcoded and site-wide to making it partially configurable by each subsite.

Each subsite can define their own navbar in the `navbars.json` config file. I tried to make the format as intuitive as possible.

FYI this doesn't yet support the `<b-dropdown-group>` component used in #1429, so if we end up wanting that we'll have to extend this.