### PR TITLE
Add classes for hiding elements on small screens.

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @import "variables.scss";
 /* hub-specific overrides to variables */
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
@@ -520,6 +521,35 @@ h6:hover .heading-anchor span:before {
     }
     a:hover {
         text-decoration: underline;
+    }
+}
+
+/* Convenience classes to hide elements below a certain screen width.
+ * These use Bootstrap's breakpoint definitions (found in its scss/_variables.scss file).
+ * See also: https://getbootstrap.com/docs/5.0/layout/breakpoints/
+ */
+// Hide on screens narrower than 576px (by default).
+@media (max-width: map.get($grid-breakpoints, "sm")) {
+    .sm-plus {
+        display: none;
+    }
+}
+// 768px
+@media (max-width: map.get($grid-breakpoints, "md")) {
+    .md-plus {
+        display: none;
+    }
+}
+// 992px
+@media (max-width: map.get($grid-breakpoints, "lg")) {
+    .lg-plus {
+        display: none;
+    }
+}
+// 1200px
+@media (max-width: map.get($grid-breakpoints, "xl")) {
+    .xl-plus {
+        display: none;
     }
 }
 

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -24,10 +24,13 @@
                     <b-nav-form id="search" action="/search/" method="get">
                         <b-form-input id="search-input" size="sm" name="q" placeholder="Search"></b-form-input>
                     </b-nav-form>
-                    <b-nav-item :href="editUrl">
-                        <i class="fab fa-lg fa-github"></i>
-                        <span class="xl-plus"> Edit</span>
-                    </b-nav-item>
+                    <b-nav-text>
+                        <!-- Workaround for the lack of a working `aria-label` prop on `<b-nav-item>`. -->
+                        <a class="edit-link" :href="editUrl" aria-label="Edit this page">
+                            <i class="fab fa-lg fa-github"></i>
+                            <span class="xl-plus"> Edit</span>
+                        </a>
+                    </b-nav-text>
                 </b-navbar-nav>
             </b-collapse>
         </b-navbar>
@@ -190,7 +193,10 @@ function getPath(page) {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+@use "sass:map";
+@import "~bootstrap/scss/bootstrap.scss";
+
 #subsite-name {
     display: flex;
     margin-right: 10px;
@@ -206,5 +212,10 @@ function getPath(page) {
 }
 #search-input {
     width: 175px;
+}
+@media (min-width: map.get($grid-breakpoints, "lg")) {
+    .edit-link {
+        padding-left: 8px;
+    }
 }
 </style>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -26,7 +26,7 @@
                     </b-nav-form>
                     <b-nav-item :href="editUrl">
                         <i class="fab fa-lg fa-github"></i>
-                        Edit
+                        <span class="xl-plus"> Edit</span>
                     </b-nav-item>
                 </b-navbar-nav>
             </b-collapse>


### PR DESCRIPTION
This adds a few convenience classes so you can easily mark an element to only show on larger screens.

For example, this PR also includes a change using the new system to hide the "Edit" label on the NavBar Github link when the screen width gets below 1200px (it was bunching up and causing layout issues). It does this by just adding the `xl-plus` class to it. The class names use Bootstrap's [size names](https://getbootstrap.com/docs/5.0/layout/breakpoints/): `sm-plus`, `md-plus`, `lg-plus`, and `xl-plus`.