### PR TITLE
List VueArticles in dynamic pages too

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -530,7 +530,7 @@ module.exports = function (api) {
     api.createPages(async ({ graphql }) => {
         eventsData = await graphql(`
             query {
-                allArticle(filter: { category: { eq: "events" } }) {
+                allParentArticle(filter: { category: { eq: "events" } }) {
                     totalCount
                     edges {
                         node {
@@ -588,7 +588,7 @@ module.exports = function (api) {
 
 function makeCalendar(eventsData) {
     let events = [];
-    for (let event of eventsData.data.allArticle.edges) {
+    for (let event of eventsData.data.allParentArticle.edges) {
         event = event.node;
         if (event.date) {
             const evt = {};

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -269,10 +269,10 @@ class nodeModifier {
                     mimeType: node.internal.mimeType,
                     // If you include the `content` too, the node appears to get re-parsed and ends up
                     // with the original metadata values (before the edits done by `processNonInsert()`).
-                }
+                },
             };
             for (let [key, value] of Object.entries(node)) {
-                if (! (key.startsWith("$") || key === "id" || key === "internal")) {
+                if (!(key.startsWith("$") || key === "id" || key === "internal")) {
                     newNode[key] = cloneDeep(value);
                 }
             }
@@ -391,7 +391,7 @@ module.exports = function (api) {
          *      This is supposed to be fixed by Gridsome 1.0.
          */
         actions.addCollection({
-            typeName: "ParentArticle"
+            typeName: "ParentArticle",
         });
         for (let type of ARTICLE_TYPES) {
             actions.addSchemaTypes(

--- a/src/components/pages/Events.vue
+++ b/src/components/pages/Events.vue
@@ -89,7 +89,7 @@ query($subsite: String, $mainPath: String, $footerPath: String) {
         title
         content
     }
-    upcoming: allArticle(
+    upcoming: allParentArticle(
         sortBy: "date", order: ASC, filter: {
             category: {eq: "events"}, subsites: {contains: [$subsite]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {lte: 0}
@@ -102,7 +102,7 @@ query($subsite: String, $mainPath: String, $footerPath: String) {
             }
         }
     }
-    recent: allArticle(
+    recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
             category: {eq: "events"}, subsites: {contains: [$subsite]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {between: [1, 365]}
@@ -116,7 +116,7 @@ query($subsite: String, $mainPath: String, $footerPath: String) {
         }
     }
 }
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/components/pages/EventsArchive.vue
+++ b/src/components/pages/EventsArchive.vue
@@ -58,7 +58,7 @@ query($subsite: String, $mainPath: String, $footerPath: String) {
         title
         content
     }
-    events: allArticle(
+    events: allParentArticle(
         sortBy: "date", order: DESC, filter: {
             subsites: {contains: [$subsite]}, category: {eq: "events"},
             has_date: {eq: true}, days_ago: {gt: 364}, draft: {ne: true}

--- a/src/components/pages/News.vue
+++ b/src/components/pages/News.vue
@@ -44,7 +44,7 @@ query($subsite: String, $mainPath: String) {
             path
         }
     }
-    articles: allArticle(
+    articles: allParentArticle(
             sortBy: "date", order: DESC, filter: {
                 category: {eq: "news"}, subsites: {contains: [$subsite]}, draft: {ne: true}
             }

--- a/src/components/pages/SubsiteHome.vue
+++ b/src/components/pages/SubsiteHome.vue
@@ -124,7 +124,7 @@ query($subsite: String, $cardsPath: String, $insertRegex: String) {
             }
         }
     }
-    news: allArticle(
+    news: allParentArticle(
         limit: 5, filter: {category: {eq: "news" }, subsites: {contains: [$subsite]}, draft: {ne: true}}
     ) {
         totalCount
@@ -134,7 +134,7 @@ query($subsite: String, $cardsPath: String, $insertRegex: String) {
             }
         }
     }
-    events: allArticle(
+    events: allParentArticle(
         limit: 5, sortBy: "date", order: ASC,
         filter: {
             category: {eq: "events"}, subsites: {contains: [$subsite]}, has_date: {eq: true}, days_ago: {lte: 0},
@@ -151,7 +151,7 @@ query($subsite: String, $cardsPath: String, $insertRegex: String) {
         }
     }
 }
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/components/pages/TaggedEvents.vue
+++ b/src/components/pages/TaggedEvents.vue
@@ -78,7 +78,7 @@ query($tag: String, $mainPath: String, $footerPath: String) {
         title
         content
     }
-    upcoming: allArticle(
+    upcoming: allParentArticle(
         sortBy: "date", order: ASC, filter: {
             category: {eq: "events"}, tags: {contains: [$tag]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {lte: 0}
@@ -91,7 +91,7 @@ query($tag: String, $mainPath: String, $footerPath: String) {
             }
         }
     }
-    recent: allArticle(
+    recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
             category: {eq: "events"}, tags: {contains: [$tag]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {between: [1, 365]}
@@ -105,7 +105,7 @@ query($tag: String, $mainPath: String, $footerPath: String) {
         }
     }
 }
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/pages/Blog.vue
+++ b/src/pages/Blog.vue
@@ -47,7 +47,7 @@ query {
         title
         content
     }
-    articles: allArticle(sortBy: "date", order: DESC, filter: {category: {eq: "blog"}, draft: {ne: true}}) {
+    articles: allParentArticle(sortBy: "date", order: DESC, filter: {category: {eq: "blog"}, draft: {ne: true}}) {
         totalCount
         edges {
             node {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -148,7 +148,7 @@ query {
             }
         }
     }
-    news: allArticle(
+    news: allParentArticle(
         limit: 5, filter: {category: {eq: "news" }, subsites: {contains: ["global"]}, draft: {ne: true}}
     ) {
         totalCount
@@ -158,7 +158,7 @@ query {
             }
         }
     }
-    events: allArticle(
+    events: allParentArticle(
         limit: 5, sortBy: "date", order: ASC,
         filter: {
             category: {eq: "events"}, subsites: {contains: ["global"]}, has_date: {eq: true}, days_ago: {lte: 0},
@@ -174,7 +174,7 @@ query {
             }
         }
     }
-    blog: allArticle(limit: 5, filter: {category: {eq: "blog"}, draft: {ne: true}}) {
+    blog: allParentArticle(limit: 5, filter: {category: {eq: "blog"}, draft: {ne: true}}) {
         totalCount
         edges {
             node {
@@ -182,7 +182,7 @@ query {
             }
         }
     }
-    careers: allArticle(
+    careers: allParentArticle(
         limit: 5, sortBy: "date", order: DESC, filter: {
             category: {eq: "careers"}, closed: {eq: false}, draft: {ne: true}
         }
@@ -203,7 +203,7 @@ query {
         }
     }
 }
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/pages/bare/eu/Events.vue
+++ b/src/pages/bare/eu/Events.vue
@@ -78,7 +78,7 @@ query {
         title
         content
     }
-    upcoming: allArticle(
+    upcoming: allParentArticle(
         sortBy: "date", order: ASC, filter: {
             category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {lte: 0}
@@ -91,7 +91,7 @@ query {
             }
         }
     }
-    recent: allArticle(
+    recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
             category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {between: [1, 365]}
@@ -105,7 +105,7 @@ query {
         }
     }
 }
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/pages/bare/eu/News.vue
+++ b/src/pages/bare/eu/News.vue
@@ -41,7 +41,7 @@ query {
             path
         }
     }
-    articles: allArticle(
+    articles: allParentArticle(
             sortBy: "date", order: DESC, filter: {
                 category: {eq: "news"}, subsites: {contains: ["eu"]}, draft: {ne: true}
             }

--- a/src/pages/bare/eu/latest/Events.vue
+++ b/src/pages/bare/eu/latest/Events.vue
@@ -33,7 +33,7 @@ export default {
 
 <page-query>
 query {
-    events: allArticle(
+    events: allParentArticle(
         limit: 5, sortBy: "date", order: ASC,
         filter: {
             category: {eq: "events"}, subsites: {contains: ["eu"]}, has_date: {eq: true}, days_ago: {lte: 0},

--- a/src/pages/bare/eu/latest/News.vue
+++ b/src/pages/bare/eu/latest/News.vue
@@ -26,7 +26,7 @@ export default {
 
 <page-query>
 query {
-    news: allArticle(
+    news: allParentArticle(
         limit: 5, filter: {category: {eq: "news" }, subsites: {contains: ["eu"]}, draft: {ne: true}}
     ) {
         totalCount

--- a/src/pages/everywhere/Events.vue
+++ b/src/pages/everywhere/Events.vue
@@ -77,7 +77,7 @@ query {
             path
         }
     }
-    upcoming: allArticle(
+    upcoming: allParentArticle(
         sortBy: "date", order: ASC, filter: {
             category: {eq: "events"}, draft: {ne: true}, has_date: {eq: true}, days_ago: {lte: 0}
         }
@@ -89,7 +89,7 @@ query {
             }
         }
     }
-    recent: allArticle(
+    recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
             category: {eq: "events"}, draft: {ne: true}, has_date: {eq: true}, days_ago: {between: [1, 365]}
         }
@@ -102,7 +102,7 @@ query {
         }
     }
 }
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/pages/everywhere/News.vue
+++ b/src/pages/everywhere/News.vue
@@ -38,7 +38,7 @@ query {
             path
         }
     }
-    articles: allArticle(
+    articles: allParentArticle(
             sortBy: "date", order: DESC, filter: {category: {eq: "news"}, draft: {ne: true}}
         ) {
         totalCount


### PR DESCRIPTION
This resolves #751 by creating a new Collection called `ParentArticle`. Each `ParentArticle` is created by copying the data from an `Article` or `VueArticle`. But FYI the "copies" are mostly just references to the same string objects, so there's not much memory overhead.

So dynamic pages can just query for `allParentArticle` instead of doubling the number of queries (one for `Article`s and one for `VueArticle`s). Since the GraphQL queries are the least dynamic part of the system, without this there's not much we can do to avoid hardcoding two copies of every query.

This was the least bad solution I found. I also [tried](https://github.com/NickSto/galaxy-hub/commit/93ddb29d97993069334a9b1baff178be5d338c02) creating a sort of inheritance through GraphQL interfaces, but I don't think Gridsome offers enough access to the schema to make it work.

FYI, I've tested and this doesn't add any significant time or memory usage to the build (or development server).