### PR TITLE
Add GCC2023 banner to EU landing page

### DIFF
--- a/content/bare/eu/usegalaxy/main/index.md
+++ b/content/bare/eu/usegalaxy/main/index.md
@@ -6,6 +6,13 @@ title: Galaxy Europe
 
 <slot name="/bare/eu/usegalaxy/main/jumbotron" />
 
+<a href="/events/gcc2023/" target="_blank">
+    <img src="/images/events/gcc2023/au-gcc-banner.png" alt="GCC2023 banner" />
+</a>
+
+<br/>
+<br/>
+
 "Anyone, anywhere in the world should have free, unhindered access to not just my research, but to the research of every great and enquiring mind across the spectrum of human understanding." – Prof. Stephen Hawking
 
 <iframe title="Recent Galaxy Europe news" height="450"


### PR DESCRIPTION
Added banner with link opening new tab:

![image](https://user-images.githubusercontent.com/42562517/225189109-0e51e90c-5ce8-4758-b071-02fdc2116e92.png)
