### PR TITLE
Add the option to hide the metadata display on events pages when desired

### DIFF
--- a/content/0examples/non-vue/index.md
+++ b/content/0examples/non-vue/index.md
@@ -2,6 +2,7 @@
 title: Example Markdown page (without Vue components)
 tease: A tease
 hide_tease: true
+hide_metadata: false
 pretitle: Some content to show above the title.
 # Normally you wouldn't set the category manually. Instead, it's set based on where this file is
 # placed in the content directory. Since this isn't in the right place, we set it here manually.

--- a/content/events/gcc2023/index.md
+++ b/content/events/gcc2023/index.md
@@ -2,8 +2,10 @@
 title: "2023 Galaxy Community Conference (GCC2023)"
 skip_title_render: true
 autotoc: false
+hide_metadata: true
 components: true
 subsites: [all]
+date: 2021-09-01
 ---
 
 <slot name="/events/gcc2023/header" />

--- a/content/events/gcc2023/index.md
+++ b/content/events/gcc2023/index.md
@@ -5,7 +5,6 @@ autotoc: false
 hide_metadata: true
 components: true
 subsites: [all]
-date: 2021-09-01
 ---
 
 <slot name="/events/gcc2023/header" />

--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -10,34 +10,36 @@
         <h1 class="title float-left" v-if="!article.skip_title_render">{{ article.title }}</h1>
         <div class="clearfix"></div>
         <p class="subtitle" v-if="article.tease && !article.hide_tease">{{ article.tease }}</p>
-        <ul class="metadata list-unstyled" v-if="article.category === 'events'">
-            <li v-if="article.date"><span class="metakey">Date:</span> {{ dateSpan }}</li>
-            <li v-if="article.location && article.location.name">
-                <span class="metakey">Location: </span>
-                <a v-if="article.location.url" :href="article.location.url">{{ article.location.name }}</a>
-                <template v-else>{{ article.location.name }}</template>
-            </li>
-            <li v-if="hasContacts">
-                <span class="metakey">Contact: </span>
-                <Contacts :contact="article.contact" :contacts="article.contacts" />
-            </li>
-            <li v-if="article.links.length > 0">
-                <span class="metakey">Links: </span>
-                <template v-for="link in article.links">
-                    <a :href="link.url" :key="link.url">{{ link.text }}</a
-                    >.
-                </template>
-            </li>
-        </ul>
-        <section class="metadata freetext" v-else>
-            <p class="contact" v-if="hasContacts">
-                Contact: <Contacts :contact="article.contact" :contacts="article.contacts" />
-            </p>
-            <p class="authors" v-if="article.authors">By {{ article.authors }}</p>
-            <p class="date" v-if="article.date">
-                {{ articleDateStr }}
-            </p>
-        </section>
+        <template v-if="!article.hide_metadata === true">
+            <ul class="metadata list-unstyled" v-if="article.category === 'events'">
+                <li v-if="article.date"><span class="metakey">Date:</span> {{ dateSpan }}</li>
+                <li v-if="article.location && article.location.name">
+                    <span class="metakey">Location: </span>
+                    <a v-if="article.location.url" :href="article.location.url">{{ article.location.name }}</a>
+                    <template v-else>{{ article.location.name }}</template>
+                </li>
+                <li v-if="hasContacts">
+                    <span class="metakey">Contact: </span>
+                    <Contacts :contact="article.contact" :contacts="article.contacts" />
+                </li>
+                <li v-if="article.links.length > 0">
+                    <span class="metakey">Links: </span>
+                    <template v-for="link in article.links">
+                        <a :href="link.url" :key="link.url">{{ link.text }}</a
+                        >.
+                    </template>
+                </li>
+            </ul>
+            <section class="metadata freetext" v-else>
+                <p class="contact" v-if="hasContacts">
+                    Contact: <Contacts :contact="article.contact" :contacts="article.contacts" />
+                </p>
+                <p class="authors" v-if="article.authors">By {{ article.authors }}</p>
+                <p class="date" v-if="article.date">
+                    {{ articleDateStr }}
+                </p>
+            </section>
+        </template>
         <p class="outlink" v-if="article.external_url">See <a :href="article.external_url">(external) url</a></p>
         <p class="blogref" v-if="article.source_blog && article.source_blog_url">
             From <a :href="article.source_blog_url">{{ article.source_blog }}</a>

--- a/src/templates/Article.vue
+++ b/src/templates/Article.vue
@@ -13,6 +13,7 @@ query Article($path: String!) {
         title
         tease
         hide_tease
+        hide_metadata
         pretitle
         subsites
         main_subsite

--- a/src/templates/VueArticle.vue
+++ b/src/templates/VueArticle.vue
@@ -27,6 +27,7 @@ query VueArticle($path: String!) {
         title
         tease
         hide_tease
+        hide_metadata
         pretitle
         subsites
         main_subsite


### PR DESCRIPTION
Currently only used in the gcc2023 page; this new `hide_metadata` option for articles does that, deferring to the page author to convey whatever information they need.