### PR TITLE
location_url -> location.url on a few posts

### DIFF
--- a/content/events/2022-06-07-elixir-training-platform/index.md
+++ b/content/events/2022-06-07-elixir-training-platform/index.md
@@ -6,7 +6,7 @@ tease: "Workshop at the ELIXIR All Hands 2022"
 continent: EU
 location:
   name: "ELIXIR All Hands 2022, Amsterdam, Europe"
-location_url: "https://elixir-europe.org/events/elixir-all-hands-2022"
+  url: "https://elixir-europe.org/events/elixir-all-hands-2022"
 external_url: "https://docs.google.com/document/d/1vlHODVnN9RFTp2fr2NCcLV4ujb8Js3EH6NqXHfP_F9E/edit#"
 gtn: false
 contact: "Fotis Psomopoulos, Jessica Lindvall, Katharina Heil, Ana P. Melo, Alexia Cardona, Eija Korpelainen, Patricia Palagi, Loredana Le Pera, Eva Alloza, Bérénice Batut, Egon Willighagen"

--- a/content/events/2022-06-08-elixir-covid/index.md
+++ b/content/events/2022-06-08-elixir-covid/index.md
@@ -6,7 +6,7 @@ tease: "Workshop at the ELIXIR All Hands 2022"
 continent: EU
 location:
   name: "ELIXIR All Hands 2022, Amsterdam, Europe"
-location_url: "https://elixir-europe.org/events/elixir-all-hands-2022"
+  url: "https://elixir-europe.org/events/elixir-all-hands-2022"
 external_url: "https://docs.google.com/document/d/1FKBYBxehpaxFT_vLURwq5TbyQjxI4sYiSKeULT0ioso/edit"
 gtn: false
 contact: "Marianna Ventouratou"

--- a/content/events/2022-06-08-vhir/index.md
+++ b/content/events/2022-06-08-vhir/index.md
@@ -6,7 +6,7 @@ tease: "overview of the main bioinformatics resources useful in the day-to-day l
 continent: EU
 location:
   name: "Vall d'Hebron University Hospital (HUVH), Spain, Europe"
-location_url: "http://en.vhir.org/portal1/homepage.asp"
+  url: "http://en.vhir.org/portal1/homepage.asp"
 external_url: "http://en.vhir.org/portal1/curso.asp?s=docencia&contentid=238299"
 gtn: false
 contact: "Mireia Ferrer"

--- a/content/events/2022-06-09-community-call/index.md
+++ b/content/events/2022-06-09-community-call/index.md
@@ -6,7 +6,7 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Simon Bray"

--- a/content/events/2022-06-23-community-call/index.md
+++ b/content/events/2022-06-23-community-call/index.md
@@ -6,7 +6,7 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "John Davis, Marius van den Beek"

--- a/content/events/2022-07-07-community-call/index.md
+++ b/content/events/2022-07-07-community-call/index.md
@@ -6,7 +6,7 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Anup Kumar"

--- a/content/events/2022-07-irods-user-group-meeting/index.md
+++ b/content/events/2022-07-irods-user-group-meeting/index.md
@@ -6,8 +6,8 @@ tease: "iRODS 2022 User Group Meeting"
 continent: EU
 location:
   name: "KU Leuven, Belgium"
+  url: "https://www.kuleuven.be/english/kuleuven"
 external_url: "https://irods.org/ugm2022/"
-location_url: "https://www.kuleuven.be/english/kuleuven"
 gtn: false
 contact: "Kaivan Kamali, Nate Coraor, Marius van den Beek, John Chilton, Anton Nekrutenko"
 tags: [ ]

--- a/content/events/2022-08-04-community-call/index.md
+++ b/content/events/2022-08-04-community-call/index.md
@@ -6,7 +6,7 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Kaivan Kamali"

--- a/content/events/2022-08-18-community-call/index.md
+++ b/content/events/2022-08-18-community-call/index.md
@@ -6,7 +6,7 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Outreachy mentors & interns"

--- a/content/events/2022-08-taiarapu-assembly-annotation/index.md
+++ b/content/events/2022-08-taiarapu-assembly-annotation/index.md
@@ -7,7 +7,6 @@ continent: AU
 location:
   name: 'Centre Ifremer du Pacifique, Taiarapu-Ouest, Polynésie française'
 image:
-location_url: ""
 external_url: "https://wwz.ifremer.fr/Recherche/Departements-scientifiques/Departement-Infrastructures-de-Recherche-et-Systemes-d-Information/Bioinformatique/Animations-scientifiques/Formations-Bioinformatiques-en-Polynesie-2022"
 gtn: true
 contact: "Alexandre Cormier, Cyril Noel, Patrick Durand"

--- a/content/events/2022-09-01-community-call/index.md
+++ b/content/events/2022-09-01-community-call/index.md
@@ -6,7 +6,7 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Dannon Baker"

--- a/content/events/2022-09-15-community-call/index.md
+++ b/content/events/2022-09-15-community-call/index.md
@@ -6,7 +6,7 @@ tease: "A forum to share updates and discuss community-wide topics"
 continent: GL
 location:
   name: "Galaxy Community Call, Online, Global"
-location_url: "/community/community-calls/"
+  url: "/community/community-calls/"
 external_url:
 gtn: false
 contact: "Michelle Savage, Ahmed Awan, Tyler Collins"

--- a/content/events/2023-02-ebi-single-cell/index.md
+++ b/content/events/2023-02-ebi-single-cell/index.md
@@ -6,7 +6,7 @@ tease: "Participants will be guided through the droplet-based scRNA-seq analysis
 continent: EU
 location:
   name: "Online, EMBL-EBI, Hinxton, United Kingdom"
-location_url: "https://www.ebi.ac.uk/training"
+  url: "https://www.ebi.ac.uk/training"
 external_url: "https://www.ebi.ac.uk/training/events/single-cell-rna-seq-analysis-using-galaxy-0/"
 gtn: false
 contact: "Jane Reynolds"

--- a/content/events/2023-04-sib-introduction/index.md
+++ b/content/events/2023-04-sib-introduction/index.md
@@ -6,7 +6,7 @@ tease: "This 1.5-day course will give a general introduction on the galaxy web-p
 continent: EU
 location:
   name: "Bern Switzerland"
-location_url: "https://www.sib.swiss/training"
+  url: "https://www.sib.swiss/training"
 external_url: "https://www.sib.swiss/training/course/20230425_GALXY"
 gtn: true
 contact: "Lucille Delisle, Hans-Rudolf Hotz"

--- a/content/events/bcc2020/index.md
+++ b/content/events/bcc2020/index.md
@@ -6,7 +6,6 @@ tease: "Galaxy & BOSC join forces again for 8 days of training, meeting, network
 continent: GL
 location:
   name: "Online, Global"
-location_url: ""
 external_url: "https://bcc2020.github.io/"
 image: 
 gtn: true


### PR DESCRIPTION
This adjusts the most recent events to use the newer, structured `location` metadata field instead of `location_url` as a separate field.

This should help people using existing events as a template.