### PR TITLE
Expand on file organization documentation, add breadcrumbs to Hub documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,75 +6,11 @@ This is the repository for the [Galaxy Community Hub](https://galaxyproject.org)
 
 We could describe it here, but really, see the web site that is generated from this repository: [galaxyproject.org](https://galaxyproject.org). That will save a lot of typing.
 
-## Getting started
+## More info
 
-First, make sure you have [Node](https://nodejs.org/en/) installed. Then, you'll need a package manager. These instructions use [yarn 1](https://yarnpkg.com/)\*, but there are equivalent commands for [npm](https://docs.npmjs.com/cli/v7/commands/npm).
-
-\*Do not use Yarn 2.
-
-### Get Node and Yarn
-
-What if you don't already have Node and Yarn 1 installed?
-
-#### On MacOS
-
-If you don't already have Node and Yarn installed, then we recommend using Homebrew.  If you don't have Homebrew, then install it with
-```sh
-$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-Then update your `$PATH` by following the displayed instructions.
-
-To install Node:
-```sh
-$ brew install node
-```
-
-Then install Yarn 1:
-```sh
-$ npm install --global yarn
-```
-
-### Clone the repo and launch the site.
-
-You can get the site running locally by first cloning this repo:  
-```sh
-$ git clone 'https://github.com/galaxyproject/galaxy-hub.git'
-```
-
-Then install the dependencies:
-```sh
-$ cd galaxy-hub
-$ yarn install
-```
-
-Then you can build the site in development mode to run it in a local server (at http://localhost:8080) and see your content:
-```sh
-$ yarn develop
-```
-This command includes a hot reloader which will update the site automatically each time you edit a file.
-
-To generate the static files for the entire site, just run `build` instead:
-```sh
-$ yarn build
-```
-The static files can then be found in the `dist` directory.
+The main documentation for the Hub is kept on the Hub itself! See [this page](https://galaxyproject.org/hub/) for info on things like contributing content and running the site locally. Of course, since this repo is the source for the site, you can also find the documentation here. The source for that page is in [content/hub/index.md](https://github.com/galaxyproject/galaxy-hub/blob/master/content/hub/index.md).
 
 ## Creating static pages
-
-### File organization
-
-To see an example of how the files are organized, see the [`src`](/NickSto/galaxy-hub/tree/gridhub/src) directory of the [`gridhub`](/NickSto/galaxy-hub/tree/gridhub) branch of [`galaxy-hub`](/galaxyproject/galaxy-hub).
-
-For static pages (normal, informational pages), you create a directory, whose name becomes the last part of the url. Then you create an `index.md` file inside it. The url will be everything *after* `content` and *before* `index.md`:
-
-| Path to Markdown file                        | URL path                      |
-|:---------------------------------------------|:----------------------------- |
-| `content/events/2021-02-gtn/index.md`        | `/events/2021-02-gtn/`        |
-| `content/galaxy-project/statistics/index.md` | `/galaxy-project/statistics/` |
-
-### Writing the Markdown
-
-See the [Authoring Guide](doc/AUTHORING.md)
 
 ### Custom layouts for static pages
 
@@ -110,10 +46,6 @@ To define a new category, just add another entry, with the parent url as the key
 ## Creating dynamic pages
 
 Dynamic pages are ones where part of it is auto-generated. Usually they list a certain group of static pages.
-
-### File organization
-
-These are created by making a `.vue` file in the `src/pages/` directory. Much like the Markdown files, the placement of the `.vue` file determines the url. So `src/pages/Blog.vue` displays at `/blog/` and `src/pages/news/Gtn.vue` would display at `/news/gtn/`. There's also the `src/mediated-pages/` directory, which works the same except pages there have access to some custom variables set by the framework.
 
 ### Querying for the auto-generated content
 

--- a/content/hub/contributing/file-organization/index.md
+++ b/content/hub/contributing/file-organization/index.md
@@ -1,5 +1,6 @@
 ---
 title: File organization
+pretitle: "[Home](/) > [Hub](/hub/) > [Contributing](/hub/contributing/) > [File Organization](/hub/contributing/file-organization/)"
 ---
 
 A central concept of the Hub system is that the organization of the files is the same as the organization of the pages on the website. That means that the path for the Markdown file for each page is the same as its url. Examples will illustrate this best:

--- a/content/hub/contributing/file-organization/index.md
+++ b/content/hub/contributing/file-organization/index.md
@@ -3,7 +3,9 @@ title: File organization
 pretitle: "[Home](/) > [Hub](/hub/) > [Contributing](/hub/contributing/) > [File Organization](/hub/contributing/file-organization/)"
 ---
 
-A central concept of the Hub system is that the organization of the files is the same as the organization of the pages on the website. That means that the path for the Markdown file for each page is the same as its url. Examples will illustrate this best:
+## The url is the directory
+
+A central concept of the Hub is that the organization of the files is the same as the organization of the pages on the website. That means that the path for the Markdown file for each page is the same as its url. Examples will illustrate this best:
 
 <div class="compact">
 
@@ -15,3 +17,34 @@ A central concept of the Hub system is that the organization of the files is the
 </div>
 
 Basically, the directories in the `content` directory are the urls of the site. The content of each page is in an `index.md` file inside the final directory in the path.
+
+### Dynamic pages
+
+Dynamic pages are kept in a different place but also follow this principle for the most part. Dynamic pages are ones which automatically aggregate other pages, like [/events/](https://galaxyproject.org/events/).
+
+The source code that generates the structure of dynamic pages is kept in Vue files in the `src/` directory. Most dynamic pages are in `src/pages/` and their location within that directory is the same as their url:
+
+<div class="compact">
+
+| Path to Vue file               | URL                                 |
+|:-------------------------------|:------------------------------------|
+| `src/pages/Careers.vue`        | `galaxyproject.org/careers/`        |
+| `src/pages/bare/eu/Events.vue` | `galaxyproject.org/bare/eu/events/` |
+
+</div>
+
+However, some Vue files generate multiple dynamic pages at different urls. Since one file produces pages at multiple urls, the file location can't mirror the url. These Vue files are kept in `src/components/pages/`.
+
+For example, these two Vue files generate many different pages:
+
+<div class="compact">
+
+| Vue file | `src/components/pages/Events.vue`    | `src/components/pages/TaggedEvents.vue`       |
+|:---------|:-------------------------------------|:----------------------------------------------|
+| URL      | `galaxyproject.org/events/`          | `galaxyproject.org/events/cofests/`           |
+| URL      | `galaxyproject.org/eu/events/`       | `galaxyproject.org/events/webinars/`          |
+| URL      | `galaxyproject.org/pasteur/events/`  | `galaxyproject.org/events/cofests/papercuts/` |
+| URL      | `galaxyproject.org/freiburg/events/` | `galaxyproject.org/community/devroundtable/`  |
+|          |  etc...                              |                                               |
+
+</div>

--- a/content/hub/contributing/index.md
+++ b/content/hub/contributing/index.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing content
-pretitle: "[← Back to Hub documentation home](/hub/)"
+pretitle: "[Home](/) > [Hub](/hub/) > [Contributing](/hub/contributing/)"
 ---
 
 This page is for those who want to create or edit content pages on the Hub.
@@ -62,7 +62,7 @@ The message you get after you do that will include a url you can visit to create
 
 Static files are written in YAML and Markdown.
 
-Each file should start with the metadata in [YAML](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started) format. This section starts and ends with a line with just three dashes (`---`). The YAML header is where you put the title of the page and other metadata like the date of an event. Then after the YAML section is the content of the page in [Markdown](https://www.markdownguide.org/basic-syntax/).
+Each file should start with the metadata in [YAML](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started) format. This section starts and ends with a line with just three dashes (`---`). The YAML header is where you put the title of the page and other metadata like the date of an event. Then after the YAML section is the content of the page in [Markdown](https://www.markdownguide.org/basic-syntax/). See [this page](/hub/contributing/markdown/) for tips on formatting your Markdown.
 
 ## Running the development server
 

--- a/content/hub/contributing/markdown/index.md
+++ b/content/hub/contributing/markdown/index.md
@@ -1,9 +1,9 @@
 ---
-title: Authoring Guide
-pretitle: "[← Back to Hub documentation](/hub/)"
+title: Advanced Markdown
+pretitle: "[Home](/) > [Hub](/hub/) > [Contributing](/hub/contributing/) > [Markdown](/hub/contributing/markdown/)"
 ---
 
-These are some tips for writing the Markdown for your articles.
+These are some tips for when you need to go beyond basic Markdown for your articles.
 
 ## Inserting HTML
 

--- a/content/hub/dev/history/index.md
+++ b/content/hub/dev/history/index.md
@@ -1,5 +1,6 @@
 ---
 title: Community Hub History
+pretitle: "[Home](/) > [Hub](/hub/) > Dev > [History](/hub/dev/history/)"
 ---
 
 This page keeps track of some institutional knowledge about this site (the Galaxy Community Hub) itself.

--- a/content/hub/global/index.md
+++ b/content/hub/global/index.md
@@ -1,6 +1,6 @@
 ---
 title: The Global Hub
-pretitle: "[← Back to Hub documentation home](/hub/)"
+pretitle: "[Home](/) > [Hub](/hub/) > [Global Hub](/hub/global/)"
 ---
 
 The "Global Hub" is what we call the system for dividing the Hub into "subsites" where each Galaxy community can have their own section of the website. When you click the "Regions" dropdown menu in the navbar, those are all subsites.

--- a/content/hub/index.md
+++ b/content/hub/index.md
@@ -1,5 +1,6 @@
 ---
 title: About The Galaxy Community Hub
+pretitle: "[Home](/) > [Hub](/hub/)"
 ---
 
 This website ([galaxyproject.org](/)) is a central place for information and updates about the Galaxy Project.


### PR DESCRIPTION
This expands the content in [/hub/contributing/file-organization/](https://galaxyproject.org/hub/contributing/file-organization/) with info about the Vue files for dynamic pages.

I also decided to try out breadcrumbs instead of the generic "back to home" at the top of the page. Maybe a bit of a prototype for #957?