### PR TITLE
Rename "Support" NavBar dropdown to "Help".

### DIFF
--- a/navbars.json
+++ b/navbars.json
@@ -6,7 +6,7 @@
         ],
         "right": [
             {
-                "label": "Support",
+                "label": "Help",
                 "contents": [
                     { "label": "Get started", "target": "/get-started/" },
                     { "label": "Training", "target": "/learn/" },


### PR DESCRIPTION
I think "Help" is a better description of what you'll find under the current "Support" dropdown. To me, "Support" suggests more like live software support, but the things in the dropdown are more like self-help resources.

It also gives us just a smidge more room in the navbar, which really matters at this point.

Before:
![image](https://user-images.githubusercontent.com/645773/184236119-c975204f-e777-4107-8edb-bd45e00fb3bf.png)

After:
![image](https://user-images.githubusercontent.com/645773/184235995-8dc059dd-b131-419e-a8bf-5e11f7498452.png)
