### PR TITLE
Fix link in new history search news item

### DIFF
--- a/content/news/2023-03-15-new-history-search/index.md
+++ b/content/news/2023-03-15-new-history-search/index.md
@@ -9,7 +9,7 @@ authors_structured:
 subsites: [global, all, esg]
 ---
 
-In the previous [`release_22.05`](http://localhost:8080/news/2022-08-galaxy-release-22-05/) (_August 2022_), Galaxy's History Panel was updated to a fresh and enhanced interface that users have been getting used to since. For the latest `release_23.0`, Galaxy developers have worked hard on further perfecting and enhancing the user experience of the history:
+In the previous [`release_22.05`](https://galaxyproject.org/news/2022-08-galaxy-release-22-05/) (_August 2022_), Galaxy's History Panel was updated to a fresh and enhanced interface that users have been getting used to since. For the latest `release_23.0`, Galaxy developers have worked hard on further perfecting and enhancing the user experience of the history:
 
 | `22.05` (_August 2022_) | `23.0` (March 2023) |
 | ----------------------- | ------------------- |
@@ -59,7 +59,7 @@ The Related items filter was added to the History filtering options to help user
 
 ### Older Implementation
 
-In the previous [`release_22.05`](http://localhost:8080/news/2022-08-galaxy-release-22-05/) (_August 2022_), this feature was added not as a filter but just as a visible indicator, where **only the Inputs** of an item would get the `arrow-up` icon next to them, with the current item being indicated by a checkmark:
+In the previous [`release_22.05`](https://galaxyproject.org/news/2022-08-galaxy-release-22-05/) (_August 2022_), this feature was added not as a filter but just as a visible indicator, where **only the Inputs** of an item would get the `arrow-up` icon next to them, with the current item being indicated by a checkmark:
 
 ![Screenshot of a history from release_22.05, the top most dataset is expanded and a "sitemap" icon is clicked which is showing inputs for that dataset. Each of those inputs has a small upward arrow next to the dataset number. The 'end' dataset of those inputs has a checkmark icon next to the dataset number. The history is titled the beta history and there are a lot of new buttons at the top.](https://docs.galaxyproject.org/en/master/_images/22.05-history.png)
 


### PR DESCRIPTION
I mistakenly linked `http://localhost:8080/news/2022-08-galaxy-release-22-05/` instead of `http://galaxyproject/news/2022-08-galaxy-release-22-05/`