### PR TITLE
Put list of components autodetected by `fileRequiresVue()` into constant, tweak algorithm

### DIFF
--- a/src/build/partition-content.mjs
+++ b/src/build/partition-content.mjs
@@ -355,8 +355,9 @@ function getChildrenByType(dirPath) {
 
 /** Read the file to see if it requires `vue-remark`.
  *  @returns {boolean} If there's a `components` key in the graymatter, it will return its value (converted to boolean).
- *    Otherwise, it will look for the strings `'<slot '` or `'<g-image '` in the file contents. If either is found, it
- *    will return `true`. Otherwise it returns `false`.
+ *    Otherwise, it will look for the strings `'<slot '`, `'<g-image '`, `'<link-box '`, `'<vega-embed '`, or
+ *    `'<markdown-embed '` in the file contents. If any is found, it will return `true`.
+ *    Otherwise it returns `false`.
  */
 function fileRequiresVue(filePath) {
     let fileContents = fs.readFileSync(filePath, { encoding: "utf8" });

--- a/src/build/partition-content.mjs
+++ b/src/build/partition-content.mjs
@@ -9,6 +9,7 @@ import { PathInfo } from "../lib/paths.mjs";
 export const CONTENT_TYPES = ["md", "vue", "insert", "resource"];
 const SCRIPT_DIR = nodePath.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = nodePath.dirname(nodePath.dirname(SCRIPT_DIR));
+const AUTODETECT_COMPONENTS = ["slot", "g-image", "link-box", "vega-embed", "markdown-embed"];
 
 export class Partitioner {
     /** Create a `Partitioner`.
@@ -355,9 +356,8 @@ function getChildrenByType(dirPath) {
 
 /** Read the file to see if it requires `vue-remark`.
  *  @returns {boolean} If there's a `components` key in the graymatter, it will return its value (converted to boolean).
- *    Otherwise, it will look for the strings `'<slot '`, `'<g-image '`, `'<link-box '`, `'<vega-embed '`, or
- *    `'<markdown-embed '` in the file contents. If any is found, it will return `true`.
- *    Otherwise it returns `false`.
+ *    Otherwise, it will look in the file contents for the start tags of elements in `AUTODETECT_COMPONENTS`, e.g.
+ *    `'<slot'`. If any is found, it will return `true`. Otherwise it returns `false`.
  */
 function fileRequiresVue(filePath) {
     let fileContents = fs.readFileSync(filePath, { encoding: "utf8" });
@@ -365,14 +365,14 @@ function fileRequiresVue(filePath) {
     if (Object.prototype.hasOwnProperty.call(metadata, "components")) {
         return !!metadata.components;
     }
-    if (fileContainsTags(content, ["slot", "g-image", "link-box", "vega-embed", "markdown-embed"])) {
+    if (fileContainsTags(content, AUTODETECT_COMPONENTS)) {
         return true;
     }
     return false;
 }
 
 function fileContainsTags(fileContents, tags) {
-    let queryStrings = tags.map((tag) => `<${tag} `);
+    let queryStrings = tags.map((tag) => `<${tag}`);
     for (let line of splitlines(fileContents)) {
         for (let query of queryStrings) {
             if (line.includes(query)) {


### PR DESCRIPTION
The `fileRequiresVue()` function in `partition-content.mjs` contained a periodically-growing, hardcoded list of components it searches Markdown files for. This list was out of sync with another list that was in its docstring.

This updates the documentation and puts the hardcoded list in a constant, at least. It still feels like these should go in `config.json` or something. But there's another duplicate list of the global components in `main.js`, and it's a lot harder to source that one from `config.json`. But at least this reduces the number of duplicates by one.

This also tweaks the autodetection algorithm by removing the requirement for the tag to have a space after it (e.g. it looks for `<slot`, not `<slot ` now). This could save a future headache if we end up in the situation where we include a component with no props. False positives have a small cost, so it's better to be on the safe side.