### PR TITLE
Add `hide_tease` metadata field

### DIFF
--- a/content/0examples/non-vue/index.md
+++ b/content/0examples/non-vue/index.md
@@ -1,6 +1,7 @@
 ---
 title: Example Markdown page (without Vue components)
 tease: A tease
+hide_tease: true
 # Normally you wouldn't set the category manually. Instead, it's set based on where this file is
 # placed in the content directory. Since this isn't in the right place, we set it here manually.
 category: events

--- a/content/0examples/vue-remark/index.md
+++ b/content/0examples/vue-remark/index.md
@@ -1,6 +1,7 @@
 ---
 title: Example Markdown page with Vue components
 tease: A tease
+hide_tease: false
 # Normally you wouldn't set the category manually. Instead, it's set based on where this file is
 # placed in the content directory. Since this isn't in the right place, we set it here manually.
 category: news

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -8,7 +8,7 @@
         <g-image v-if="article.image" class="img-fluid main-image" :src="image" />
         <h1 class="title float-left" v-if="!article.skip_title_render">{{ article.title }}</h1>
         <div class="clearfix"></div>
-        <p class="subtitle" v-if="article.tease">{{ article.tease }}</p>
+        <p class="subtitle" v-if="article.tease && !article.hide_tease">{{ article.tease }}</p>
         <ul class="metadata list-unstyled" v-if="article.category === 'events'">
             <li v-if="article.date"><span class="metakey">Date:</span> {{ dateSpan }}</li>
             <li v-if="article.location">

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -12,6 +12,7 @@ query Article($path: String!) {
         id
         title
         tease
+        hide_tease
         subsites
         main_subsite
         category

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -26,6 +26,7 @@ query VueArticle($path: String!) {
         id
         title
         tease
+        hide_tease
         subsites
         main_subsite
         category


### PR DESCRIPTION
This field allows an author to show the tease in the listing page (`/news/`, `/events/`, etc), but hide it on the Article/VueArticle's actual page.

This is useful in cases like when we're importing content from .eu which doesn't have a tease, so we just use the first sentence of the content. That works, but looks repetitive when it shows up twice in a row on the article's page. So this works around that issue.