### PR TITLE
Enable Regions dropdown for subsites other than Global

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -10,7 +10,7 @@
                     <p>{{ subsiteName }}</p>
                 </b-navbar-brand>
                 <b-navbar-nav id="subsite-items">
-                    <b-nav-item-dropdown id="subsite-select" v-if="false" text="Regions">
+                    <b-nav-item-dropdown id="subsite-select" v-if="subsite !== defaultSubsite" text="Regions">
                         <b-dropdown-item v-for="link of subsiteLinks" :key="link.key" :to="link.path">
                             {{ link.name }}
                         </b-dropdown-item>


### PR DESCRIPTION
This enables the NavBar "Regions" dropdown menu for switching between subsites, but only for the new (non-Global) subsites.

Since the non-Global subsites aren't accessible* yet, this doesn't really make them public yet. So it's not the official unveiling yet. It just makes it easier to test and preview what it'll eventually look like.

\* The exception is that there's a few events with a `main_subsite` set, which makes the navbar for that subsite display. But there's only two at the moment. Call it a "stealth launch" if you want.