### PR TITLE
Change how NavBar subsite dropdown menu order is stored.

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,56 +36,47 @@
             ]
         },
         "default": "global",
+        "navbar": ["global", "us", "eu", "freiburg", "erasmusmc", "belgium", "pasteur", "genouest", "elixir-it", "ifb"],
         "all": {
             "global": {
                 "name": "Global",
-                "gitter": "galaxyproject/Lobby",
-                "order": 0
+                "gitter": "galaxyproject/Lobby"
             },
             "us": {
                 "name": "US",
-                "gitter": "galaxyproject/Lobby",
-                "order": 1
+                "gitter": "galaxyproject/Lobby"
             },
             "eu": {
                 "name": "Europe",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 2
+                "gitter": "usegalaxy-eu/Lobby"
             },
             "freiburg": {
                 "name": "Freiburg",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 3
+                "gitter": "usegalaxy-eu/Lobby"
             },
             "erasmusmc": {
                 "name": "Erasmus MC",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 4
+                "gitter": "usegalaxy-eu/Lobby"
             },
             "belgium": {
                 "name": "VIB",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 5
+                "gitter": "usegalaxy-eu/Lobby"
             },
             "pasteur": {
                 "name": "Pasteur",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 6
+                "gitter": "usegalaxy-eu/Lobby"
             },
             "genouest": {
                 "name": "GenOuest",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 7
+                "gitter": "usegalaxy-eu/Lobby"
             },
             "elixir-it": {
                 "name": "ELIXIR-IT/Laniakea",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 8
+                "gitter": "usegalaxy-eu/Lobby"
             },
             "ifb": {
                 "name": "ELIXIR-FR/IFB",
-                "gitter": "usegalaxy-eu/Lobby",
-                "order": 9
+                "gitter": "usegalaxy-eu/Lobby"
             }
         }
     },

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -140,21 +140,11 @@ export default {
             }
         },
         subsiteLinks() {
-            let subsitesLinks = [];
-            for (let [subsite, metadata] of Object.entries(CONFIG.subsites.all)) {
-                if (subsite === this.subsite) {
-                    continue;
-                }
-                let link = {
-                    key: subsite,
-                    name: metadata.name,
-                    order: metadata.order,
-                };
-                link.path = getPathPrefix(subsite) + "/";
-                subsitesLinks.push(link);
-            }
-            subsitesLinks.sort((a, b) => a.order > b.order);
-            return subsitesLinks;
+            return CONFIG.subsites.navbar.map((subsite) => ({
+                key: subsite,
+                name: CONFIG.subsites.all[subsite].name,
+                path: getPathPrefix(subsite) + "/",
+            }));
         },
         theme() {
             if (this.customContent.style?.lightBg) {


### PR DESCRIPTION
This makes it so the list of subsites in the NavBar "Regions" drop-down is stored in the `subsites.navbar` key of config.json, instead of using the `order` property of each entry in the `subsites.all` list. It duplicates the subsite keys again, but it seems a bit more natural to store the order in an array instead of indices of properties of objects. It also makes it more explicit what the setting is for, and allows omitting subsites too.

One visible change this makes is that it now shows the current subsite in the list instead of omitting it. I think this makes navigation a bit easier, and it's also consistent with how the rest of the NavBar links work.