### PR TITLE
Fix relative links in US navbar.

### DIFF
--- a/content/us/navbar.yml
+++ b/content/us/navbar.yml
@@ -1,2 +1,9 @@
 style:
   color: "#4e7152"
+left:
+- label: News
+  relativeTo: subsite
+  target: news/
+- label: Events
+  relativeTo: subsite
+  target: events/


### PR DESCRIPTION
Because of the way NavBar defaults are inherited, the US navbar's "News" and "Events" links were to the Global feeds, not the US feeds. See #1635 for details.