### PR TITLE
Add BWCloud maintenance notice to EU

### DIFF
--- a/content/bare/eu/usegalaxy/notices.md
+++ b/content/bare/eu/usegalaxy/notices.md
@@ -1,6 +1,12 @@
+<div class="alert" style="background: #FFD500;">
+
+The Freiburg Galaxy's compute infrastructure is currently under maintenance. The maintenance is expected to last until tomorrow, 31-03-2023. We apologize for any inconvenience this may cause.
+
+</div>
+
 <!--div class="alert" style="background: #FFD500;">
 
-The Freiburg Galaxy team will be striking on 03.03.2023. 
+The Freiburg Galaxy team will be striking on 03.03.2023.
 For more information, please see our [blog post](https://galaxyproject.org/news/2023-02-27-climate-strike/).
 
 </div-->


### PR DESCRIPTION
BWCloud is currently under maintenance and will last until tomorrow.

BWCloud notice: https://www.bw-cloud.org/de/news/2023/12-03-ankuendigung_wartung_bwcloud