### PR TITLE
Add pointers to .eu from pages without full list of news/events

### DIFF
--- a/content/belgium/events/main.md
+++ b/content/belgium/events/main.md
@@ -2,6 +2,16 @@
 title: VIB Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new VIB events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/belgium/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content relevant to the VIB Galaxy community. For events prior to this year, see the [events archive](/belgium/events/archive/).

--- a/content/belgium/news/main.md
+++ b/content/belgium/news/main.md
@@ -2,6 +2,16 @@
 title: VIB Galaxy News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## VIB Galaxy News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about ELIXIR-Belgium's Galaxy server, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/belgium/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These

--- a/content/elixir-it/events/main.md
+++ b/content/elixir-it/events/main.md
@@ -2,6 +2,16 @@
 title: ELIXIR-IT/Laniakea Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new ELIXIR-IT/Laniakea events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/elixir-it/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content relevant to the ELIXIR-IT/Laniakea Galaxy community. For events prior to this year, see the [events archive](/elixir-it/events/archive/).

--- a/content/elixir-it/news/main.md
+++ b/content/elixir-it/news/main.md
@@ -2,6 +2,16 @@
 title: ELIXIR-IT/Laniakea Galaxy News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## ELIXIR-IT/Laniakea Galaxy News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about ELIXIR-IT/Laniakea's Galaxy server, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/elixir-it/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These

--- a/content/erasmusmc/events/main.md
+++ b/content/erasmusmc/events/main.md
@@ -2,6 +2,16 @@
 title: Erasmus MC Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new Erasmus MC events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/erasmusmc/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content relevant to the Erasmus MC Galaxy community. For events prior to this year, see the [events archive](/erasmusmc/events/archive/).

--- a/content/erasmusmc/news/main.md
+++ b/content/erasmusmc/news/main.md
@@ -2,6 +2,16 @@
 title: Erasmus MC Galaxy News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## Erasmus MC Galaxy News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about Erasmus MC's Galaxy server, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/erasmusmc/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These

--- a/content/eu/events/main.md
+++ b/content/eu/events/main.md
@@ -2,6 +2,16 @@
 title: European Galaxy Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new Galaxy Europe events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content related to the European Galaxy community. For events prior to this year, see the [events archive](/eu/events/archive/).

--- a/content/eu/news/main.md
+++ b/content/eu/news/main.md
@@ -2,6 +2,16 @@
 title: Galaxy Europe News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## Galaxy Europe News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about Galaxy Europe, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These

--- a/content/freiburg/events/main.md
+++ b/content/freiburg/events/main.md
@@ -2,6 +2,16 @@
 title: Freiburg Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new Freiburg events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/freiburg/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content relevant to the Freiburg Galaxy community. For events prior to this year, see the [events archive](/freiburg/events/archive/).

--- a/content/freiburg/news/main.md
+++ b/content/freiburg/news/main.md
@@ -2,6 +2,16 @@
 title: Freiburg Galaxy News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## Freiburg Galaxy News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about Freiburg's Galaxy server, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/freiburg/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These

--- a/content/genouest/events/main.md
+++ b/content/genouest/events/main.md
@@ -2,6 +2,16 @@
 title: GenOuest Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new GenOuest events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/genouest/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content relevant to the GenOuest Galaxy community. For events prior to this year, see the [events archive](/genouest/events/archive/).

--- a/content/genouest/news/main.md
+++ b/content/genouest/news/main.md
@@ -2,6 +2,16 @@
 title: GenOuest Galaxy News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## GenOuest Galaxy News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about GenOuest's Galaxy server, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/genouest/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These

--- a/content/ifb/events/main.md
+++ b/content/ifb/events/main.md
@@ -2,6 +2,16 @@
 title: ELIXIR-FR/IFB Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new ELIXIR-FR/IFB events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/ifb/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content relevant to the ELIXIR-FR/IFB Galaxy community. For events prior to this year, see the [events archive](/ifb/events/archive/).

--- a/content/ifb/news/main.md
+++ b/content/ifb/news/main.md
@@ -2,6 +2,16 @@
 title: ELIXIR-FR/IFB Galaxy News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## ELIXIR-FR/IFB Galaxy News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about ELIXIR-FR/IFB's Galaxy server, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/ifb/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These

--- a/content/pasteur/events/main.md
+++ b/content/pasteur/events/main.md
@@ -2,6 +2,16 @@
 title: Pasteur Event Horizon
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## The Event Horizon is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new Pasteur events, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/pasteur/events).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/events.svg" style="width:220px;" alt="events" />
 
 Upcoming (and past) events with content relevant to the Pasteur Galaxy community. For events prior to this year, see the [events archive](/pasteur/events/archive/).

--- a/content/pasteur/news/main.md
+++ b/content/pasteur/news/main.md
@@ -2,6 +2,16 @@
 title: Pasteur Galaxy News
 ---
 
+<div class="alert alert-warning trim-p" style="padding-top: 5px; padding-bottom: 15px">
+
+## Pasteur Galaxy News is still migrating
+
+This page won't have all historical posts until we're done moving content from the old host.
+
+This is the home for new posts about Pasteur's Galaxy server, but if you're looking for older content, you can find it [here](https://usegalaxy-eu.github.io/pasteur/news).
+
+</div>
+
 <img class="img-fluid float-right" src="/images/undraw-illustrations/news.svg" style="width:220px;" alt="news" />
 
 This page contains announcements of interest to the Galaxy Community. These


### PR DESCRIPTION
This adds a notice at the top of every European page with a full list of news or events:

![image](https://user-images.githubusercontent.com/645773/191821094-ef9e7c84-015a-47de-be1c-82d858e728ba.png)

The link is to the equivalent page on https://usegalaxy-eu.github.io.

I think we should have some kind of notice like this until we've migrated all (or most) of the .eu content.

This is part of the plan laid out in https://github.com/galaxyproject/galaxy-hub/issues/1480#issuecomment-1170362963.