### PR TITLE
Fix issue navigating between subsite homepages

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -52,15 +52,12 @@ export default {
         NavBarItem,
     },
     data() {
-        let pathPrefix;
-        if (!this.subsite || this.subsite === CONFIG.subsites.default) {
-            pathPrefix = "";
-        } else {
-            pathPrefix = `/${this.subsite}`;
-        }
         return {
-            pathPrefix,
+            pathPrefix: getPathPrefix(this.subsite, CONFIG.subsites.default),
         };
+    },
+    beforeUpdate() {
+        this.pathPrefix = getPathPrefix(this.subsite, CONFIG.subsites.default);
     },
     computed: {
         customContent() {
@@ -148,6 +145,13 @@ export default {
         },
     },
 };
+function getPathPrefix(subsite, defaultSubsite) {
+    if (!subsite || subsite === defaultSubsite) {
+        return "";
+    } else {
+        return `/${subsite}`;
+    }
+}
 /** Turn the raw, human-friendly navbar definition into a structure more easily used in the template. */
 function parseCustomContent(rawContent, pathPrefix) {
     let content = {};

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -58,12 +58,6 @@ export default {
         update(this);
     },
     computed: {
-        title() {
-            return searchBundle(this.bundles.main, "title", this.subsiteData.name);
-        },
-        subtitle() {
-            return searchBundle(this.bundles.main, "subtitle");
-        },
         cardRows() {
             return makeCardRows(this.$page.cards, this.latest, this.cards, `/${this.$context.subsite}`);
         },
@@ -86,6 +80,8 @@ function update(data) {
     data.cards = gatherCards(data.inserts);
     data.latest = gatherCollections(data.$page);
     data.bundles = gatherBundles(data.inserts);
+    data.title = searchBundle(data.bundles.main, "title", data.subsiteData.name);
+    data.subtitle = searchBundle(data.bundles.main, "subtitle");
 }
 </script>
 

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -52,12 +52,10 @@ export default {
         };
     },
     created() {
-        this.subsite = this.$context.subsite;
-        this.subsiteData = CONFIG.subsites.all[this.$context.subsite];
-        this.inserts = gatherInserts(this.$page.allInsert);
-        this.cards = gatherCards(this.inserts);
-        this.latest = gatherCollections(this.$page);
-        this.bundles = gatherBundles(this.inserts);
+        update(this);
+    },
+    beforeUpdate() {
+        update(this);
     },
     computed: {
         title() {
@@ -81,6 +79,14 @@ export default {
         }
     },
 };
+function update(data) {
+    data.subsite = data.$context.subsite;
+    data.subsiteData = CONFIG.subsites.all[data.$context.subsite];
+    data.inserts = gatherInserts(data.$page.allInsert);
+    data.cards = gatherCards(data.inserts);
+    data.latest = gatherCollections(data.$page);
+    data.bundles = gatherBundles(data.inserts);
+}
 </script>
 
 <page-query>

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -47,8 +47,12 @@ export default {
         Bundle,
     },
     metaInfo() {
+        let data = this;
         return {
-            title: this.inserts.main ? this.inserts.main.title : this.subsiteData.name,
+            title: () => this.title || (this.inserts.main && this.inserts.main.title) || this.subsiteData.name,
+            afterNavigation(metaInfo) {
+                metaInfo.title = data.title;
+            },
         };
     },
     created() {


### PR DESCRIPTION
When navigating between subsite homepages (ones that use `SubsiteHome.vue`), most of the content fails to update.

This is because many of the data structures those pages use are defined in the `created()` hook, which doesn't run between navigations because the page doesn't get re-created. Instead, we have to use the `beforeUpdate()` hook, which runs [just after the page data changes](https://vuejs.org/guide/essentials/lifecycle.html#lifecycle-diagram).