### PR TITLE
Fine tune NavBar search box size on different screen sizes

### DIFF
--- a/cypress/integration/main.spec.js
+++ b/cypress/integration/main.spec.js
@@ -12,10 +12,6 @@ describe("Sitewide tests", () => {
     it("Visits the homepage", () => {
         cy.visit("/");
     });
-    it("Opens gitter sidecar and the iframe is injected", () => {
-        cy.get(".gitter-open-chat-button").click();
-        cy.get("iframe[src='https://gitter.im/galaxyproject/Lobby/~embed']").should("be.visible");
-    });
     it("Tests the NavBar", () => {
         // Check that the dropdown menus work.
         // findByRole doesn't seem to work on invisible elements.
@@ -28,6 +24,10 @@ describe("Sitewide tests", () => {
             .findByText(/Events/i)
             .click();
         cy.location("pathname").should("equal", "/events/");
+    });
+    it("Opens gitter sidecar and the iframe is injected", () => {
+        cy.get(".gitter-open-chat-button").click();
+        cy.get("iframe[src='https://gitter.im/galaxyproject/Lobby/~embed']").should("be.visible");
     });
 });
 

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -210,9 +210,21 @@ function getPath(page) {
     margin: 0;
     padding: 0;
 }
+/* Play with search box size at different resolutions to get a little more space when needed. */
 #search-input {
     width: 175px;
 }
+@media (min-width: map.get($grid-breakpoints, "lg")) and (max-width: map.get($grid-breakpoints, "xl")) {
+    #search-input {
+        width: 125px;
+    }
+}
+@media (max-width: map.get($grid-breakpoints, "lg")) {
+    #search-input {
+        width: 250px;
+    }
+}
+// The <b-nav-text> workaround (see above) requires us to set this manually.
 @media (min-width: map.get($grid-breakpoints, "lg")) {
     .edit-link {
         padding-left: 8px;


### PR DESCRIPTION
This shrinks the search box when the screen starts getting narrow and we start really running out of space in the NavBar.

It expands it again once the screen gets truly mobile-size because then the NavBar collapses to a hamburger dropdown, where we have more horizontal space for each item again.