### PR TITLE
Skip compression of webp in image compression github action

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -12,7 +12,6 @@ on:
       - "**.jpg"
       - "**.jpeg"
       - "**.png"
-      - "**.webp"
   push:
     branches:
       - master
@@ -20,7 +19,6 @@ on:
       - "**.jpg"
       - "**.jpeg"
       - "**.png"
-      - "**.webp"
   workflow_dispatch:
   schedule:
     - cron: "00 23 * * 0"


### PR DESCRIPTION
We will assume webp contributors will do this on their own -- calibre otherwise will sometimes repeatedly recompress the same webp.

xref #1761 