### PR TITLE
Add a flexible way to add a "back to X" link at the top of any page

### DIFF
--- a/content/0examples/non-vue/index.md
+++ b/content/0examples/non-vue/index.md
@@ -2,6 +2,7 @@
 title: Example Markdown page (without Vue components)
 tease: A tease
 hide_tease: true
+pretitle: Some content to show above the title.
 # Normally you wouldn't set the category manually. Instead, it's set based on where this file is
 # placed in the content directory. Since this isn't in the right place, we set it here manually.
 category: events

--- a/content/0examples/vue-remark/index.md
+++ b/content/0examples/vue-remark/index.md
@@ -2,6 +2,7 @@
 title: Example Markdown page with Vue components
 tease: A tease
 hide_tease: false
+pretitle: Some content to show above the title.
 # Normally you wouldn't set the category manually. Instead, it's set based on where this file is
 # placed in the content directory. Since this isn't in the right place, we set it here manually.
 category: news

--- a/content/hub/authoring/index.md
+++ b/content/hub/authoring/index.md
@@ -1,5 +1,6 @@
 ---
 title: Authoring Guide
+pretitle: "[← Back to Hub documentation](/hub/)"
 ---
 
 These are some tips for writing the Markdown for your articles.

--- a/content/hub/global/index.md
+++ b/content/hub/global/index.md
@@ -1,5 +1,6 @@
 ---
 title: The Global Hub
+pretitle: "[← Back to Hub documentation](/hub/)"
 ---
 
 The "Global Hub" is what we call the system for dividing the Hub into "subsites" where each Galaxy community can have their own section of the website. When you click the "Regions" dropdown menu in the navbar, those are all subsites.

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -3,6 +3,7 @@
         <g-link v-if="article.category" :to="categoryIndex" class="link">
             &larr; Back to <span class="text-capitalize">{{ article.category }}</span>
         </g-link>
+        <div v-if="article.pretitle" class="pretitle markdown" v-html="mdToHtml(article.pretitle)" />
         <Redirect v-if="article.redirect" :url="article.redirect" :location="this.location" />
         <div class="clearfix"></div>
         <g-image v-if="article.image" class="img-fluid main-image" :src="image" />
@@ -48,7 +49,7 @@
 <script>
 import Redirect from "@/components/Redirect";
 import Contacts from "@/components/Contacts";
-import { ensureDomain, humanDateSpan } from "~/lib/utils.js";
+import { ensureDomain, humanDateSpan, mdToHtml } from "~/lib/utils.js";
 import { getImage } from "~/lib/pages.mjs";
 import CONFIG from "~/../config.json";
 import * as dayjs from "dayjs";
@@ -94,6 +95,9 @@ export default {
     },
     props: {
         article: { type: Object, required: true },
+    },
+    methods: {
+        mdToHtml,
     },
     data() {
         return {

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -13,6 +13,7 @@ query Article($path: String!) {
         title
         tease
         hide_tease
+        pretitle
         subsites
         main_subsite
         category

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -27,6 +27,7 @@ query VueArticle($path: String!) {
         title
         tease
         hide_tease
+        pretitle
         subsites
         main_subsite
         category


### PR DESCRIPTION
Pages with a specific category (like `events`) get a special link at the top to navigate back to the listing for all pages in that category (e.g. "[← Back to events](https://galaxyproject.org/events/)"). But such a backlink would be useful for a lot of other types of pages. Clearly, since many already put them in manually (see [this page](https://galaxyproject.org/learn/privacy-features/) or [this one](https://galaxyproject.org/learn/advanced-workflow/extract/)).

This would be solved by a more comprehensive inter-page navigation UI like #957 proposes. But until then, this adds a simple and flexible way to solve this particular problem on a page-by-page basis.

Instead of adding a narrowly specific metadata field just for the concept of a top-of-the-page link, this gives a field (`pretitle`) where you can specify any kind of Markdown content you'd like to put at the top of the page. This gives control of the presentation to the author and could be useful for other top-line content.