### PR TITLE
Port more content from .eu

### DIFF
--- a/content/events/2019-04-bioit/index.md
+++ b/content/events/2019-04-bioit/index.md
@@ -6,12 +6,12 @@ tease: ""
 continent: NA
 location:
   name: "BioIT World, Boston, Massachusetts, United States"
-location_url: "http://www.giiconference.com/chi653337/" 
-external_url:
+  url: "http://www.giiconference.com/chi653337/"
 image: /events/2019-04-bioit/bioitworld19.png
 gtn: false
-contact: "Presenters"
-contact_url: "/people/jeremy-goecks/"
+contacts:
+- name: Jeremy Goecks
+  url: /people/jeremy-goecks/
 tags: [ cofest ]
 subsites: [global, us]
 ---

--- a/content/events/2022-05-12-community-call/index.md
+++ b/content/events/2022-05-12-community-call/index.md
@@ -12,7 +12,7 @@ gtn: false
 contact: "TBA"
 links:
 tags: ["community-call"]
-subsites: [global, us]
+subsites: [all]
 ---
 <iframe width="560" height="315" src="https://www.youtube.com/embed/6tT_TFq-6A8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/events/2022-05-26-community-call/index.md
+++ b/content/events/2022-05-26-community-call/index.md
@@ -12,7 +12,7 @@ gtn: false
 contact: "Mike Schatz"
 links:
 tags: ["community-call"]
-subsites: [global, us]
+subsites: [all]
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/PGMrUfgRQd8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/events/2022-06-08-elixir-communities-connectedness/index.md
+++ b/content/events/2022-06-08-elixir-communities-connectedness/index.md
@@ -6,7 +6,7 @@ tease: "Workshop at the ELIXIR All Hands 2022"
 continent: EU
 location:
   name: "ELIXIR All Hands 2022, Amsterdam, Europe"
-location_url: "https://elixir-europe.org/events/elixir-all-hands-2022"
+  url: "https://elixir-europe.org/events/elixir-all-hands-2022"
 external_url: "https://docs.google.com/document/d/194CPrabfk0qd9uTnxOFB2WNkppyiRfIPZxp1o6XYlg4/edit#heading=h.2et92p0"
 gtn: false
 contact: "Katharina Heil"

--- a/content/events/2022-06-09-community-call/index.md
+++ b/content/events/2022-06-09-community-call/index.md
@@ -12,7 +12,7 @@ gtn: false
 contact: "Simon Bray"
 links:
 tags: ["community-call"]
-subsites: [global, us]
+subsites: [all]
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ob8dNeCRaic" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/events/2022-06-09-elixir-eosc-life/index.md
+++ b/content/events/2022-06-09-elixir-eosc-life/index.md
@@ -6,7 +6,7 @@ tease: "Talk at the ELIXIR All Hands 2022"
 continent: EU
 location:
   name: "ELIXIR All Hands 2022, Amsterdam, Europe"
-location_url: "https://elixir-europe.org/events/elixir-all-hands-2022"
+  url: "https://elixir-europe.org/events/elixir-all-hands-2022"
 external_url: "https://elixir-events.eventscase.com/EN/elixirallhands2022/Agenda"
 gtn: false
 contact: "Beatriz Serrano-Solano"

--- a/content/events/2022-06-09-elixir-infrastructure/index.md
+++ b/content/events/2022-06-09-elixir-infrastructure/index.md
@@ -6,7 +6,7 @@ tease: "Talk at the ELIXIR All Hands 2022"
 continent: EU
 location:
   name: "ELIXIR All Hands 2022, Amsterdam, Europe"
-location_url: "https://elixir-europe.org/events/elixir-all-hands-2022"
+  url: "https://elixir-europe.org/events/elixir-all-hands-2022"
 external_url: "https://elixir-events.eventscase.com/EN/elixirallhands2022/Agenda"
 gtn: false
 contact: "Björn Grüning"

--- a/content/events/2022-06-09-elixir-tools-ecosystem/index.md
+++ b/content/events/2022-06-09-elixir-tools-ecosystem/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Science driven improvements to tools ecosystems "
+title: "Science driven improvements to tools ecosystems"
 date: '2022-06-09'
 days: 1
 tease: "Workshop at the ELIXIR All Hands 2022"
 continent: EU
 location:
   name: "ELIXIR All Hands 2022, Amsterdam, Europe"
-location_url: "https://elixir-europe.org/events/elixir-all-hands-2022"
+  url: "https://elixir-europe.org/events/elixir-all-hands-2022"
 external_url: "https://docs.google.com/document/d/1VA_9_1TOECPL26exs4Nyow_Y2V9RGzOnzF0WYcmLxyo/edit"
 gtn: false
 contact: "Johan Gustafsson, Steven Manos, Nigel Ward, Andrew Lonie, Brian Davis, Sarah Beecroft, Carole Goble, Finn Bacall, Nicola Soranzo, Bjӧrn Grüning, Herve Menager, Hans Ienasescu"

--- a/content/events/2022-06-23-community-call/index.md
+++ b/content/events/2022-06-23-community-call/index.md
@@ -12,7 +12,7 @@ gtn: false
 contact: "John Davis, Marius van den Beek"
 links:
 tags: ["community-call"]
-subsites: [global, us]
+subsites: [all]
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/rl3a-vvoAGQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/events/2022-06-summer-schools-bioinformatics/index.md
+++ b/content/events/2022-06-summer-schools-bioinformatics/index.md
@@ -6,11 +6,9 @@ tease: "Applications close 8 March"
 continent: EU
 location:
   name: "EMBL-EBI, Online, Hinxton, United Kingdom"
+  url: "https://www.ebi.ac.uk/training/"
 external_url: "https://coursesandconferences.wellcomeconnectingscience.org/event/summer-school-in-bioinformatics-20220613/?utm_campaign=ssbi2022-summer-school-in-bioinformatics"
-location_url: "https://www.ebi.ac.uk/training/"
 gtn: false
 contact: "Organizers"
-tags: [ ]
-image: 
-subsites: [global, us]
+subsites: [all]
 ---

--- a/content/events/2022-07-04-galaxy-rnaseq-workshop-freiburg/index.md
+++ b/content/events/2022-07-04-galaxy-rnaseq-workshop-freiburg/index.md
@@ -1,0 +1,33 @@
+---
+title: Galaxy RNA-Seq data analysis workshop
+date: '2022-07-04'
+end: '2022-07-05'
+tease: We are offering a Galaxy 2-days crash course on RNA-Seq data analysis.
+hide_tease: true
+tags: [training]
+contacts:
+- email: contact@usegalaxy.eu
+  name: Freiburg Galaxy Team
+location:
+  name: online
+supporters:
+- crc1425
+- crc992
+- meinbio
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+We are offering a Galaxy 2-days crash course on RNA-Seq data analysis. This course is offered mainly for students and members of CRCs from Freiburg. There are 25 places available.
+
+For the workshop application, please contact the organizer (Anika Erxleben: erxleben@informatik.uni-freiburg.de).
+  
+## Venue
+
+Institute for Biology II/III, Schänzlestr. 1, Freiburg
+
+## Program
+
+- Monday, 04 July, 9-17:00 - Galaxy introduction
+- Tuesday, 05 July 9-17:00 - RNA Seq Data analysis
+

--- a/content/events/2022-07-04-galaxyws-trr167/index.md
+++ b/content/events/2022-07-04-galaxyws-trr167/index.md
@@ -1,0 +1,80 @@
+---
+title: Galaxy Training on HTS data analysis for the members of NeuroMac
+date: '2022-07-04'
+end: '2022-07-08'
+tease: We are offering a Galaxy training on high-throughput data analysis.
+hide_tease: true
+tags: [training]
+contacts:
+- email: dyusuf@informatik.uni-freiburg.de
+  name: Dilmurat Yusuf
+location:
+  name: online
+supporters:
+- neuromac
+hidefooter: true
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+We are offering a Galaxy training on high-throughput data analysis. This is an
+online course and is limited to the members of NeuroMac.
+
+In order to join the training, please
+
+1. Create an account on [the European Galaxy server](https://usegalaxy.eu).
+2. Join the training group on Galaxy by clicking this [link](https://usegalaxy.eu/join-training/trr167_galaxy) which is created for the training only. After the training, you can directly access the Galaxy service from [the European Galaxy server](https://usegalaxy.eu).
+
+## Venue
+
+Online
+
+## Program
+
+Every day, the training will run from **9:00-17:00 CET** (give or take, depending
+on questions at the end). If the times will change, it will be announced during the training.
+
+Schedule:
+
+| Day        | Topics                         | Training material |
+|------------|--------------------------------|-------------------|
+| 04.07.2022 | RNA-Seq analysis: QC, genome mapping, gene quantification, DE | [](https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/ref-based/tutorial.html){: .fa .fa-laptop} |
+| 05.07.2022 | RNA-Seq analysis: visualization and functional profile        | [](https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/rna-seq-viz-with-heatmap2/tutorial.html){: .fa .fa-laptop target="_blank"} [](https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/rna-seq-viz-with-volcanoplot/tutorial.html){: .fa .fa-laptop} |
+| 06.07.2022 | Build workflow of RNA-Seq analysis |
+| 07.07.2022 | Pre-processing of scRNA | [](https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/scrna-preprocessing/tutorial.html){: .fa .fa-laptop} [](https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/scrna-preprocessing-tenx/tutorial.html){: .fa .fa-laptop} |
+| 08.07.2022 | Clustering of scRNA | [](https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/tutorial.html){: .fa .fa-laptop} |
+
+### Agenda
+Each tutorial is divided into 3 sessions:
+* **Training session** is [a zoom meeting](https://uni-freiburg.zoom.us/j/69564802900?pwd=cjZQWjFQVEYxUStCbitXRDdFdGdaQT09) where I will present the basic idea of the topic and demonstrate the data analysis on Galaxy and explain each analysis step. It is a popcorn session. Participants should relax, watch and ask questions.
+* **Hands-on session** is the work-session. Participants will perform the analysis that they have learned during the training session. The training materials are provided. All the questions during the hands-on session will be answered by me in [a SIGNAL group](https://signal.group/#CjQKIH6KglJTodpulsUflQDHyEEURMaxPWfaDvbpG0hop4XJEhCmmjxMoz_8UJy0hI6SZCFP). All the training information and training material will stay online even after the training.
+* **Q&A session**: Day ends with an extended live discussion on zoom where we all can discuss any remaining questions about the topic. This session will start at 16:30.
+
+I encourage you to start the analysis of your own data after completing the tutorials.
+
+## Links
+
+* Download [SIGNAL](https://signal.org/en/download/)
+* [Galaxy tips and tricks](https://github.com/bgruening/galaxy-tricks)
+* [Galaxy training network](http://training.galaxyproject.org)
+
+## Preparation
+Some important steps to consider before joining the training:
+
+1. For the training, all you need is a computer with a latest web browser.
+2. Galaxy interactive tours guide you stepwise through the Galaxy user interface
+and the history. They will help you to follow the Galaxy introduction, and
+ensure everyone has a basic understanding of how Galaxy works. It is recommended
+to go through the following two Galaxy interactive tours before beginning the
+ training, but it is not mandatory.
+    - [Galaxy UI](https://usegalaxy.eu/tours/core.galaxy_ui)
+    - [History Introduction](https://usegalaxy.eu/tours/core.history)
+
+If you have any questions, please do not hesitate to [contact me](mailto:dyusuf@informatik.uni-freiburg.de).
+
+## Organizers
+
+{% assign extra_organizers =  "galaxy-freiburg|galaxy-europe" | split: "|"  %}
+{% include sponsors.html supporters=extra_organizers hidetitle=true %}
+
+

--- a/content/events/2022-07-07-community-call/index.md
+++ b/content/events/2022-07-07-community-call/index.md
@@ -12,7 +12,7 @@ gtn: false
 contact: "Anup Kumar"
 links:
 tags: ["community-call"]
-subsites: [global, us]
+subsites: [all]
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/3uNtw0_sSDU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/events/2022-07-making-sense-genomic-data/index.md
+++ b/content/events/2022-07-making-sense-genomic-data/index.md
@@ -7,7 +7,6 @@ continent: GL
 location:
   name: "Online, Mexico, South Africa, Sydney, UK, India"
 external_url: "https://www.futurelearn.com/courses/making-sense-of-genomic-data-covid-19-web-based-bioinformatics"
-location_url: ""
 gtn: false
 contacts:
 - name: "Carolina Castañeda Garcia"

--- a/content/events/2022-07-making-sense-genomic-data/index.md
+++ b/content/events/2022-07-making-sense-genomic-data/index.md
@@ -9,8 +9,12 @@ location:
 external_url: "https://www.futurelearn.com/courses/making-sense-of-genomic-data-covid-19-web-based-bioinformatics"
 location_url: ""
 gtn: false
-contact: "Carolina Castañeda Garcia, Claudine Nkera-Gutabara, Tanya Golubchik, Tracey Calvert-Joshua, Varun Shamanna"
-tags: [ ]
-image: 
+contacts:
+- name: "Carolina Castañeda Garcia"
+- name: "Claudine Nkera-Gutabara"
+- name: "Tanya Golubchik"
+- name: "Tracey Calvert-Joshua"
+- name: "Varun Shamanna"
+tags: [ training ]
 subsites: [global, all-eu]
 ---

--- a/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
+++ b/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
@@ -1,5 +1,7 @@
 ---
 title: "EuroScienceGateway Kick-off Meeting"
+tease: "Within the European Galaxy Days, the EuroScienceGateway consortium of 18 partners will get together in Freiburg, Germany, for a 2-day Kick-off Meeting."
+hide_tease: true
 date: "2022-10-06"
 end: "2022-10-07"
 tags: [conference]
@@ -16,7 +18,8 @@ location:
 supporters:
 - eu
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
+main_subsite: freiburg
 ---
 
 Within the **European Galaxy Days**, the **EuroScienceGateway consortium of 18 partners** will get together in Freiburg, Germany, 

--- a/content/events/2022-10-cloud-computing-workshop/index.md
+++ b/content/events/2022-10-cloud-computing-workshop/index.md
@@ -8,6 +8,7 @@ location:
   name: "Online"
 external_url: "https://www.abrf.org/workshops-webinars"
 gtn: false
-contact: "Melanie Foell"
+contacts:
+- name: "Melanie Foell"
 subsites: [global, all-eu]
 ---

--- a/content/events/2022-11-BH2022/index.md
+++ b/content/events/2022-11-BH2022/index.md
@@ -7,7 +7,6 @@ continent: EU
 location:
   name: "Paris + Online, France"
   url: "https://biohackathon-europe.org/"
-external_url: ""
 image: "/images/logos/bhlogo.png"
 gtn: False
 contact: "Project organizers"

--- a/content/events/2022-gcc/index.md
+++ b/content/events/2022-gcc/index.md
@@ -8,9 +8,8 @@ location:
   name: "University of Minnesota, Minneapolis, Minnesota, United States"
   url: https://twin-cities.umn.edu/
 external_url: "/events/gcc2022/"
-image: 
 gtn: true
 contact: Organizers
-tags: [ cofest ]
-subsites: [global, us]
+tags: [cofest]
+subsites: [all]
 ---

--- a/content/news/2022-06-27-tool-update/index.md
+++ b/content/news/2022-06-27-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-06-27
+tease: "On 2022-06-27, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-06-27'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-06-27-tool-update/index.md
+++ b/content/news/2022-06-27-tool-update/index.md
@@ -1,0 +1,87 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-06-27
+date: '2022-06-27'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-06-27, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #333](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#333/)
+
+
+## Data Managers
+
+- data_manager_eggnog_mapper_abspath was updated to [81a286e4c5a2](https://toolshed.g2.bx.psu.edu/view/galaxyp/data_manager_eggnog_mapper_abspath/81a286e4c5a2)
+
+## Proteomics
+
+- eggnog_mapper was updated to [5a30ae278db0](https://toolshed.g2.bx.psu.edu/view/galaxyp/eggnog_mapper/5a30ae278db0)
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+- pep_pointer was updated to [a6282baa8c6f](https://toolshed.g2.bx.psu.edu/view/galaxyp/pep_pointer/a6282baa8c6f)
+- syndiva was updated to [0254731f047b](https://toolshed.g2.bx.psu.edu/view/iuc/syndiva/0254731f047b)
+
+## RNA Analysis
+
+- barrnap was updated to [fe48aa4ccd5e](https://toolshed.g2.bx.psu.edu/view/iuc/barrnap/fe48aa4ccd5e)
+
+## Single-cell
+
+- anndata_export was updated to [0cb889db0910](https://toolshed.g2.bx.psu.edu/view/iuc/anndata_export/0cb889db0910)
+- anndata_import was updated to [fb9e030ffae4](https://toolshed.g2.bx.psu.edu/view/iuc/anndata_import/fb9e030ffae4)
+- anndata_inspect was updated to [ee98d611afc6](https://toolshed.g2.bx.psu.edu/view/iuc/anndata_inspect/ee98d611afc6)
+- anndata_manipulate was updated to [3d748954434b](https://toolshed.g2.bx.psu.edu/view/iuc/anndata_manipulate/3d748954434b)
+- modify_loom was updated to [4b0adaa31c95](https://toolshed.g2.bx.psu.edu/view/iuc/modify_loom/4b0adaa31c95)
+
+## Multiple Alignments
+
+- kc_align was updated to [97476dfde728](https://toolshed.g2.bx.psu.edu/view/iuc/kc_align/97476dfde728)
+
+## Variant Calling
+
+- vg_deconstruct was updated to [76d18b1e970b](https://toolshed.g2.bx.psu.edu/view/iuc/vg_deconstruct/76d18b1e970b)
+- vg_view was updated to [ee62774bb5bd](https://toolshed.g2.bx.psu.edu/view/iuc/vg_view/ee62774bb5bd)
+
+## Get Data
+
+- ncbi_datasets was updated to [b2ae7186d41f](https://toolshed.g2.bx.psu.edu/view/iuc/ncbi_datasets/b2ae7186d41f)
+
+## Nanopore
+
+- nanocompore_db was updated to [35d3618b124b](https://toolshed.g2.bx.psu.edu/view/iuc/nanocompore_db/35d3618b124b)
+- nanocompore_sampcomp was updated to [c0fb573c1e8d](https://toolshed.g2.bx.psu.edu/view/iuc/nanocompore_sampcomp/c0fb573c1e8d)
+
+## FASTA/FASTQ
+
+- cutadapt was updated to [5915ea1ec9b1](https://toolshed.g2.bx.psu.edu/view/lparsons/cutadapt/5915ea1ec9b1)
+
+## Assembly
+
+- ragtag was updated to [d110a4141898](https://toolshed.g2.bx.psu.edu/view/iuc/ragtag/d110a4141898)
+
+## SAM/BAM
+
+- samtools_stats was updated to [3a0efe14891f](https://toolshed.g2.bx.psu.edu/view/devteam/samtools_stats/3a0efe14891f)
+- samtools_markdup was updated to [887e02a45734](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_markdup/887e02a45734)
+
+## Mothur
+
+- mothur_get_relabund was updated to [6b3130958acc](https://toolshed.g2.bx.psu.edu/view/iuc/mothur_get_relabund/6b3130958acc)
+
+## Imaging
+
+- spyboat was updated to [9c53c7da9cbe](https://toolshed.g2.bx.psu.edu/view/iuc/spyboat/9c53c7da9cbe)
+
+## Metagenomic Analysis
+
+- staramr was updated to [be818ae858e4](https://toolshed.g2.bx.psu.edu/view/nml/staramr/be818ae858e4)
+
+

--- a/content/news/2022-07-03-tool-update/index.md
+++ b/content/news/2022-07-03-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-07-03
+tease: "On 2022-07-03, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-07-03'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-07-03-tool-update/index.md
+++ b/content/news/2022-07-03-tool-update/index.md
@@ -1,0 +1,77 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-07-03
+date: '2022-07-03'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-07-03, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #334](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#334/)
+
+
+## Join, Subtract and Group
+
+- datamash_ops was updated to [746e8e4bf929](https://toolshed.g2.bx.psu.edu/view/iuc/datamash_ops/746e8e4bf929)
+- datamash_reverse was updated to [f198773344e4](https://toolshed.g2.bx.psu.edu/view/iuc/datamash_reverse/f198773344e4)
+- datamash_transpose was updated to [ac092723240d](https://toolshed.g2.bx.psu.edu/view/iuc/datamash_transpose/ac092723240d)
+
+## Proteomics
+
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_semanticvalidator was updated to [b60c5420dac6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_semanticvalidator/b60c5420dac6)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## hca_sc_scanpy_tools
+
+- scanpy_find_markers was updated to [af5e4efa9e66](https://toolshed.g2.bx.psu.edu/view/ebi-gxa/scanpy_find_markers/af5e4efa9e66)
+
+## Metagenomic Analysis
+
+- concoct was updated to [7a145c72d375](https://toolshed.g2.bx.psu.edu/view/iuc/concoct/7a145c72d375)
+- concoct_coverage_table was updated to [052e6bc06ea3](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_coverage_table/052e6bc06ea3)
+- concoct_cut_up_fasta was updated to [137ede2b48c0](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_cut_up_fasta/137ede2b48c0)
+- concoct_extract_fasta_bins was updated to [92a2d9109528](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_extract_fasta_bins/92a2d9109528)
+- concoct_merge_cut_up_clustering was updated to [ce1a3ce0e807](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_merge_cut_up_clustering/ce1a3ce0e807)
+- das_tool was updated to [a8e434ebe961](https://toolshed.g2.bx.psu.edu/view/iuc/das_tool/a8e434ebe961)
+- drep_compare was updated to [54aa421c2911](https://toolshed.g2.bx.psu.edu/view/iuc/drep_compare/54aa421c2911)
+- drep_dereplicate was updated to [368cb4bef9d8](https://toolshed.g2.bx.psu.edu/view/iuc/drep_dereplicate/368cb4bef9d8)
+- fasta_to_contig2bin was updated to [5033d753964b](https://toolshed.g2.bx.psu.edu/view/iuc/fasta_to_contig2bin/5033d753964b)
+- recentrifuge was updated to [09b7b0b2e2c2](https://toolshed.g2.bx.psu.edu/view/iuc/recentrifuge/09b7b0b2e2c2)
+
+## Variant Calling
+
+- delly_call was updated to [c34eab9d5134](https://toolshed.g2.bx.psu.edu/view/iuc/delly_call/c34eab9d5134)
+- delly_classify was updated to [df4300f300e4](https://toolshed.g2.bx.psu.edu/view/iuc/delly_classify/df4300f300e4)
+- delly_cnv was updated to [8ad49c4272ea](https://toolshed.g2.bx.psu.edu/view/iuc/delly_cnv/8ad49c4272ea)
+- delly_filter was updated to [74f9f312c713](https://toolshed.g2.bx.psu.edu/view/iuc/delly_filter/74f9f312c713)
+- delly_lr was updated to [7bd397ff21a2](https://toolshed.g2.bx.psu.edu/view/iuc/delly_lr/7bd397ff21a2)
+- delly_merge was updated to [6c44bbc0eaa5](https://toolshed.g2.bx.psu.edu/view/iuc/delly_merge/6c44bbc0eaa5)
+- ensembl_vep was updated to [27fd1c1f00a8](https://toolshed.g2.bx.psu.edu/view/iuc/ensembl_vep/27fd1c1f00a8)
+- vcf2maf was updated to [2973994fecd6](https://toolshed.g2.bx.psu.edu/view/iuc/vcf2maf/2973994fecd6)
+
+## Nanopore
+
+- medaka_consensus was updated to [d6cddc06aeae](https://toolshed.g2.bx.psu.edu/view/iuc/medaka_consensus/d6cddc06aeae)
+- medaka_consensus_pipeline was updated to [cb34f00cc10f](https://toolshed.g2.bx.psu.edu/view/iuc/medaka_consensus_pipeline/cb34f00cc10f)
+- medaka_variant was updated to [cc36773a3681](https://toolshed.g2.bx.psu.edu/view/iuc/medaka_variant/cc36773a3681)
+- medaka_variant_pipeline was updated to [1d62240feff3](https://toolshed.g2.bx.psu.edu/view/iuc/medaka_variant_pipeline/1d62240feff3)
+
+## Assembly
+
+- yahs was updated to [d87433f2a54d](https://toolshed.g2.bx.psu.edu/view/iuc/yahs/d87433f2a54d)
+
+## None
+
+- data_manager_build_kraken2_database was updated to [9002633b4737](https://toolshed.g2.bx.psu.edu/view/iuc/data_manager_build_kraken2_database/9002633b4737)
+
+## Annotation
+
+- annotatemyids was updated to [4f2967b27e67](https://toolshed.g2.bx.psu.edu/view/iuc/annotatemyids/4f2967b27e67)
+
+

--- a/content/news/2022-07-10-tool-update/index.md
+++ b/content/news/2022-07-10-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-07-10
+tease: "On 2022-07-10, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-07-10'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-07-10-tool-update/index.md
+++ b/content/news/2022-07-10-tool-update/index.md
@@ -1,0 +1,78 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-07-10
+date: '2022-07-10'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-07-10, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #335](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#335/)
+
+
+## Text Manipulation
+
+- concatenate_multiple_datasets was updated to [55cf9d9defd1](https://toolshed.g2.bx.psu.edu/view/artbio/concatenate_multiple_datasets/55cf9d9defd1)
+- split_file_on_column was updated to [d4b5b70e82cb](https://toolshed.g2.bx.psu.edu/view/bgruening/split_file_on_column/d4b5b70e82cb)
+
+## Mapping
+
+- bowtie2 was updated to [f6877ad76b00](https://toolshed.g2.bx.psu.edu/view/devteam/bowtie2/f6877ad76b00)
+- bbtools_bbmap was updated to [858a65b52cf9](https://toolshed.g2.bx.psu.edu/view/iuc/bbtools_bbmap/858a65b52cf9)
+- hisat2 was updated to [f4af63aaf57a](https://toolshed.g2.bx.psu.edu/view/iuc/hisat2/f4af63aaf57a)
+
+## Assembly
+
+- cap3 was updated to [d76a0d8a9eac](https://toolshed.g2.bx.psu.edu/view/artbio/cap3/d76a0d8a9eac)
+- velvet was updated to [920677cd220f](https://toolshed.g2.bx.psu.edu/view/devteam/velvet/920677cd220f)
+- smudgeplot was updated to [24e471d13fe9](https://toolshed.g2.bx.psu.edu/view/galaxy-australia/smudgeplot/24e471d13fe9)
+
+## Get Data
+
+- unipept was updated to [7863f1abcdda](https://toolshed.g2.bx.psu.edu/view/galaxyp/unipept/7863f1abcdda)
+
+## Proteomics
+
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Climate Analysis
+
+- climate_stripes was updated to [abdc27e01dca](https://toolshed.g2.bx.psu.edu/view/climate/climate_stripes/abdc27e01dca)
+
+## Metagenomic Analysis
+
+- bracken was updated to [19035a7b1106](https://toolshed.g2.bx.psu.edu/view/iuc/bracken/19035a7b1106)
+- concoct was updated to [3842ef1b2f34](https://toolshed.g2.bx.psu.edu/view/iuc/concoct/3842ef1b2f34)
+- concoct_coverage_table was updated to [6302656ed45d](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_coverage_table/6302656ed45d)
+- concoct_cut_up_fasta was updated to [0132036a530a](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_cut_up_fasta/0132036a530a)
+- concoct_extract_fasta_bins was updated to [bcd8d64f82b7](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_extract_fasta_bins/bcd8d64f82b7)
+- concoct_merge_cut_up_clustering was updated to [21ccf9548e2c](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_merge_cut_up_clustering/21ccf9548e2c)
+
+## Variant Calling
+
+- irissv was updated to [b4b6b660293a](https://toolshed.g2.bx.psu.edu/view/iuc/irissv/b4b6b660293a)
+- lofreq_alnqual was updated to [791f73caa0c8](https://toolshed.g2.bx.psu.edu/view/iuc/lofreq_alnqual/791f73caa0c8)
+- lofreq_call was updated to [4805fe3d8fda](https://toolshed.g2.bx.psu.edu/view/iuc/lofreq_call/4805fe3d8fda)
+- lofreq_indelqual was updated to [971e07ca4456](https://toolshed.g2.bx.psu.edu/view/iuc/lofreq_indelqual/971e07ca4456)
+
+## FASTA/FASTQ
+
+- flash was updated to [01a4ebf1f237](https://toolshed.g2.bx.psu.edu/view/iuc/flash/01a4ebf1f237)
+
+## Phylogenetics
+
+- pangolin was updated to [a2099fb98cdb](https://toolshed.g2.bx.psu.edu/view/iuc/pangolin/a2099fb98cdb)
+
+## Annotation
+
+- hamronize_summarize was updated to [6e2731b13533](https://toolshed.g2.bx.psu.edu/view/iuc/hamronize_summarize/6e2731b13533)
+
+

--- a/content/news/2022-07-18-tool-update/index.md
+++ b/content/news/2022-07-18-tool-update/index.md
@@ -1,0 +1,97 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-07-18
+date: '2022-07-18'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-07-18, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #336](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#336/)
+
+
+## Text Manipulation
+
+- tables_arithmetic_operations was updated to [82fa5062d611](https://toolshed.g2.bx.psu.edu/view/devteam/tables_arithmetic_operations/82fa5062d611)
+- regex_find_replace was updated to [399da6b5ec21](https://toolshed.g2.bx.psu.edu/view/galaxyp/regex_find_replace/399da6b5ec21)
+
+## ChemicalToolBox
+
+- gmx_check was updated to [26467f738ed4](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_check/26467f738ed4)
+- gmx_editconf was updated to [067c643b0cc0](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_editconf/067c643b0cc0)
+- gmx_em was updated to [9660b2c5fdda](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_em/9660b2c5fdda)
+- gmx_energy was updated to [b3ce2a978520](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_energy/b3ce2a978520)
+- gmx_get_builtin_file was updated to [1f98845f4df4](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_get_builtin_file/1f98845f4df4)
+- gmx_makendx was updated to [a72a739de916](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_makendx/a72a739de916)
+- gmx_makendx was updated to [c102b3f42778](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_makendx/c102b3f42778)
+- gmx_merge_topology_files was updated to [17c12d5cb336](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_merge_topology_files/17c12d5cb336)
+- gmx_restraints was updated to [455470c9d8e6](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_restraints/455470c9d8e6)
+- gmx_restraints was updated to [4f371a6a30d4](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_restraints/4f371a6a30d4)
+- gmx_rg was updated to [018628703771](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_rg/018628703771)
+- gmx_setup was updated to [1a5991ec7ce1](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_setup/1a5991ec7ce1)
+- gmx_setup was updated to [ea2287ee360b](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_setup/ea2287ee360b)
+- gmx_sim was updated to [4c4f1761d31f](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_sim/4c4f1761d31f)
+- gmx_solvate was updated to [2dfcf594c838](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_solvate/2dfcf594c838)
+- gmx_solvate was updated to [696c5419ea84](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_solvate/696c5419ea84)
+- gmx_trj was updated to [4a303225d447](https://toolshed.g2.bx.psu.edu/view/chemteam/gmx_trj/4a303225d447)
+
+## Assembly
+
+- merqury was updated to [f8113c25bc6b](https://toolshed.g2.bx.psu.edu/view/iuc/merqury/f8113c25bc6b)
+- rnaspades was updated to [378e55aeeb25](https://toolshed.g2.bx.psu.edu/view/iuc/rnaspades/378e55aeeb25)
+- spades_biosyntheticspades was updated to [1fc82fe7ebef](https://toolshed.g2.bx.psu.edu/view/iuc/spades_biosyntheticspades/1fc82fe7ebef)
+- spades_coronaspades was updated to [fee85957cebe](https://toolshed.g2.bx.psu.edu/view/iuc/spades_coronaspades/fee85957cebe)
+- spades_metaplasmidspades was updated to [21da31ed41a1](https://toolshed.g2.bx.psu.edu/view/iuc/spades_metaplasmidspades/21da31ed41a1)
+- spades_metaviralspades was updated to [86f66ab58e14](https://toolshed.g2.bx.psu.edu/view/iuc/spades_metaviralspades/86f66ab58e14)
+- spades_plasmidspades was updated to [6aad515a5270](https://toolshed.g2.bx.psu.edu/view/iuc/spades_plasmidspades/6aad515a5270)
+- spades_rnaviralspades was updated to [b3490b036c5a](https://toolshed.g2.bx.psu.edu/view/iuc/spades_rnaviralspades/b3490b036c5a)
+- yahs was updated to [a3a92e30a727](https://toolshed.g2.bx.psu.edu/view/iuc/yahs/a3a92e30a727)
+- metaspades was updated to [606b09cc9860](https://toolshed.g2.bx.psu.edu/view/nml/metaspades/606b09cc9860)
+- spades was updated to [78ced22d09a2](https://toolshed.g2.bx.psu.edu/view/nml/spades/78ced22d09a2)
+
+## Gemini
+
+- gemini_actionable_mutations was updated to [db47f4939381](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_actionable_mutations/db47f4939381)
+- gemini_amend was updated to [334e946cacd4](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_amend/334e946cacd4)
+- gemini_annotate was updated to [cf0f0f05ba9f](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_annotate/cf0f0f05ba9f)
+- gemini_burden was updated to [f0bf88e9e689](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_burden/f0bf88e9e689)
+- gemini_db_info was updated to [c2a413e47fe9](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_db_info/c2a413e47fe9)
+- gemini_fusions was updated to [c00dcd1455a0](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_fusions/c00dcd1455a0)
+- gemini_gene_wise was updated to [e57a1b0ac6be](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_gene_wise/e57a1b0ac6be)
+- gemini_inheritance was updated to [2c68e29c3527](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_inheritance/2c68e29c3527)
+- gemini_interactions was updated to [f745f54638e5](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_interactions/f745f54638e5)
+- gemini_load was updated to [2270a8b83c12](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_load/2270a8b83c12)
+- gemini_lof_sieve was updated to [4b5123d51e8c](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_lof_sieve/4b5123d51e8c)
+- gemini_pathways was updated to [9551b3da9f5d](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_pathways/9551b3da9f5d)
+- gemini_qc was updated to [20f2ecf46dcb](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_qc/20f2ecf46dcb)
+- gemini_query was updated to [77a1e60fd1de](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_query/77a1e60fd1de)
+- gemini_roh was updated to [e8349da26ed5](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_roh/e8349da26ed5)
+- gemini_set_somatic was updated to [7814e39409d1](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_set_somatic/7814e39409d1)
+- gemini_stats was updated to [b92cfa44f5be](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_stats/b92cfa44f5be)
+- gemini_windower was updated to [406d3552beca](https://toolshed.g2.bx.psu.edu/view/iuc/gemini_windower/406d3552beca)
+
+## Proteomics
+
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## FASTA/FASTQ
+
+- gfastats was updated to [8ccbf07a5433](https://toolshed.g2.bx.psu.edu/view/bgruening/gfastats/8ccbf07a5433)
+
+## Virology
+
+- ivar_consensus was updated to [2d9926ce62be](https://toolshed.g2.bx.psu.edu/view/iuc/ivar_consensus/2d9926ce62be)
+- ivar_consensus was updated to [e319b5b65879](https://toolshed.g2.bx.psu.edu/view/iuc/ivar_consensus/e319b5b65879)
+- ivar_filtervariants was updated to [0135f1d487a0](https://toolshed.g2.bx.psu.edu/view/iuc/ivar_filtervariants/0135f1d487a0)
+- ivar_removereads was updated to [ee29337f905c](https://toolshed.g2.bx.psu.edu/view/iuc/ivar_removereads/ee29337f905c)
+- ivar_trim was updated to [5671e1d3d5ee](https://toolshed.g2.bx.psu.edu/view/iuc/ivar_trim/5671e1d3d5ee)
+- ivar_variants was updated to [252dfb042563](https://toolshed.g2.bx.psu.edu/view/iuc/ivar_variants/252dfb042563)
+- ivar_variants was updated to [584beffa972b](https://toolshed.g2.bx.psu.edu/view/iuc/ivar_variants/584beffa972b)
+
+

--- a/content/news/2022-07-18-tool-update/index.md
+++ b/content/news/2022-07-18-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-07-18
+tease: "On 2022-07-18, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-07-18'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-07-19-tool-update/index.md
+++ b/content/news/2022-07-19-tool-update/index.md
@@ -1,0 +1,56 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-07-19
+date: '2022-07-19'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-07-19, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #337](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#337/)
+
+
+## Text Manipulation
+
+- column_remove_by_header was updated to [2040e4c2750a](https://toolshed.g2.bx.psu.edu/view/iuc/column_remove_by_header/2040e4c2750a)
+
+## Proteomics
+
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Machine Learning
+
+- ml_visualization_ex was updated to [f96efab83b65](https://toolshed.g2.bx.psu.edu/view/bgruening/ml_visualization_ex/f96efab83b65)
+
+## Imaging
+
+- landmark_registration was updated to [aee73493bf53](https://toolshed.g2.bx.psu.edu/view/imgteam/landmark_registration/aee73493bf53)
+
+## FASTA/FASTQ
+
+- adapter_removal was updated to [04d05400d3a6](https://toolshed.g2.bx.psu.edu/view/iuc/adapter_removal/04d05400d3a6)
+
+## Metagenomic Analysis
+
+- aldex2 was updated to [f4d0bd4b4d6d](https://toolshed.g2.bx.psu.edu/view/iuc/aldex2/f4d0bd4b4d6d)
+- ancombc was updated to [939c59ab61cf](https://toolshed.g2.bx.psu.edu/view/iuc/ancombc/939c59ab61cf)
+- instrain_compare was updated to [14e40ebee56c](https://toolshed.g2.bx.psu.edu/view/iuc/instrain_compare/14e40ebee56c)
+- instrain_profile was updated to [c332659ecdcc](https://toolshed.g2.bx.psu.edu/view/iuc/instrain_profile/c332659ecdcc)
+
+## Mothur
+
+- mothur_chimera_ccode was updated to [d433ebd156c7](https://toolshed.g2.bx.psu.edu/view/iuc/mothur_chimera_ccode/d433ebd156c7)
+
+## Phylogenetics
+
+- pangolin was updated to [77402759b866](https://toolshed.g2.bx.psu.edu/view/iuc/pangolin/77402759b866)
+
+

--- a/content/news/2022-07-19-tool-update/index.md
+++ b/content/news/2022-07-19-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-07-19
+tease: "On 2022-07-19, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-07-19'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-07-24-tool-update/index.md
+++ b/content/news/2022-07-24-tool-update/index.md
@@ -1,0 +1,83 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-07-24
+date: '2022-07-24'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-07-24, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #338](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#338/)
+
+
+## Text Manipulation
+
+- split_file_on_column was updated to [ff2a81aa3f08](https://toolshed.g2.bx.psu.edu/view/bgruening/split_file_on_column/ff2a81aa3f08)
+
+## Variant Calling
+
+- bcftools_annotate was updated to [2436e3bef247](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_annotate/2436e3bef247)
+- bcftools_call was updated to [072f606e2e69](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_call/072f606e2e69)
+- bcftools_cnv was updated to [4891338c6c54](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_cnv/4891338c6c54)
+- bcftools_concat was updated to [5ee777f9db23](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_concat/5ee777f9db23)
+- bcftools_consensus was updated to [92182c270ce4](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_consensus/92182c270ce4)
+- bcftools_convert_from_vcf was updated to [7cea7c7bf203](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_convert_from_vcf/7cea7c7bf203)
+- bcftools_convert_to_vcf was updated to [c14b33ab15d8](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_convert_to_vcf/c14b33ab15d8)
+- bcftools_csq was updated to [8899a6d50699](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_csq/8899a6d50699)
+- bcftools_filter was updated to [6ca7c55a27e8](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_filter/6ca7c55a27e8)
+- bcftools_gtcheck was updated to [39810174657a](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_gtcheck/39810174657a)
+- bcftools_isec was updated to [02f349bdbf96](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_isec/02f349bdbf96)
+- bcftools_merge was updated to [3e0e55c628b8](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_merge/3e0e55c628b8)
+- bcftools_norm was updated to [a62e934346f5](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_norm/a62e934346f5)
+- bcftools_plugin_color_chrs was updated to [71dfde92fd57](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_plugin_color_chrs/71dfde92fd57)
+- bcftools_plugin_frameshifts was updated to [48ac4d611e92](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_plugin_frameshifts/48ac4d611e92)
+- bcftools_query was updated to [3b1b51e1fcba](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_query/3b1b51e1fcba)
+- bcftools_reheader was updated to [9ef52d95114b](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_reheader/9ef52d95114b)
+- bcftools_roh was updated to [b76adb2f1c51](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_roh/b76adb2f1c51)
+- bcftools_stats was updated to [c636e58df612](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_stats/c636e58df612)
+- bcftools_view was updated to [1d1762860d7e](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_view/1d1762860d7e)
+
+## Proteomics
+
+- eggnog_mapper was updated to [9d1fbff733cf](https://toolshed.g2.bx.psu.edu/view/galaxyp/eggnog_mapper/9d1fbff733cf)
+- maxquant was updated to [74f5d355d156](https://toolshed.g2.bx.psu.edu/view/galaxyp/maxquant/74f5d355d156)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Imaging
+
+- curve_fitting was updated to [e0af18405e37](https://toolshed.g2.bx.psu.edu/view/imgteam/curve_fitting/e0af18405e37)
+- overlay_images was updated to [bf590a9733ed](https://toolshed.g2.bx.psu.edu/view/imgteam/overlay_images/bf590a9733ed)
+
+## Metagenomic Analysis
+
+- concoct was updated to [28e8d2bd6aba](https://toolshed.g2.bx.psu.edu/view/iuc/concoct/28e8d2bd6aba)
+
+## Assembly
+
+- idba_hybrid was updated to [5c5806e23338](https://toolshed.g2.bx.psu.edu/view/iuc/idba_hybrid/5c5806e23338)
+- idba_tran was updated to [03de4e0f84c2](https://toolshed.g2.bx.psu.edu/view/iuc/idba_tran/03de4e0f84c2)
+- idba_ud was updated to [1542a2fffe0c](https://toolshed.g2.bx.psu.edu/view/iuc/idba_ud/1542a2fffe0c)
+
+## Extract Features
+
+- fraggenescan was updated to [2dfb2fba4081](https://toolshed.g2.bx.psu.edu/view/iuc/fraggenescan/2dfb2fba4081)
+
+## Phylogenetics
+
+- raxml was updated to [29ff6a849eac](https://toolshed.g2.bx.psu.edu/view/iuc/raxml/29ff6a849eac)
+
+## Virology
+
+- snipit was updated to [20b4c59bec12](https://toolshed.g2.bx.psu.edu/view/iuc/snipit/20b4c59bec12)
+
+## None
+
+- data_manager_pangolin_data was updated to [33158d21324d](https://toolshed.g2.bx.psu.edu/view/iuc/data_manager_pangolin_data/33158d21324d)
+
+

--- a/content/news/2022-07-24-tool-update/index.md
+++ b/content/news/2022-07-24-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-07-24
+tease: "On 2022-07-24, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-07-24'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-07-31-tool-update/index.md
+++ b/content/news/2022-07-31-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-07-31
+tease: "On 2022-07-31, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-07-31'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-07-31-tool-update/index.md
+++ b/content/news/2022-07-31-tool-update/index.md
@@ -1,0 +1,77 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-07-31
+date: '2022-07-31'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-07-31, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #339](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#339/)
+
+
+## Text Manipulation
+
+- column_maker was updated to [6595517c2dd8](https://toolshed.g2.bx.psu.edu/view/devteam/column_maker/6595517c2dd8)
+
+## RNA Analysis
+
+- arriba was updated to [a24ca22b906e](https://toolshed.g2.bx.psu.edu/view/iuc/arriba/a24ca22b906e)
+- arriba_draw_fusions was updated to [2d4e3aff9dc7](https://toolshed.g2.bx.psu.edu/view/iuc/arriba_draw_fusions/2d4e3aff9dc7)
+- arriba_get_filters was updated to [125d20cb23d7](https://toolshed.g2.bx.psu.edu/view/iuc/arriba_get_filters/125d20cb23d7)
+- stringtie was updated to [cef79931dda5](https://toolshed.g2.bx.psu.edu/view/iuc/stringtie/cef79931dda5)
+
+## Proteomics
+
+- maxquant was updated to [1f39c833f65f](https://toolshed.g2.bx.psu.edu/view/galaxyp/maxquant/1f39c833f65f)
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Metagenomic Analysis
+
+- checkm_analyze was updated to [7ccea589e8b7](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_analyze/7ccea589e8b7)
+- checkm_lineage_set was updated to [b39999cdbf21](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_lineage_set/b39999cdbf21)
+- checkm_lineage_wf was updated to [760dc0c0e689](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_lineage_wf/760dc0c0e689)
+- checkm_plot was updated to [356839cd89d2](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_plot/356839cd89d2)
+- checkm_qa was updated to [5c0493cdced9](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_qa/5c0493cdced9)
+- checkm_taxon_set was updated to [e3f1c47246fd](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_taxon_set/e3f1c47246fd)
+- checkm_taxonomy_wf was updated to [91230b9141c1](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_taxonomy_wf/91230b9141c1)
+- checkm_tetra was updated to [878d742dacf0](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_tetra/878d742dacf0)
+- checkm_tree was updated to [9b2790bca5b5](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_tree/9b2790bca5b5)
+- checkm_tree_qa was updated to [dd51f61c2309](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_tree_qa/dd51f61c2309)
+- metabat2 was updated to [01f02c5ddff8](https://toolshed.g2.bx.psu.edu/view/iuc/metabat2/01f02c5ddff8)
+- metabat2_jgi_summarize_bam_contig_depths was updated to [1592150e38d2](https://toolshed.g2.bx.psu.edu/view/iuc/metabat2_jgi_summarize_bam_contig_depths/1592150e38d2)
+- nonpareil was updated to [45210df786b9](https://toolshed.g2.bx.psu.edu/view/iuc/nonpareil/45210df786b9)
+
+## Nanopore
+
+- clair3 was updated to [44f6ec903688](https://toolshed.g2.bx.psu.edu/view/iuc/clair3/44f6ec903688)
+- ngmlr was updated to [bb51c75a0157](https://toolshed.g2.bx.psu.edu/view/iuc/ngmlr/bb51c75a0157)
+
+## Assembly
+
+- yahs was updated to [fc925f53cae7](https://toolshed.g2.bx.psu.edu/view/iuc/yahs/fc925f53cae7)
+
+## Variant Calling
+
+- bcftools_mpileup was updated to [f506df85c652](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_mpileup/f506df85c652)
+
+## Virology
+
+- freyja_aggregate_plot was updated to [0ceb9fb0f4ce](https://toolshed.g2.bx.psu.edu/view/iuc/freyja_aggregate_plot/0ceb9fb0f4ce)
+- freyja_boot was updated to [dda5772507b2](https://toolshed.g2.bx.psu.edu/view/iuc/freyja_boot/dda5772507b2)
+- freyja_demix was updated to [fc6252e78d5b](https://toolshed.g2.bx.psu.edu/view/iuc/freyja_demix/fc6252e78d5b)
+- freyja_variants was updated to [08c2d81e7942](https://toolshed.g2.bx.psu.edu/view/iuc/freyja_variants/08c2d81e7942)
+
+## None
+
+- data_manager_nextclade was updated to [4de9e77bcc9e](https://toolshed.g2.bx.psu.edu/view/iuc/data_manager_nextclade/4de9e77bcc9e)
+
+

--- a/content/news/2022-08-05-galaxy-open-api/index.md
+++ b/content/news/2022-08-05-galaxy-open-api/index.md
@@ -1,6 +1,7 @@
 ---
 title: OpenAPI support in Galaxy and Interactive API Documentation
 tease: "Since Galaxy release 22.05 it's much easier to discover, explore, learn and experiment with the Galaxy Rest API."
+hide_tease: true
 date: '2022-08-05'
 tags: [galaxy]
 supporters:

--- a/content/news/2022-08-05-galaxy-open-api/index.md
+++ b/content/news/2022-08-05-galaxy-open-api/index.md
@@ -1,0 +1,100 @@
+---
+title: OpenAPI support in Galaxy and Interactive API Documentation
+tease: "Since Galaxy release 22.05 it's much easier to discover, explore, learn and experiment with the Galaxy Rest API."
+date: '2022-08-05'
+tags: [galaxy]
+supporters:
+- galaxy-europe
+subsites: [eu, freiburg]
+main_subsite: freiburg
+---
+
+Since Galaxy release 22.05 it's much easier to **discover**, **explore**, **learn** and **experiment** with the *Galaxy Rest API*.
+
+Thanks to the recent development efforts in modernizing the Galaxy backend by migrating our custom API framework to [FastAPI](https://fastapi.tiangolo.com/) and moving from a Synchronous (WSGI) to an Asynchronous Server Gateway Interface ([ASGI](https://asgi.readthedocs.io/en/latest/specs/main.html)), the Galaxy API is now [OpenAPI](https://github.com/OAI/OpenAPI-Specification) compliant. This enables many new features that were not possible with the previous framework.
+
+One of those new features is that we now have interactive API documentation using [Swagger](https://swagger.io/)!
+
+[You can go to **https://usegalaxy.eu/api/docs** and try it out now!](https://usegalaxy.eu/api/docs)
+
+![Galaxy OpenAPI Demo](./2022-08-05-galaxy-open-api.gif)
+
+
+### Let's have a look at how we are migrating our existing API routes
+
+As an example, we can see how the *show quota details* route was migrated in the [*Quotas* API](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/api/quotas.py).
+
+Usually, the first step is moving the existing API logic to a *service layer*. Then, in the API module, we can focus on documenting each endpoint and keep the logic in a different class [QuotasService](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/services/quotas.py) that has extensive [Python type hints](https://docs.python.org/3/library/typing.html) and returns [Pydantic](https://pydantic-docs.helpmanual.io/) models. These *Pydantic models* annotate each field with additional information used by FastAPI to generate the interactive documentation.
+
+Here's an example of the *QuotaDetails* Pydantic model. It provides type hints for each field, default values, title and description:
+
+```python
+class QuotaDetails(QuotaBase):
+    description: str = QuotaDescriptionField
+    bytes: int = Field(
+        ...,
+        title="Bytes",
+        description="The amount, expressed in bytes, of this Quota.",
+    )
+    operation: QuotaOperation = QuotaOperationField
+    display_amount: str = Field(
+        ...,
+        title="Display Amount",
+        description="Human-readable representation of the `amount` field.",
+    )
+    default: List[DefaultQuota] = Field(
+        [],
+        title="Default",
+        description="A list indicating which types of default user quotas, if any, are associated with this quota.",
+    )
+    users: List[UserQuota] = Field(
+        [],
+        title="Users",
+        description="A list of specific users associated with this quota.",
+    )
+    groups: List[GroupQuota] = Field(
+        [],
+        title="Groups",
+        description="A list of specific groups of users associated with this quota.",
+    )
+```
+
+
+Then, the `api/quotas/{id}` route in our [Quotas API module](https://github.com/galaxyproject/galaxy/blob/c975fbc538bdd600d91116c82e7536cd4828714e/lib/galaxy/webapps/galaxy/api/quotas.py#L65) will be something like this:
+
+```python
+@router.cbv
+class FastAPIQuota:
+    service: QuotasService = depends(QuotasService)
+
+...
+
+    @router.get(
+        "/api/quotas/{id}",
+        summary="Displays details on a particular active quota.",
+        require_admin=True,
+    )
+    def show(
+        self, trans: ProvidesUserContext = DependsOnTrans, id: EncodedDatabaseIdField = QuotaIdPathParam
+    ) -> QuotaDetails:
+        """Displays details on a particular active quota."""
+        return self.service.show(trans, id)
+```
+
+While the `show` function in the [*QuotasService* class](https://github.com/galaxyproject/galaxy/blob/c975fbc538bdd600d91116c82e7536cd4828714e/lib/galaxy/webapps/galaxy/services/quotas.py#L56) is the same that we had in the previous API framework, now, it uses Pydantic models and type annotations to document the parameters and return models.
+
+```python
+class QuotasService(ServiceBase):
+    """Interface/service object shared by controllers for interacting with quotas."""
+
+...
+
+    def show(self, trans: ProvidesUserContext, id: EncodedDatabaseIdField, deleted: bool = False) -> QuotaDetails:
+        """Displays information about a quota."""
+        quota = self.quota_manager.get_quota(trans, id, deleted=deleted)
+        rval = quota.to_dict(view="element", value_mapper={"id": trans.security.encode_id, "total_disk_usage": float})
+        return QuotaDetails.parse_obj(rval)
+```
+
+Galaxy is a complex application and its API is considerable large! So there are still some undocumented routes out there. If you are familiar with Galaxy and want to help migrate more API routes or improve the existing documented ones, you are very welcome! Please look at this [GitHub issue](https://github.com/galaxyproject/galaxy/issues/10889) to track which APIs still need documentation.
+

--- a/content/news/2022-08-07-tool-update/index.md
+++ b/content/news/2022-08-07-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-08-07
+tease: "On 2022-08-07, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-08-07'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-08-07-tool-update/index.md
+++ b/content/news/2022-08-07-tool-update/index.md
@@ -1,0 +1,65 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-08-07
+date: '2022-08-07'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-08-07, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #340](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#340/)
+
+
+## GIS Data Handling
+
+- xarray_coords_info was updated to [663e6f115a76](https://toolshed.g2.bx.psu.edu/view/ecology/xarray_coords_info/663e6f115a76)
+- xarray_mapplot was updated to [506b6d6880ff](https://toolshed.g2.bx.psu.edu/view/ecology/xarray_mapplot/506b6d6880ff)
+- xarray_metadata_info was updated to [00de53d18b99](https://toolshed.g2.bx.psu.edu/view/ecology/xarray_metadata_info/00de53d18b99)
+- xarray_netcdf2netcdf was updated to [c91c27b63fb2](https://toolshed.g2.bx.psu.edu/view/ecology/xarray_netcdf2netcdf/c91c27b63fb2)
+- xarray_select was updated to [b393815e4cb7](https://toolshed.g2.bx.psu.edu/view/ecology/xarray_select/b393815e4cb7)
+
+## Variant Calling
+
+- snpeff was updated to [5c7b70713fb5](https://toolshed.g2.bx.psu.edu/view/iuc/snpeff/5c7b70713fb5)
+
+## Proteomics
+
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+- proteomiqon_psmstatistics was updated to [9ac2e8232c5c](https://toolshed.g2.bx.psu.edu/view/galaxyp/proteomiqon_psmstatistics/9ac2e8232c5c)
+
+## Assembly
+
+- quast was updated to [3061c8b029e5](https://toolshed.g2.bx.psu.edu/view/iuc/quast/3061c8b029e5)
+
+## Imaging
+
+- landmark_registration was updated to [12997d4c5b00](https://toolshed.g2.bx.psu.edu/view/imgteam/landmark_registration/12997d4c5b00)
+
+## Metagenomic Analysis
+
+- concoct was updated to [147577841bb8](https://toolshed.g2.bx.psu.edu/view/iuc/concoct/147577841bb8)
+- concoct_coverage_table was updated to [5ded3318cf8a](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_coverage_table/5ded3318cf8a)
+- concoct_cut_up_fasta was updated to [989f1256d7a9](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_cut_up_fasta/989f1256d7a9)
+- concoct_extract_fasta_bins was updated to [505111e8aca5](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_extract_fasta_bins/505111e8aca5)
+- concoct_merge_cut_up_clustering was updated to [794d4e27925b](https://toolshed.g2.bx.psu.edu/view/iuc/concoct_merge_cut_up_clustering/794d4e27925b)
+- metabat2 was updated to [708abf08a626](https://toolshed.g2.bx.psu.edu/view/iuc/metabat2/708abf08a626)
+- metabat2_jgi_summarize_bam_contig_depths was updated to [a4441f35f17b](https://toolshed.g2.bx.psu.edu/view/iuc/metabat2_jgi_summarize_bam_contig_depths/a4441f35f17b)
+
+## Phylogenetics
+
+- nextalign was updated to [4d93e708218c](https://toolshed.g2.bx.psu.edu/view/iuc/nextalign/4d93e708218c)
+- nextclade was updated to [07ab9bd68a02](https://toolshed.g2.bx.psu.edu/view/iuc/nextclade/07ab9bd68a02)
+
+## Annotation
+
+- hamronize_summarize was updated to [243c87f34f39](https://toolshed.g2.bx.psu.edu/view/iuc/hamronize_summarize/243c87f34f39)
+- hamronize_tool was updated to [41c7e03b3eab](https://toolshed.g2.bx.psu.edu/view/iuc/hamronize_tool/41c7e03b3eab)
+- maker was updated to [370c210d9541](https://toolshed.g2.bx.psu.edu/view/iuc/maker/370c210d9541)
+
+

--- a/content/news/2022-08-15-tool-update/index.md
+++ b/content/news/2022-08-15-tool-update/index.md
@@ -1,0 +1,43 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-08-15
+date: '2022-08-15'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-08-15, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #341](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#341/)
+
+
+## Proteomics
+
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Machine Learning
+
+- keras_batch_models was updated to [0dc3027df8f4](https://toolshed.g2.bx.psu.edu/view/bgruening/keras_batch_models/0dc3027df8f4)
+- keras_model_builder was updated to [053570bac5ea](https://toolshed.g2.bx.psu.edu/view/bgruening/keras_model_builder/053570bac5ea)
+- keras_model_config was updated to [0c933465d70e](https://toolshed.g2.bx.psu.edu/view/bgruening/keras_model_config/0c933465d70e)
+
+## Assembly
+
+- spades was updated to [9be710099b99](https://toolshed.g2.bx.psu.edu/view/nml/spades/9be710099b99)
+
+## Mothur
+
+- mothur_remove_dists was updated to [11795a719c90](https://toolshed.g2.bx.psu.edu/view/iuc/mothur_remove_dists/11795a719c90)
+
+## None
+
+- data_manager_nextclade was updated to [c8b67693199e](https://toolshed.g2.bx.psu.edu/view/iuc/data_manager_nextclade/c8b67693199e)
+
+

--- a/content/news/2022-08-15-tool-update/index.md
+++ b/content/news/2022-08-15-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-08-15
+tease: "On 2022-08-15, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-08-15'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-08-16-tool-update/index.md
+++ b/content/news/2022-08-16-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-08-16
+tease: "On 2022-08-16, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-08-16'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-08-16-tool-update/index.md
+++ b/content/news/2022-08-16-tool-update/index.md
@@ -1,0 +1,111 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-08-16
+date: '2022-08-16'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-08-16, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #343](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#343/)
+
+
+## Machine Learning
+
+- sklearn_build_pipeline was updated to [b1eda492f063](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_build_pipeline/b1eda492f063)
+- sklearn_clf_metrics was updated to [0ee984c1cbd6](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_clf_metrics/0ee984c1cbd6)
+- sklearn_data_preprocess was updated to [80074b842ebd](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_data_preprocess/80074b842ebd)
+- sklearn_discriminant_classifier was updated to [4335cec181ba](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_discriminant_classifier/4335cec181ba)
+- sklearn_ensemble was updated to [a07ab242b0b5](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_ensemble/a07ab242b0b5)
+- sklearn_feature_selection was updated to [4483b84310ec](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_feature_selection/4483b84310ec)
+- sklearn_generalized_linear was updated to [dc4b5fd604a6](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_generalized_linear/dc4b5fd604a6)
+- sklearn_model_validation was updated to [5d5d9cc554f9](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_model_validation/5d5d9cc554f9)
+- sklearn_nn_classifier was updated to [2c58b83c9bad](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_nn_classifier/2c58b83c9bad)
+- sklearn_numeric_clustering was updated to [7dd3fb35904f](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_numeric_clustering/7dd3fb35904f)
+- sklearn_pairwise_metrics was updated to [b07416ec8d16](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_pairwise_metrics/b07416ec8d16)
+- sklearn_regression_metrics was updated to [5c9fb40ae174](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_regression_metrics/5c9fb40ae174)
+- sklearn_sample_generator was updated to [eb41d87cb1de](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_sample_generator/eb41d87cb1de)
+- sklearn_searchcv was updated to [301e07345c93](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_searchcv/301e07345c93)
+- sklearn_svm_classifier was updated to [b7c3e9a3b954](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_svm_classifier/b7c3e9a3b954)
+
+## Statistics
+
+- scipy_sparse was updated to [4efac966af2a](https://toolshed.g2.bx.psu.edu/view/bgruening/scipy_sparse/4efac966af2a)
+
+## Assembly
+
+- rnaspades was updated to [675ee1aa5952](https://toolshed.g2.bx.psu.edu/view/iuc/rnaspades/675ee1aa5952)
+- spades_biosyntheticspades was updated to [d89ced9439f3](https://toolshed.g2.bx.psu.edu/view/iuc/spades_biosyntheticspades/d89ced9439f3)
+- spades_coronaspades was updated to [ff41a00a6745](https://toolshed.g2.bx.psu.edu/view/iuc/spades_coronaspades/ff41a00a6745)
+- spades_metaplasmidspades was updated to [4a01e0d2892c](https://toolshed.g2.bx.psu.edu/view/iuc/spades_metaplasmidspades/4a01e0d2892c)
+- spades_metaviralspades was updated to [e060c3987513](https://toolshed.g2.bx.psu.edu/view/iuc/spades_metaviralspades/e060c3987513)
+- spades_plasmidspades was updated to [75405f5e2cc5](https://toolshed.g2.bx.psu.edu/view/iuc/spades_plasmidspades/75405f5e2cc5)
+- spades_rnaviralspades was updated to [48cf45a53456](https://toolshed.g2.bx.psu.edu/view/iuc/spades_rnaviralspades/48cf45a53456)
+- metaspades was updated to [6563e22a9fd0](https://toolshed.g2.bx.psu.edu/view/nml/metaspades/6563e22a9fd0)
+
+## Proteomics
+
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Metagenomic Analysis
+
+- checkm_analyze was updated to [5ee29434330f](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_analyze/5ee29434330f)
+- checkm_lineage_set was updated to [640400ad260d](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_lineage_set/640400ad260d)
+- checkm_lineage_wf was updated to [f0107b9f2dc3](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_lineage_wf/f0107b9f2dc3)
+- checkm_plot was updated to [b24e4f6c8b4d](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_plot/b24e4f6c8b4d)
+- checkm_qa was updated to [8236b90ce44c](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_qa/8236b90ce44c)
+- checkm_taxon_set was updated to [600b129adb72](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_taxon_set/600b129adb72)
+- checkm_taxonomy_wf was updated to [2e995a9aa00e](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_taxonomy_wf/2e995a9aa00e)
+- checkm_tetra was updated to [bb3b50fa4956](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_tetra/bb3b50fa4956)
+- checkm_tree was updated to [6d1c282e2ce2](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_tree/6d1c282e2ce2)
+- checkm_tree_qa was updated to [b9a38ce53252](https://toolshed.g2.bx.psu.edu/view/iuc/checkm_tree_qa/b9a38ce53252)
+
+## NCBI Blast
+
+- magicblast was updated to [aea6702a3cd5](https://toolshed.g2.bx.psu.edu/view/iuc/magicblast/aea6702a3cd5)
+
+## Annotation
+
+- te_finder was updated to [838fb3a1678f](https://toolshed.g2.bx.psu.edu/view/iuc/te_finder/838fb3a1678f)
+
+## Graph/Display Data
+
+- intervene was updated to [33b8c5eedc04](https://toolshed.g2.bx.psu.edu/view/iuc/intervene/33b8c5eedc04)
+
+## Convert Formats
+
+- samtools_bam_to_cram was updated to [0b663ca9a961](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_bam_to_cram/0b663ca9a961)
+
+## SAM/BAM
+
+- samtools_split was updated to [bcedabb53ddf](https://toolshed.g2.bx.psu.edu/view/devteam/samtools_split/bcedabb53ddf)
+- samtools_ampliconclip was updated to [5f3ea90dc6ae](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_ampliconclip/5f3ea90dc6ae)
+- samtools_coverage was updated to [ae36fab06bc2](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_coverage/ae36fab06bc2)
+- samtools_depth was updated to [56faa6a57e50](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_depth/56faa6a57e50)
+- samtools_fastx was updated to [b3d99709fe1a](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_fastx/b3d99709fe1a)
+- samtools_fixmate was updated to [41e36c99a008](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_fixmate/41e36c99a008)
+- samtools_markdup was updated to [b5527cc104ab](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_markdup/b5527cc104ab)
+- samtools_merge was updated to [36677f429310](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_merge/36677f429310)
+- samtools_view was updated to [5826298f6a73](https://toolshed.g2.bx.psu.edu/view/iuc/samtools_view/5826298f6a73)
+
+## Mothur
+
+- mothur_count_groups was updated to [28867c3771e1](https://toolshed.g2.bx.psu.edu/view/iuc/mothur_count_groups/28867c3771e1)
+
+## Extract Features
+
+- b2btools_single_sequence was updated to [b694a77ca1e8](https://toolshed.g2.bx.psu.edu/view/iuc/b2btools_single_sequence/b694a77ca1e8)
+
+## Virology
+
+- cooc_mutbamscan was updated to [373c1735d31f](https://toolshed.g2.bx.psu.edu/view/iuc/cooc_mutbamscan/373c1735d31f)
+- cooc_pubmut was updated to [d04ea6b052c5](https://toolshed.g2.bx.psu.edu/view/iuc/cooc_pubmut/d04ea6b052c5)
+- cooc_tabmut was updated to [4be399803856](https://toolshed.g2.bx.psu.edu/view/iuc/cooc_tabmut/4be399803856)
+
+

--- a/content/news/2022-08-21-tool-update/index.md
+++ b/content/news/2022-08-21-tool-update/index.md
@@ -1,0 +1,93 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-08-21
+date: '2022-08-21'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-08-21, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #344](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#344/)
+
+
+## RAD-seq
+
+- bwa was updated to [e188dc7a68e6](https://toolshed.g2.bx.psu.edu/view/devteam/bwa/e188dc7a68e6)
+
+## Proteomics
+
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## ChemicalToolBox
+
+- alphafold2 was updated to [ca90d17ff51b](https://toolshed.g2.bx.psu.edu/view/galaxy-australia/alphafold2/ca90d17ff51b)
+
+## Machine Learning
+
+- keras_train_and_eval was updated to [e1317b5502fa](https://toolshed.g2.bx.psu.edu/view/bgruening/keras_train_and_eval/e1317b5502fa)
+- ml_visualization_ex was updated to [c80db5d6fd8c](https://toolshed.g2.bx.psu.edu/view/bgruening/ml_visualization_ex/c80db5d6fd8c)
+- model_prediction was updated to [29e4122c90de](https://toolshed.g2.bx.psu.edu/view/bgruening/model_prediction/29e4122c90de)
+- sklearn_estimator_attributes was updated to [d0352e8b4c10](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_estimator_attributes/d0352e8b4c10)
+- sklearn_fitted_model_eval was updated to [c2e2aa55dd5c](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_fitted_model_eval/c2e2aa55dd5c)
+- sklearn_lightgbm was updated to [27f8bd20a936](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_lightgbm/27f8bd20a936)
+- sklearn_model_fit was updated to [fc70bf5c3b58](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_model_fit/fc70bf5c3b58)
+- sklearn_pca was updated to [3af626081467](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_pca/3af626081467)
+- sklearn_stacking_ensemble_models was updated to [b94babda32e4](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_stacking_ensemble_models/b94babda32e4)
+- sklearn_to_categorical was updated to [14180f9c831e](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_to_categorical/14180f9c831e)
+- sklearn_train_test_eval was updated to [4d1637cac794](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_train_test_eval/4d1637cac794)
+- sklearn_train_test_split was updated to [6e25381dad5c](https://toolshed.g2.bx.psu.edu/view/bgruening/sklearn_train_test_split/6e25381dad5c)
+
+## Multiple Alignments
+
+- chromeister was updated to [b768cc4cca40](https://toolshed.g2.bx.psu.edu/view/iuc/chromeister/b768cc4cca40)
+
+## Variant Calling
+
+- bcftools_isec was updated to [81e4014fa809](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_isec/81e4014fa809)
+- bcftools_mpileup was updated to [31ea13dfe5e6](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_mpileup/31ea13dfe5e6)
+- bcftools_view was updated to [1d1762860d7e](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_view/1d1762860d7e)
+- bcftools_view was updated to [38d75661c235](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_view/38d75661c235)
+- delly_lr was updated to [97f649646cc1](https://toolshed.g2.bx.psu.edu/view/iuc/delly_lr/97f649646cc1)
+
+## Assembly
+
+- genomescope was updated to [01210c4e9144](https://toolshed.g2.bx.psu.edu/view/iuc/genomescope/01210c4e9144)
+
+## Convert Formats
+
+- biom_convert was updated to [1b5fc03380d4](https://toolshed.g2.bx.psu.edu/view/iuc/biom_convert/1b5fc03380d4)
+
+## Phylogenetics
+
+- hyphy_absrel was updated to [a6619171428e](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_absrel/a6619171428e)
+- hyphy_annotate was updated to [2318841ec191](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_annotate/2318841ec191)
+- hyphy_bgm was updated to [4515f2f64e13](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_bgm/4515f2f64e13)
+- hyphy_busted was updated to [caf23deba39a](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_busted/caf23deba39a)
+- hyphy_cfel was updated to [91679ca1480d](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_cfel/91679ca1480d)
+- hyphy_conv was updated to [6761212b7f1d](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_conv/6761212b7f1d)
+- hyphy_fade was updated to [a73fff151e38](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_fade/a73fff151e38)
+- hyphy_fel was updated to [b110a31a9c61](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_fel/b110a31a9c61)
+- hyphy_fubar was updated to [6e72195b364a](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_fubar/6e72195b364a)
+- hyphy_gard was updated to [659517798cc4](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_gard/659517798cc4)
+- hyphy_meme was updated to [d5d909979314](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_meme/d5d909979314)
+- hyphy_prime was updated to [0407236012e5](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_prime/0407236012e5)
+- hyphy_relax was updated to [7207313de5a8](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_relax/7207313de5a8)
+- hyphy_slac was updated to [1467fb7e162d](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_slac/1467fb7e162d)
+- hyphy_sm19 was updated to [d52a803b2b5c](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_sm19/d52a803b2b5c)
+- hyphy_strike_ambigs was updated to [f5bbd4b34541](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_strike_ambigs/f5bbd4b34541)
+- hyphy_summary was updated to [11dd1a96ffe9](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_summary/11dd1a96ffe9)
+- hyphy_summary was updated to [f3e408cc2546](https://toolshed.g2.bx.psu.edu/view/iuc/hyphy_summary/f3e408cc2546)
+
+## Metagenomic Analysis
+
+- humann_barplot was updated to [3f16956afb8a](https://toolshed.g2.bx.psu.edu/view/iuc/humann_barplot/3f16956afb8a)
+
+

--- a/content/news/2022-08-21-tool-update/index.md
+++ b/content/news/2022-08-21-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-08-21
+tease: "On 2022-08-21, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-08-21'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-08-28-tool-update/index.md
+++ b/content/news/2022-08-28-tool-update/index.md
@@ -1,0 +1,74 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-08-28
+date: '2022-08-28'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-08-28, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #345](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#345/)
+
+
+## Assembly
+
+- rnaspades was updated to [1d06c8b38e77](https://toolshed.g2.bx.psu.edu/view/iuc/rnaspades/1d06c8b38e77)
+- spades_biosyntheticspades was updated to [051fd2db8a27](https://toolshed.g2.bx.psu.edu/view/iuc/spades_biosyntheticspades/051fd2db8a27)
+- spades_coronaspades was updated to [34305b013402](https://toolshed.g2.bx.psu.edu/view/iuc/spades_coronaspades/34305b013402)
+- spades_metaplasmidspades was updated to [e5a3b75a271f](https://toolshed.g2.bx.psu.edu/view/iuc/spades_metaplasmidspades/e5a3b75a271f)
+- spades_metaviralspades was updated to [328aa71f0f3c](https://toolshed.g2.bx.psu.edu/view/iuc/spades_metaviralspades/328aa71f0f3c)
+- spades_plasmidspades was updated to [1708851f8804](https://toolshed.g2.bx.psu.edu/view/iuc/spades_plasmidspades/1708851f8804)
+- spades_rnaviralspades was updated to [d5fb354f745d](https://toolshed.g2.bx.psu.edu/view/iuc/spades_rnaviralspades/d5fb354f745d)
+- metaspades was updated to [fd128c111ab0](https://toolshed.g2.bx.psu.edu/view/nml/metaspades/fd128c111ab0)
+- spades was updated to [33368fec3b70](https://toolshed.g2.bx.psu.edu/view/nml/spades/33368fec3b70)
+
+## RNA Analysis
+
+- circexplorer2 was updated to [465d6578b4d0](https://toolshed.g2.bx.psu.edu/view/iuc/circexplorer2/465d6578b4d0)
+- deseq2 was updated to [8fe98f7094de](https://toolshed.g2.bx.psu.edu/view/iuc/deseq2/8fe98f7094de)
+
+## Proteomics
+
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Metagenomic Analysis
+
+- bracken was updated to [79450f7fd718](https://toolshed.g2.bx.psu.edu/view/iuc/bracken/79450f7fd718)
+- megan_blast2rma was updated to [45fd617493eb](https://toolshed.g2.bx.psu.edu/view/iuc/megan_blast2rma/45fd617493eb)
+- megan_daa2rma was updated to [8a9cad43dcde](https://toolshed.g2.bx.psu.edu/view/iuc/megan_daa2rma/8a9cad43dcde)
+- megan_daa_meganizer was updated to [6ca88053665c](https://toolshed.g2.bx.psu.edu/view/iuc/megan_daa_meganizer/6ca88053665c)
+- megan_sam2rma was updated to [ef0443c0eaba](https://toolshed.g2.bx.psu.edu/view/iuc/megan_sam2rma/ef0443c0eaba)
+- recentrifuge was updated to [fe733f05c2f8](https://toolshed.g2.bx.psu.edu/view/iuc/recentrifuge/fe733f05c2f8)
+- srst2 was updated to [f9a0855c792d](https://toolshed.g2.bx.psu.edu/view/iuc/srst2/f9a0855c792d)
+
+## Single-cell
+
+- raceid_clustering was updated to [0bff0ee0683a](https://toolshed.g2.bx.psu.edu/view/iuc/raceid_clustering/0bff0ee0683a)
+- raceid_filtnormconf was updated to [b83fbc90161e](https://toolshed.g2.bx.psu.edu/view/iuc/raceid_filtnormconf/b83fbc90161e)
+- raceid_inspectclusters was updated to [f3eb2291da05](https://toolshed.g2.bx.psu.edu/view/iuc/raceid_inspectclusters/f3eb2291da05)
+- raceid_inspecttrajectory was updated to [a6821f856a1e](https://toolshed.g2.bx.psu.edu/view/iuc/raceid_inspecttrajectory/a6821f856a1e)
+- raceid_trajectory was updated to [2af7c5086a96](https://toolshed.g2.bx.psu.edu/view/iuc/raceid_trajectory/2af7c5086a96)
+
+## Variant Calling
+
+- gatk4_mutect2 was updated to [fb0bb7174530](https://toolshed.g2.bx.psu.edu/view/iuc/gatk4_mutect2/fb0bb7174530)
+
+## Get Data
+
+- ncbi_datasets was updated to [18eed8fa7f23](https://toolshed.g2.bx.psu.edu/view/iuc/ncbi_datasets/18eed8fa7f23)
+
+## Annotation
+
+- gubbins was updated to [96e6283e4745](https://toolshed.g2.bx.psu.edu/view/iuc/gubbins/96e6283e4745)
+
+## Picard
+
+- picard was updated to [b502c227b5e6](https://toolshed.g2.bx.psu.edu/view/devteam/picard/b502c227b5e6)
+
+

--- a/content/news/2022-08-28-tool-update/index.md
+++ b/content/news/2022-08-28-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-08-28
+tease: "On 2022-08-28, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-08-28'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-09-04-tool-update/index.md
+++ b/content/news/2022-09-04-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-09-04
+tease: "On 2022-09-04, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-09-04'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-09-04-tool-update/index.md
+++ b/content/news/2022-09-04-tool-update/index.md
@@ -1,0 +1,40 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-09-04
+date: '2022-09-04'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-09-04, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #346](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#346/)
+
+
+## Proteomics
+
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Metagenomic Analysis
+
+- kraken_biom was updated to [3ff4712dc111](https://toolshed.g2.bx.psu.edu/view/iuc/kraken_biom/3ff4712dc111)
+- vapor was updated to [3fe0d1df3950](https://toolshed.g2.bx.psu.edu/view/iuc/vapor/3fe0d1df3950)
+
+## Variant Calling
+
+- bcftools_plugin_setgt was updated to [2c4941386820](https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_plugin_setgt/2c4941386820)
+- deepvariant was updated to [98fe794d2ec0](https://toolshed.g2.bx.psu.edu/view/iuc/deepvariant/98fe794d2ec0)
+
+## Phylogenetics
+
+- ete was updated to [ed74587a13c8](https://toolshed.g2.bx.psu.edu/view/earlhaminst/ete/ed74587a13c8)
+- nextclade was updated to [feb40665d7cd](https://toolshed.g2.bx.psu.edu/view/iuc/nextclade/feb40665d7cd)
+
+

--- a/content/news/2022-09-11-tool-update/index.md
+++ b/content/news/2022-09-11-tool-update/index.md
@@ -1,0 +1,37 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-09-11
+date: '2022-09-11'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-09-11, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #347](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#347/)
+
+
+## Proteomics
+
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## Metagenomic Analysis
+
+- kraken_biom was updated to [65eb9962d272](https://toolshed.g2.bx.psu.edu/view/iuc/kraken_biom/65eb9962d272)
+- srst2 was updated to [46c5d7a0393b](https://toolshed.g2.bx.psu.edu/view/iuc/srst2/46c5d7a0393b)
+
+## Annotation
+
+- isescan was updated to [19f42b3ea391](https://toolshed.g2.bx.psu.edu/view/iuc/isescan/19f42b3ea391)
+
+## Variant Calling
+
+- odgi_build was updated to [6584dfcc7165](https://toolshed.g2.bx.psu.edu/view/iuc/odgi_build/6584dfcc7165)
+- odgi_viz was updated to [911a3517b738](https://toolshed.g2.bx.psu.edu/view/iuc/odgi_viz/911a3517b738)
+
+

--- a/content/news/2022-09-11-tool-update/index.md
+++ b/content/news/2022-09-11-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-09-11
+tease: "On 2022-09-11, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-09-11'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 

--- a/content/news/2022-09-18-tool-update/index.md
+++ b/content/news/2022-09-18-tool-update/index.md
@@ -1,0 +1,45 @@
+---
+title: UseGalaxy.eu Tool Updates for 2022-09-18
+date: '2022-09-18'
+tags: [tools]
+supporters:
+- denbi
+- elixir
+subsites: [freiburg]
+main_subsite: freiburg
+---
+
+On 2022-09-18, the tools on UseGalaxy.eu were updated by our automated tool update and installation process in [Jenkins Build #348](https://build.galaxyproject.eu/job/usegalaxy-eu/job/install-tools/#348/)
+
+
+## Proteomics
+
+- openms_openpepxl was updated to [40cc19c0dbd6](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/40cc19c0dbd6)
+- openms_openpepxl was updated to [a2a842b00f9c](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/a2a842b00f9c)
+- openms_openpepxl was updated to [fc36cfd19834](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_openpepxl/fc36cfd19834)
+- openms_percolatoradapter was updated to [0fc9ae55bcfc](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/0fc9ae55bcfc)
+- openms_percolatoradapter was updated to [e7881a82b56d](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_percolatoradapter/e7881a82b56d)
+- openms_xfdr was updated to [81402a5e4173](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/81402a5e4173)
+- openms_xfdr was updated to [9a6e3bb0f358](https://toolshed.g2.bx.psu.edu/view/galaxyp/openms_xfdr/9a6e3bb0f358)
+
+## ChemicalToolBox
+
+- alphafold2 was updated to [7fbec959cf2b](https://toolshed.g2.bx.psu.edu/view/galaxy-australia/alphafold2/7fbec959cf2b)
+
+## Imaging
+
+- bfconvert was updated to [f3360fbeda64](https://toolshed.g2.bx.psu.edu/view/imgteam/bfconvert/f3360fbeda64)
+
+## Multiple Alignments
+
+- clustalw was updated to [d9c2b2fde6a3](https://toolshed.g2.bx.psu.edu/view/devteam/clustalw/d9c2b2fde6a3)
+
+## Assembly
+
+- shovill was updated to [ad80238462c1](https://toolshed.g2.bx.psu.edu/view/iuc/shovill/ad80238462c1)
+
+## Annotation
+
+- annotatemyids was updated to [fe3ca740a485](https://toolshed.g2.bx.psu.edu/view/iuc/annotatemyids/fe3ca740a485)
+
+

--- a/content/news/2022-09-18-tool-update/index.md
+++ b/content/news/2022-09-18-tool-update/index.md
@@ -1,11 +1,13 @@
 ---
 title: UseGalaxy.eu Tool Updates for 2022-09-18
+tease: "On 2022-09-18, the tools on UseGalaxy.eu were updated by our automated tool update and installation process."
+hide_tease: true
 date: '2022-09-18'
 tags: [tools]
 supporters:
 - denbi
 - elixir
-subsites: [freiburg]
+subsites: [eu, freiburg]
 main_subsite: freiburg
 ---
 


### PR DESCRIPTION
With this PR, we will have all EU events from June 8 to now and all EU news posts from June 27 to now.

Note: One [page](https://galaxyproject.eu/event/2022-06-29-GalaxyWS_TRR167/) is not fully working yet. It contains a [Jekyll include](https://jekyllrb.com/docs/includes/) of sponsors.html, which we have yet to implement. (See #1138.)