### PR TITLE
* added news item

### DIFF
--- a/content/news/2023-02-20-tlaas-training-infrastructure-as-a-service/index.md
+++ b/content/news/2023-02-20-tlaas-training-infrastructure-as-a-service/index.md
@@ -1,0 +1,15 @@
+---
+title: 'Success Story: “TIaaS: Training Infrastructure as a Service”'
+tease: 'TIaaS allows trainees’ jobs to be run preferentially and avoids long execution times, depending on the server load. By providing access to this service, the Galaxy Training Network ensured that TIaaS would be freely available to anyone and facilitated access to an extensive catalogue of FAIR training materials.'
+date: '2023-02-20'
+tags: [TIaaS]
+supporters:
+- eosc
+external_url: "https://www.eosc-life.eu/news/success-story-tlaas-training-infrastructure-as-a-service"
+subsites: [all-eu, all]
+main_subsite: eu
+---
+
+The “TIaaS: Training Infrastructure as a Service” initiative was awarded funding by EOSC-Life through the Second Training Open Call.
+
+TIaaS allows trainees’ jobs to be run preferentially and avoids long execution times, depending on the server load. By providing access to this service, the Galaxy Training Network ensured that TIaaS would be freely available to anyone and facilitated access to an extensive catalogue of FAIR training materials.


### PR DESCRIPTION
https://www.eosc-life.eu/news/success-story-tlaas-training-infrastructure-as-a-service/ -> they write Tlaas (with L)but should be TIaaS (with I) 