### PR TITLE
Move margin below img-sizer images to outside the div

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -602,8 +602,12 @@ pre {
     max-height: 100%;
     object-fit: contain;
 }
+.img-sizer {
+    margin-bottom: 1rem;
+}
 .img-sizer p {
     height: 100%;
+    margin-bottom: 0;
 }
 /***** Markdown styling helpers *****/
 .autowidth img {


### PR DESCRIPTION
When you use the `.img-sizer` class, the result is a `<div>` with that class, with a `<p>` inside, and an `<img>` inside that.

Previously, the `<p>` retained its default spacing, so it had a `margin-bottom: 1rem` below the `<p>` and above the bottom of the `<div>`. This has been fine generally, but if you want to add a border to the `<div>`, it makes it look asymmetrical. This places the margin below the `<div>` instead.