### PR TITLE
Remove EU maintenance notice

### DIFF
--- a/content/bare/eu/usegalaxy/notices.md
+++ b/content/bare/eu/usegalaxy/notices.md
@@ -1,9 +1,3 @@
-<div class="alert" style="background: #FFD500;">
-
-The Freiburg Galaxy's compute infrastructure is currently under maintenance. The maintenance is expected to last until tomorrow, 31-03-2023. We apologize for any inconvenience this may cause.
-
-</div>
-
 <!--div class="alert" style="background: #FFD500;">
 
 The Freiburg Galaxy team will be striking on 03.03.2023.


### PR DESCRIPTION
Maintenance is over and the services are back online.