### PR TITLE
Remove empty metadata fields, change location_url -> location.url

### DIFF
--- a/content/events/2020-03-wir-vs-virus/index.md
+++ b/content/events/2020-03-wir-vs-virus/index.md
@@ -6,9 +6,7 @@ tease: "Looking for bold and innovative ideas that will help society to show sol
 continent: EU
 location:
   name: "Online, Germany"
-location_url: 
 external_url: "https://galaxyproject.eu/posts/2020/03/19/wirvsvirus/"
-image: 
 gtn: true
 contact: "Organizers"
 tags: [ cofest ]

--- a/content/events/2020-06-ml/index.md
+++ b/content/events/2020-06-ml/index.md
@@ -6,8 +6,6 @@ tease: "Register by 16 June"
 continent: EU
 location:
   name: "University of Freiburg, Online, Freiburg, Germany"
-image: 
-location_url: ""
 external_url: "https://galaxyproject.eu/event/2020-05-27-Machine-Learning-Elixir/"
 gtn: true
 links:

--- a/content/events/2020-12-metabolomics/index.md
+++ b/content/events/2020-12-metabolomics/index.md
@@ -6,10 +6,8 @@ tease: "Bringing together Galaxy metabolomics researchers, users and developers,
 continent: EU
 location:
   name: "Online, Germany"
-location_url: ""
 external_url: "https://galaxyproject.eu/event/2020-11-24-metabolomics/"
 gtn: false
 contact: "Melanie Föll"
-image: 
 subsites: [global, us]
 ---

--- a/content/events/2021-01-metabolomics/index.md
+++ b/content/events/2021-01-metabolomics/index.md
@@ -7,11 +7,7 @@ continent: EU
 location:
   name: "Freiburg, Online, Germany"
 external_url: "https://galaxyproject.eu/event/2021-1-25-Metabolomics-Mini-Symposium/"
-location_url: ""
 gtn: false
 contact: "Melanie Föll, Beatriz Serrano-Solano"
-tags: []
-links:
-image: 
 subsites: [global, us]
 ---

--- a/content/events/2021-09-arc/index.md
+++ b/content/events/2021-09-arc/index.md
@@ -6,8 +6,6 @@ tease: "Build use and support ARCs with new tools, templates, and ideas."
 continent: EU
 location:
   name: "Villa Denis, Frankenstein, Germany"
-image: 
-location_url: ""
 external_url: "https://galaxyproject.eu/event/2021-08-26-hackathon-fdo/"
 gtn: false
 contact: "dataplant /@/ uni-kl.de"

--- a/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
+++ b/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
@@ -3,8 +3,8 @@ title: "EuroScienceGateway Kick-off Meeting"
 date: "2022-10-06"
 end: "2022-10-07"
 tags: [conference]
-organiser:
-  name: Freiburg Galaxy Team
+contacts:
+- name: Freiburg Galaxy Team
   email: galaxy@informatik.uni-freiburg.de
 location:
   name: Institute for Informatics, Albert-Ludwigs-University Freiburg

--- a/content/events/2022-09-29-community-call/index.md
+++ b/content/events/2022-09-29-community-call/index.md
@@ -6,11 +6,10 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Wolfgang Maier"
-links:
 tags: ["community-call"]
 subsites: [all]
 ---

--- a/content/events/2022-09-small-scale/index.md
+++ b/content/events/2022-09-small-scale/index.md
@@ -2,25 +2,16 @@
 title: "Small Scale Galaxy Admins Meeting"
 date: '2022-09-20'
 days: 1
-tease: 
 continent: GL
 location: "Online, Global"
-image: 
-location_url: 
-external_url:
 gtn: false
 contact: "Lucille Delisle"
-tags: []
 subsites: [global, us]
 ---
-
-
 
 Please [join us](https://epfl.zoom.us/j/62244337954?pwd=L2ZVSytTdlpaM1pvbjZpWjNjUm9JZz09) at 4 PM CEST ([see in your timezone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Small+Scale+Galaxy+Admins+Meeting&iso=20220920T16&p1=1229&ah=1)) 
 for a discussion about 'How I switched from an old Galaxy to an ansible Galaxy?' lead by Lucille Delisle. 
 There will also be time to discuss any current problems you encounter as a maintainer of a Galaxy server.
-
-
 
 ---
 

--- a/content/events/2022-10-13-community-call/index.md
+++ b/content/events/2022-10-13-community-call/index.md
@@ -6,11 +6,9 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
-external_url:
+  url: "/community/community-calls/"
 gtn: false
 contact: "Eli Chadwick"
-links:
 tags: ["community-call"]
 subsites: [all]
 ---

--- a/content/events/2022-10-27-community-call/index.md
+++ b/content/events/2022-10-27-community-call/index.md
@@ -6,11 +6,10 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Helena Rasche & Saskia Hiltemann"
-links:
 tags: ["community-call"]
 subsites: [all]
 ---

--- a/content/events/2022-10-cloud-computing-workshop/index.md
+++ b/content/events/2022-10-cloud-computing-workshop/index.md
@@ -7,10 +7,7 @@ continent: GL
 location:
   name: "Online"
 external_url: "https://www.abrf.org/workshops-webinars"
-location_url: ""
 gtn: false
 contact: "Melanie Foell"
-tags: [ ]
-image: 
 subsites: [global, all-eu]
 ---

--- a/content/events/2022-11-BH2022/index.md
+++ b/content/events/2022-11-BH2022/index.md
@@ -6,7 +6,7 @@ tease: "BioHackathon activities are driven by practical sessions where people ga
 continent: EU
 location:
   name: "Paris + Online, France"
-location_url: "https://biohackathon-europe.org/"
+  url: "https://biohackathon-europe.org/"
 external_url: ""
 image: "/images/logos/bhlogo.png"
 gtn: False

--- a/content/events/2022-gcc/index.md
+++ b/content/events/2022-gcc/index.md
@@ -6,7 +6,7 @@ tease: "The annual gathering of the Galaxy Community"
 continent: NA
 location:
   name: "University of Minnesota, Minneapolis, Minnesota, United States"
-location_url: https://twin-cities.umn.edu/
+  url: https://twin-cities.umn.edu/
 external_url: "/events/gcc2022/"
 image: 
 gtn: true

--- a/content/events/2022-pag/index.md
+++ b/content/events/2022-pag/index.md
@@ -6,7 +6,7 @@ tease: "Galaxy is for Plants and Animals too..."
 continent: NA
 location:
   name: "PAG, San Diego, California, United States"
-location_url: https://www.intlpag.org/2022/
+  url: https://www.intlpag.org/2022/
 gtn: true
 contact: Presenters
 image: /images/events/2022-pag/pag-2022-splash.png


### PR DESCRIPTION
Until we do an automated change of all `location_url` metadata fields to a `url` property of the `location` field (details in #1621), this makes that change for some recent events. That should help people using them as a template.

This also removes fields with empty values from recent events, too.