### PR TITLE
ESG News

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,7 +80,8 @@
             },
             "esg": {
                 "name": "EuroScienceGateway",
-                "gitter": "usegalaxy-eu/Lobby"
+                "gitter": "usegalaxy-eu/Lobby",
+                "custom": true
             }
         }
     },

--- a/config.json
+++ b/config.json
@@ -77,6 +77,10 @@
             "ifb": {
                 "name": "ELIXIR-FR/IFB",
                 "gitter": "usegalaxy-eu/Lobby"
+            },
+            "esg": {
+                "name": "EuroScienceGateway",
+                "gitter": "usegalaxy-eu/Lobby"
             }
         }
     },

--- a/content/events/2022-11-24-esg-kickoff-meeting/index.md
+++ b/content/events/2022-11-24-esg-kickoff-meeting/index.md
@@ -1,0 +1,32 @@
+---
+title: EuroScienceGateway - Kickoff meeting
+date: "2022-11-06"
+end: "2022-11-06"
+tease: "The EuroScienceGateway project officially starts with a 2 days kickoff meeting with all 17 partners"
+location:
+  city: Freiburg im Breisgau
+  country: Germany
+  name: Building 101
+  postal: 79110
+  region: Baden-Württemberg
+  street: Georges-Köhler-Allee 101
+tags: [esg]
+subsites: [all-eu, esg]
+---
+
+Co-located with the European Galaxy Days, the EuroScienceGateway consortium of 17 partners will get together in Freiburg Germany,
+for a 2 day Kick-Off meeting, organized by the coordinators of the project, Albert-Ludwigs-University Freiburg.
+The partners have the opportunity to plan together the next steps in the project, with the purpose of achieving the
+expected outcomes of the project and delivering the results in a timely and effective manner.
+
+The EuroScienceGateway project consists of 5 Work Packages, on the following topics:
+
+* WP1: Project Management, Coordination and Dissemination
+* WP2: Stimulate FAIR and reusable research
+* WP3: Pulsar Network: Distributed heterogeneous compute
+* WP4: Building blocks for a sustainable operating model
+* WP5: Community engagement, adoption and onboarding
+
+Following this meeting, the partners, universities and research centers from all across Europe, are guided in their actions towards the
+achievement of the results by the work package leaders and the coordinators of the action. The overall objective of the
+36 month EuroScienceGateway project, is to achieve a shared vision of an open collaborative digital space for European scientists.

--- a/content/projects/esg/work_packages.yml
+++ b/content/projects/esg/work_packages.yml
@@ -2,24 +2,24 @@ title: "Work Packages"
 
 summary:
   title: "Work Packages"
-  content: "EuroScienceGateway is organzied into multiple work packages, each with it's own focus."
+  content: "EuroScienceGateway is organized into multiple work packages, each with it's own focus."
 
 wp1:
   title: "Work Package 1"
-  content: "Project Management, Coordination and Dissemination"
+  content: "Project Management, Coordination and Dissemination."
 
 wp2:
   title: "Work Package 2"
-  content: "Stimulate FAIR and reusable research"
+  content: "Stimulate FAIR and reusable research."
 
 wp3:
   title: "Work Package 3"
-  content: "Pulsar Network: Distributed heterogeneous compute"
+  content: "Pulsar Network: Distributed heterogeneous compute."
 
 wp4:
   title: "Work Package 4"
-  content: "Building blocks for a sustainable operating model"
+  content: "Building blocks for a sustainable operating model."
 
 wp5:
   title: "Work Package 5"
-  content: "Community engagement, adoption and onboarding"
+  content: "Community engagement, adoption and onboarding."

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -458,6 +458,11 @@ module.exports = function (api) {
         }
         // Pages repeated across every subsite.
         for (let subsite of Object.keys(CONFIG.subsites.all)) {
+            // subsite provides it's own pages/routes
+            if (CONFIG.subsites.all[subsite].custom) {
+                continue;
+            }
+
             let prefix;
             if (subsite === CONFIG.subsites.default) {
                 prefix = "";

--- a/src/components/esg/EsgInteractivePoster.vue
+++ b/src/components/esg/EsgInteractivePoster.vue
@@ -36,7 +36,9 @@
         <b-carousel class="carousel mt-2 shadow-sm" v-model="currentInfoIndex" :interval="0" controls>
             <b-carousel-slide v-for="(info, i) in wpInfos" :key="i">
                 <h3>{{ info.title }}</h3>
-                <p>{{ info.content }}</p>
+                <p>
+                    {{ info.content }}<span v-if="info.news"> - <a :href="info.news">News</a></span>
+                </p>
             </b-carousel-slide>
         </b-carousel>
     </div>
@@ -68,26 +70,31 @@ export default {
                 title: this.$static.datasetWorkPackages.wp1.title,
                 content: this.$static.datasetWorkPackages.wp1.content,
                 area: { x: 40, y: 0, w: this.totalDimensions.w - 60, h: this.totalDimensions.h },
+                news: "/projects/esg/news/?tag=esg-wp1",
             },
             {
                 title: this.$static.datasetWorkPackages.wp2.title,
                 content: this.$static.datasetWorkPackages.wp2.content,
                 area: { x: 2310, y: 10, w: 3850, h: 770 },
+                news: "/projects/esg/news/?tag=esg-wp2",
             },
             {
                 title: this.$static.datasetWorkPackages.wp3.title,
                 content: this.$static.datasetWorkPackages.wp3.content,
                 area: { x: 2310, y: 820, w: 3850, h: 2090 },
+                news: "/projects/esg/news/?tag=esg-wp3",
             },
             {
                 title: this.$static.datasetWorkPackages.wp4.title,
                 content: this.$static.datasetWorkPackages.wp4.content,
                 area: { x: 2310, y: 820, w: 3850, h: 2090 },
+                news: "/projects/esg/news/?tag=esg-wp4",
             },
             {
                 title: this.$static.datasetWorkPackages.wp5.title,
                 content: this.$static.datasetWorkPackages.wp5.content,
                 area: { x: 40, y: 5, w: 2200, h: 1570 },
+                news: "/projects/esg/news/?tag=esg-wp5",
             },
         ];
     },

--- a/src/pages/projects/esg/Events.vue
+++ b/src/pages/projects/esg/Events.vue
@@ -71,9 +71,9 @@ query {
         content
     }
 
-    upcoming: allArticle(
+    upcoming: allParentArticle(
         sortBy: "date", order: ASC, filter: {
-            category: {eq: "events"}, subsites: {contains: ["global"]}, draft: {ne: true},
+            category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {lte: 0}
         }
     ) {
@@ -84,9 +84,9 @@ query {
         }
     }
 
-    recent: allArticle(
+    recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
-            category: {eq: "events"}, subsites: {contains: ["global"]}, draft: {ne: true},
+            category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {between: [1, 365]}
         }
     ) {
@@ -98,7 +98,7 @@ query {
     }
 }
 
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/pages/projects/esg/Index.vue
+++ b/src/pages/projects/esg/Index.vue
@@ -206,8 +206,9 @@ query {
         }
     }
 
-    news: allArticle(
-        limit: 6, filter: {category: {eq: "news" }, subsites: {contains: ["global"]}, draft: {ne: true}}
+    news: allParentArticle(
+        limit: 6, sortBy: "date", order: DESC,
+        filter: {category: {eq: "news" }, subsites: {contains: ["esg"]}, draft: {ne: true}}
     ) {
         edges {
             node {
@@ -216,10 +217,10 @@ query {
         }
     }
 
-    events: allArticle(
+    events: allParentArticle(
         limit: 5, sortBy: "date", order: ASC,
         filter: {
-            category: {eq: "events"}, subsites: {contains: ["global"]}, has_date: {eq: true}, days_ago: {lte: 0},
+            category: {eq: "events"}, subsites: {contains: ["eu"]}, has_date: {eq: true}, days_ago: {lte: 0},
             draft: {ne: true}
         }
     ) {
@@ -233,7 +234,7 @@ query {
     }
 }
 
-fragment articleFields on Article {
+fragment articleFields on ParentArticle {
     id
     title
     tease

--- a/src/pages/projects/esg/News.vue
+++ b/src/pages/projects/esg/News.vue
@@ -40,9 +40,9 @@ query {
         content
     }
 
-    articles: allArticle(
+    articles: allParentArticle(
             sortBy: "date", order: DESC, filter: {
-                category: {eq: "news"}, subsites: {contains: ["global"]}, draft: {ne: true}
+                category: {eq: "news"}, subsites: {contains: ["esg"]}, draft: {ne: true}
             }
         ) {
         edges {

--- a/src/pages/projects/esg/News.vue
+++ b/src/pages/projects/esg/News.vue
@@ -1,9 +1,14 @@
 <template>
     <EsgLayout>
-        <div v-html="$page.main.content" class="mb-4"></div>
+        <div v-if="!$route.query.tag" v-html="$page.main.content" class="mb-4"></div>
+        <div v-else>
+            <h1>{{ title }}</h1>
+            {{ description }}
+        </div>
+
         <table class="table table-striped">
             <tbody>
-                <ArticleTable v-for="edge in $page.articles.edges" :key="edge.node.id" :article="edge.node" />
+                <ArticleTable v-for="edge in articles" :key="edge.node.id" :article="edge.node" />
             </tbody>
         </table>
     </EsgLayout>
@@ -18,13 +23,62 @@ export default {
         EsgLayout,
         ArticleTable,
     },
+    computed: {
+        title() {
+            const tag = this.$route.query.tag;
+            const prefix = "News about ";
+
+            switch (tag) {
+                case "esg-wp1":
+                    return prefix + this.$page.datasetWorkPackages.wp1.title;
+                case "esg-wp2":
+                    return prefix + this.$page.datasetWorkPackages.wp2.title;
+                case "esg-wp3":
+                    return prefix + this.$page.datasetWorkPackages.wp3.title;
+                case "esg-wp4":
+                    return prefix + this.$page.datasetWorkPackages.wp4.title;
+                case "esg-wp5":
+                    return prefix + this.$page.datasetWorkPackages.wp5.title;
+                default:
+                    return this.$page.main.title;
+            }
+        },
+        description() {
+            const tag = this.$route.query.tag;
+
+            switch (tag) {
+                case "esg-wp1":
+                    return this.$page.datasetWorkPackages.wp1.content;
+                case "esg-wp2":
+                    return this.$page.datasetWorkPackages.wp2.content;
+                case "esg-wp3":
+                    return this.$page.datasetWorkPackages.wp3.content;
+                case "esg-wp4":
+                    return this.$page.datasetWorkPackages.wp4.content;
+                case "esg-wp5":
+                    return this.$page.datasetWorkPackages.wp5.content;
+                default:
+                    return this.$page.main.description;
+            }
+        },
+        articles() {
+            const tag = this.$route.query.tag;
+            const articles = this.$page.articles.edges;
+
+            if (!tag) {
+                return articles;
+            } else {
+                return articles.filter((article) => article.node.tags.includes(tag));
+            }
+        },
+    },
     metaInfo() {
         return {
-            title: this.$page.main.title,
+            title: this.title || this.$page.main.title,
             meta: [
                 {
                     name: "description",
-                    content: this.$page.main.description,
+                    content: this.description || this.$page.main.description,
                 },
             ],
         };
@@ -40,6 +94,29 @@ query {
         content
     }
 
+    datasetWorkPackages: dataset(path: "/dataset:/projects/esg/work_packages/") {
+        wp1 {
+            title,
+            content
+        },
+        wp2 {
+            title,
+            content
+        },
+        wp3 {
+            title,
+            content
+        },
+        wp4 {
+            title,
+            content
+        },
+        wp5 {
+            title,
+            content
+        },
+    }
+
     articles: allParentArticle(
             sortBy: "date", order: DESC, filter: {
                 category: {eq: "news"}, subsites: {contains: ["esg"]}, draft: {ne: true}
@@ -53,6 +130,7 @@ query {
                 external_url
                 date (format: "D MMMM YYYY")
                 path
+                tags
             }
         }
     }


### PR DESCRIPTION
Adds the `esg` subsite tag for articles and switches the ESG pages to use it. Also adds tag filtering for the ESG News page.