### PR TITLE
Fix issues with using images in /assets/media/

### DIFF
--- a/src/build/fix-links.mjs
+++ b/src/build/fix-links.mjs
@@ -15,7 +15,7 @@ let debug = false;
 // Prefixes that denote that the path is absolute and does not need altering.
 //TODO: How about urls that begin with a domain but no protocol?
 //      Check if that happens in the codebase.
-const PREFIX_WHITELIST = ["http://", "https://", "mailto:", "/images/", "//", "#"];
+const PREFIX_WHITELIST = ["http://", "https://", "mailto:", "/images/", "/assets/", "//", "#"];
 const LINK_PROPS = { img: "src", a: "href" };
 const LINK_FIXERS = { image: fixImageLink, img: fixImageLink };
 

--- a/static/assets
+++ b/static/assets
@@ -1,0 +1,1 @@
+../content/assets


### PR DESCRIPTION
This adds a symlink from static/assets to content/assets so we can place images from .eu there and have them work with unchanged absolute urls like /media/assets/image.jpg. I also had to add /assets/ to the allowlist of urls which shouldn't be altered by fix-links.mjs.