### PR TITLE
Fix openssl issue for webpack4 and node18

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,14 +29,34 @@
     "subsites": {
         "shorthands": {
             "all": [
-                "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it", "au", "eu", "us", "global"
+                "freiburg",
+                "pasteur",
+                "belgium",
+                "ifb",
+                "genouest",
+                "erasmusmc",
+                "elixir-it",
+                "au",
+                "eu",
+                "us",
+                "global"
             ],
-            "all-eu": [
-                "freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it", "eu"
-            ]
+            "all-eu": ["freiburg", "pasteur", "belgium", "ifb", "genouest", "erasmusmc", "elixir-it", "eu"]
         },
         "default": "global",
-        "navbar": ["global", "us", "eu", "au", "freiburg", "erasmusmc", "belgium", "pasteur", "genouest", "elixir-it", "ifb"],
+        "navbar": [
+            "global",
+            "us",
+            "eu",
+            "au",
+            "freiburg",
+            "erasmusmc",
+            "belgium",
+            "pasteur",
+            "genouest",
+            "elixir-it",
+            "ifb"
+        ],
         "all": {
             "global": {
                 "name": "Global",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/galaxyproject/galaxy-hub.git"
   },
   "scripts": {
-    "build": "env NODE_OPTIONS=--openssl-legacy-provider src/build/run.mjs build",
+    "build": "src/build/run.mjs build",
     "links:internal": "src/build/check-links.mjs",
     "serve": "http-server ./dist/",
-    "develop": "env NODE_OPTIONS=--openssl-legacy-provider src/build/run.mjs develop",
+    "develop": "src/build/run.mjs develop",
     "preprocess": "src/build/preprocess.mjs preprocess",
     "format": "prettier --write '*.js' 'cypress/**/*.js' 'src/**/{*.js,*.mjs,*.scss,*.vue}' '!src/.temp/**'",
     "format:check": "prettier --check '*.js' 'cypress/**/*.js' 'src/**/{*.js,*.mjs,*.scss,*.vue}' '!src/.temp/**'",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/galaxyproject/galaxy-hub.git"
   },
   "scripts": {
-    "build": "src/build/run.mjs build",
+    "build": "env NODE_OPTIONS=--openssl-legacy-provider src/build/run.mjs build",
     "links:internal": "src/build/check-links.mjs",
     "serve": "http-server ./dist/",
-    "develop": "src/build/run.mjs develop",
+    "develop": "env NODE_OPTIONS=--openssl-legacy-provider src/build/run.mjs develop",
     "preprocess": "src/build/preprocess.mjs preprocess",
     "format": "prettier --write '*.js' 'cypress/**/*.js' 'src/**/{*.js,*.mjs,*.scss,*.vue}' '!src/.temp/**'",
     "format:check": "prettier --check '*.js' 'cypress/**/*.js' 'src/**/{*.js,*.mjs,*.scss,*.vue}' '!src/.temp/**'",

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -70,8 +70,8 @@ function main(rawArgv) {
     // Gridsome still uses webpack4, which on node 17+ requires the legacy
     // openssl provider flag.
     const spawnArgs = {
-        stdio: "inherit"
-    }
+        stdio: "inherit",
+    };
     if (process.versions.node.split(".")[0] > "16") {
         spawnArgs.env = { ...process.env, NODE_OPTIONS: "--openssl-legacy-provider" };
     }


### PR DESCRIPTION
Webpack has stated they won't be fixing this in webpack4x, which we are stuck with w/ gridsome for now.  This workaround workaround works for me and allows building/serving/developing with node v18.

Edit: I need to look at what node version ubuntu-latest is using here and why it's yelling about that option being used, I haven't seen this in the Galaxy context before.  Might just be able to update base image and move on, but I'll follow up on this later (after the Galaxy freeze likely) -- no rush on the PR.