### PR TITLE
Replace existing Twitter component with a wrapper for the vue-tweet-embed ones

### DIFF
--- a/content/bare/eu/usegalaxy/proteomics/index.md
+++ b/content/bare/eu/usegalaxy/proteomics/index.md
@@ -2,6 +2,7 @@
 title: Galaxy Proteomics
 autotoc: false
 gitter: usegalaxy-eu/Lobby
+components: true
 ---
 
 <slot name="/bare/eu/usegalaxy/notices" />
@@ -31,10 +32,7 @@ Welcome to **Galaxy Proteomics**
 
 </div>
 <div class="right" style="width: calc(50% - 12px); max-width: 400px">
-
-import Twitter from "@/components/Twitter";
-<Twitter width="100%" height="420" link="https://twitter.com/usegalaxyp?ref_src=twsrc%5Etfw">Tweets by usegalaxyp</Twitter>
-
+  <twitter user="usegalaxyp" :height="420"></twitter>
 </div>
 <div class="clearfix">
 </div>

--- a/src/build/partition-content.mjs
+++ b/src/build/partition-content.mjs
@@ -9,7 +9,7 @@ import { PathInfo } from "../lib/paths.mjs";
 export const CONTENT_TYPES = ["md", "vue", "insert", "resource"];
 const SCRIPT_DIR = nodePath.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = nodePath.dirname(nodePath.dirname(SCRIPT_DIR));
-const AUTODETECT_COMPONENTS = ["slot", "g-image", "link-box", "vega-embed", "markdown-embed", "tweet", "timeline"];
+const AUTODETECT_COMPONENTS = ["slot", "g-image", "link-box", "vega-embed", "markdown-embed", "twitter"];
 
 export class Partitioner {
     /** Create a `Partitioner`.

--- a/src/components/Twitter.vue
+++ b/src/components/Twitter.vue
@@ -1,20 +1,83 @@
 <template>
-    <a class="twitter-timeline" :data-width="`${width}`" :data-height="`${height}`" data-dnt="true" :href="link"
-        ><slot></slot
-    ></a>
+    <div :class="['outer', ...outerClasses]">
+        <div class="inner" :style="innerStyle">
+            <Tweet
+                v-if="tweet"
+                :id="tweet"
+                :options="computedOptions"
+                error-message="This tweet could not be loaded."
+            ></Tweet>
+            <Timeline
+                v-else-if="user"
+                :id="user"
+                :options="computedOptions"
+                source-type="profile"
+                error-message="This Twitter feed could not be loaded."
+            ></Timeline>
+        </div>
+    </div>
 </template>
 
 <script>
-// This is in a component instead of a function so that static pages can use it by embedding it in their Markdown.
-import { addTwitterScript } from "~/lib/client.mjs";
+import { Tweet, Timeline } from "vue-tweet-embed";
+/** Convenience wrapper for vue-tweet-embed's components.
+ * This provides one component for both tweets and timelines and prevents the user from having to
+ * repeat the wrapper HTML that allows centering.
+ */
 export default {
-    props: {
-        link: { type: String, required: true },
-        height: { type: String, required: true },
-        width: { type: String, required: true },
+    components: {
+        Tweet,
+        Timeline,
     },
-    mounted() {
-        addTwitterScript(window);
+    props: {
+        /** The id of the tweet to display. There is no need to provide the `user` as well. */
+        tweet: { type: String, required: false, default: "" },
+        /** The username of the timeline to display. */
+        user: { type: String, required: false, default: "" },
+        height: { type: Number, required: false, default: 810 },
+        width: { type: Number, required: false, default: 550 },
+        center: { type: Boolean, required: false, default: true },
+        /** Extra options to be passed directly to the underlying Tweet or Timeline component. */
+        options: { type: Object, required: false, default: () => ({}) },
+    },
+    computed: {
+        outerClasses() {
+            let classes = [];
+            if (this.center) {
+                classes.push("centered");
+            }
+            return classes;
+        },
+        innerStyle() {
+            if (this.center) {
+                return `width: ${this.width}px`;
+            } else {
+                return "";
+            }
+        },
+        computedOptions() {
+            let options = {
+                height: this.height,
+                width: this.width,
+            };
+            Object.assign(options, this.options);
+            return options;
+        },
+    },
+    created() {
+        if (!(this.tweet || this.user)) {
+            throw "Either a tweet or user must be provided to Twitter component.";
+        }
     },
 };
 </script>
+
+<style scoped>
+.centered.outer {
+    text-align: center;
+}
+.centered > .inner {
+    display: inline-block;
+    max-width: 100%;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import DefaultLayout from "~/layouts/Default.vue";
 import LinkBox from "~/components/LinkBox.vue";
 import VegaEmbed from "~/components/VegaEmbed.vue";
 import MarkdownEmbed from "~/components/MarkdownEmbed.vue";
-import { Tweet, Timeline } from "vue-tweet-embed";
+import Twitter from "~/components/Twitter.vue";
 
 import BootstrapVue from "bootstrap-vue";
 
@@ -18,8 +18,7 @@ export default function (Vue, { router, head, isClient }) {
     Vue.component("LinkBox", LinkBox);
     Vue.component("VegaEmbed", VegaEmbed);
     Vue.component("MarkdownEmbed", MarkdownEmbed);
-    Vue.component("Tweet", Tweet);
-    Vue.component("Timeline", Timeline);
+    Vue.component("Twitter", Twitter);
 
     Vue.use(BootstrapVue);
     Vue.config.ignoredElements = ["gcse:search", "gcse:searchresults-only"];


### PR DESCRIPTION
This is a rewrite of our `<Twitter>` component, instead of removing it as in #1642. This component wraps the `<Tweet>` and `<Timeline>` components from `vue-tweet-embed` (added in #1641).

This was mainly needed to prevent authors from having to continually repeat the double-div wrapper and custom styling necessary for centering the embeds. It also provided an opportunity to improve the interface. Particularly, this provides a single component for both individual tweets and timelines, instead of two separate components.