### PR TITLE
Automatically publish posts from GTN

### DIFF
--- a/.github/workflows/gtn-news.yml
+++ b/.github/workflows/gtn-news.yml
@@ -39,12 +39,14 @@ jobs:
               feed_blurb = entry["summary"]
               feed_published = entry["published"].split("T")[0]
               feed_name = feed_link.split("/")[-1].replace(".html", "")
+              feed_author = entry["author"]
               posts[f"{feed_published}-{feed_name}"] = {
                   "title": feed_title,
                   "link": feed_link,
                   "blurb": feed_blurb,
                   "published": feed_published,
                   "name": feed_name,
+                  "author": feed_author,
               }
               feed_published_dt = datetime.fromisoformat(entry["published"])
               oldest = feed_published_dt if feed_published_dt < oldest else oldest
@@ -142,6 +144,7 @@ jobs:
               date: "{post['published']}"
               tags: [training, gtn-news]
               title: "{post['title']}"
+              authors: "{post['author']}"
               external: '{post["link"]}'
               ---
 

--- a/.github/workflows/gtn-news.yml
+++ b/.github/workflows/gtn-news.yml
@@ -138,14 +138,10 @@ jobs:
           """)["${{ matrix.name }}"]
           post = textwrap.dedent(f"""
               ---
-              site: [pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest]
+              site: [all]
               date: "{post['published']}"
               tags: [training, gtn-news]
               title: "{post['title']}"
-              supporters:
-              - denbi
-              - elixir
-              - gallantries
               external: '{post["link"]}'
               ---
 

--- a/.github/workflows/gtn-news.yml
+++ b/.github/workflows/gtn-news.yml
@@ -1,0 +1,166 @@
+---
+# Pull news from the Galaxy Training Network's RSS feed and add them as
+# Galaxy Hub posts.
+name: Galaxy Training Network news
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 * * * *
+
+jobs:
+  collect:
+    name: Collect news from the Galaxy Training Network
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install feedparser.
+        run: pip install feedparser~=6.0
+
+      - name: Parse GTN RSS feed.
+        id: parse
+        shell: python -u {0}
+        run: |
+          import json
+          import os
+          from datetime import datetime, timedelta, timezone
+
+          import feedparser
+
+          feedparser.sanitizer._HTMLSanitizer.acceptable_elements.remove("a")
+          feedparser.sanitizer._HTMLSanitizer.acceptable_elements.remove("img")
+
+          feed = feedparser.parse("https://training.galaxyproject.org/training-material/feed.xml")
+
+          posts = {}
+          oldest = datetime.now().astimezone()
+          for entry in feed.entries:
+              feed_title = f"[GTN news] {entry['title']}"
+              feed_link = entry["link"]
+              feed_blurb = entry["summary"]
+              feed_published = entry["published"].split("T")[0]
+              feed_name = feed_link.split("/")[-1].replace(".html", "")
+              posts[f"{feed_published}-{feed_name}"] = {
+                  "title": feed_title,
+                  "link": feed_link,
+                  "blurb": feed_blurb,
+                  "published": feed_published,
+                  "name": feed_name,
+              }
+              feed_published_dt = datetime.fromisoformat(entry["published"])
+              oldest = feed_published_dt if feed_published_dt < oldest else oldest
+          oldest = (oldest - timedelta(days=1)).astimezone(timezone.utc).date()
+
+          with open(os.environ["GITHUB_OUTPUT"], 'w') as file:
+              print("posts=%s" % json.dumps(posts), file=file)
+              print("date=%s" % oldest, file=file)
+
+      # The next two steps prevent the `pull_requests` job from running when the target pull request may
+      # already exist. They are not strictly necessary because the GitHub Action
+      # `peter-evans/create-pull-request@v5` does not create duplicate PRs by default
+      # (see https://github.com/peter-evans/create-pull-request#action-behaviour)
+      - name: Get files touched by existing GitHub PRs that are newer than the oldest article in the feed.
+        id: files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files="$(gh pr list --repo https://github.com/${{ github.repository }} -s all -S "created:>=${{ steps.parse.outputs.date }}" --json files)"
+          echo files="$files" > $GITHUB_OUTPUT
+      - name: Filter out GTN news for which a PR may already exist.
+        id: filter
+        shell: python -u {0}
+        run: |
+          import json
+          import os
+
+          files=json.loads("""
+              ${{ steps.files.outputs.files }}
+          """)
+          files={file["path"] for item in files for file in item["files"]}
+
+          posts=json.loads("""
+              ${{ steps.parse.outputs.posts }}
+          """)
+
+          existing = {
+              name
+              for name in posts
+              if any(name in file for file in files)
+          }
+          for name in existing:
+              del posts[name]
+
+          with open(os.environ["GITHUB_OUTPUT"], 'w') as file:
+              print("posts=%s" % json.dumps(posts), file=file)
+
+      - name: Prepare matrix for `pull_requests` job.
+        id: matrix
+        shell: python -u {0}
+        run: |
+          import json
+          import os
+
+          posts=json.loads("""
+              ${{ steps.filter.outputs.posts }}
+          """)
+
+          with open(os.environ["GITHUB_OUTPUT"], 'w') as file:
+              print(
+                  "matrix=%s" % f"{json.dumps({'name': list(posts)})}",
+                  file=file
+              )
+    outputs:
+      posts: ${{ steps.filter.outputs.posts }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  pull_requests:
+    name: Create pull request
+    runs-on: ubuntu-latest
+    needs: collect
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.collect.outputs.matrix)}}
+    steps:
+      - name: Check out the Galaxy Hub.
+        uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Create a Galaxy Hub post.
+        id: post
+        shell: python -u {0}
+        run: |
+          import json
+          import os
+          import textwrap
+
+          post = json.loads("""
+              ${{ needs.collect.outputs.posts }}
+          """)["${{ matrix.name }}"]
+          post = textwrap.dedent(f"""
+              ---
+              site: [pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest]
+              date: "{post['published']}"
+              tags: [training, gtn-news]
+              title: "{post['title']}"
+              supporters:
+              - denbi
+              - elixir
+              - gallantries
+              external: '{post["link"]}'
+              ---
+
+              {post["blurb"]}
+
+          """)[1:]
+
+          os.makedirs(f"./content/news/${{ matrix.name }}", exist_ok=True)
+          with open(f"./content/news/${{ matrix.name }}/index.md", "w") as file:
+              file.write(post)
+
+      - name: Create pull request.
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: Publish post ${{ matrix.name }} from GTN
+          branch: ${{ matrix.name }}
+          commit-message: Post ${{ matrix.name }} from GTN
+          body: Publish post ${{ matrix.name }} from GTN.

--- a/.github/workflows/gtn-news.yml
+++ b/.github/workflows/gtn-news.yml
@@ -3,6 +3,11 @@
 # Galaxy Hub posts.
 name: Galaxy Training Network news
 
+env:
+  base: master
+  branch: gtn-news
+  github_api_version: "2022-11-28"
+
 on:
   workflow_dispatch:
   schedule:
@@ -52,87 +57,66 @@ jobs:
               oldest = feed_published_dt if feed_published_dt < oldest else oldest
           oldest = (oldest - timedelta(days=1)).astimezone(timezone.utc).date()
 
-          with open(os.environ["GITHUB_OUTPUT"], 'w') as file:
-              print("posts=%s" % json.dumps(posts), file=file)
-              print("date=%s" % oldest, file=file)
-
-      # The next two steps prevent the `pull_requests` job from running when the target pull request may
-      # already exist. They are not strictly necessary because the GitHub Action
-      # `peter-evans/create-pull-request@v5` does not create duplicate PRs by default
-      # (see https://github.com/peter-evans/create-pull-request#action-behaviour)
-      - name: Get files touched by existing GitHub PRs that are newer than the oldest article in the feed.
-        id: files
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          files="$(gh pr list --repo https://github.com/${{ github.repository }} -s all -S "created:>=${{ steps.parse.outputs.date }}" --json files)"
-          echo files="$files" > $GITHUB_OUTPUT
-      - name: Filter out GTN news for which a PR may already exist.
-        id: filter
-        shell: python -u {0}
-        run: |
-          import json
-          import os
-
-          files=json.loads("""
-              ${{ steps.files.outputs.files }}
-          """)
-          files={file["path"] for item in files for file in item["files"]}
-
-          posts=json.loads("""
-              ${{ steps.parse.outputs.posts }}
-          """)
-
-          existing = {
-              name
-              for name in posts
-              if any(name in file for file in files)
+          # reverse ordering (sort by ascending date)
+          posts = {
+              post: posts[post]
+              for post in tuple(posts)[::-1]
           }
-          for name in existing:
-              del posts[name]
 
           with open(os.environ["GITHUB_OUTPUT"], 'w') as file:
               print("posts=%s" % json.dumps(posts), file=file)
-
-      - name: Prepare matrix for `pull_requests` job.
-        id: matrix
-        shell: python -u {0}
-        run: |
-          import json
-          import os
-
-          posts=json.loads("""
-              ${{ steps.filter.outputs.posts }}
-          """)
-
-          with open(os.environ["GITHUB_OUTPUT"], 'w') as file:
               print(
                   "matrix=%s" % f"{json.dumps({'name': list(posts)})}",
                   file=file
               )
-    outputs:
-      posts: ${{ steps.filter.outputs.posts }}
-      matrix: ${{ steps.matrix.outputs.matrix }}
 
-  pull_requests:
-    name: Create pull request
+      # Not strictly necessary but produces a workflow with less jobs.
+      - name: Filter out already published posts.
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          readarray -t all_posts <<< $(jq -r 'keys_unsorted | .[]' <<< '${{ steps.parse.outputs.posts }}')
+          posts=()
+          set +e
+          for post in "${all_posts[@]}"; do
+              # check in the base branch
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: ${{ env.github_api_version }}" \
+                /repos/${{ github.repository }}/contents/content/news/"$post"/index.md?ref=${{ env.base }}
+              test $? -ne 0 || continue
+              # check in the target branch
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: ${{ env.github_api_version }}" \
+                /repos/${{ github.repository }}/contents/content/news/"$post"/index.md?ref=${{ env.branch }}
+              test $? -ne 0 || continue
+              posts+=("$post")
+          done
+          set -e
+
+          json=$(printf '%s\n' "${posts[@]}" | jq -R . | jq -s --compact-output .)
+          matrix=$(jq -n --compact-output --argjson v "$json" '{"name": $v}')
+          echo matrix="$matrix" >> $GITHUB_OUTPUT
+    outputs:
+      posts: ${{ steps.parse.outputs.posts }}
+      matrix: ${{ steps.filter.outputs.matrix }}
+
+  commit:
+    name: Create commits
     runs-on: ubuntu-latest
     needs: collect
+    if: ${{ needs.collect.outputs.matrix != '{"name":[""]}' }}
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix: ${{fromJson(needs.collect.outputs.matrix)}}
     steps:
-      - name: Check out the Galaxy Hub.
-        uses: actions/checkout@v3
-        with:
-          ref: master
-
-      - name: Create a Galaxy Hub post.
-        id: post
+      - name: Create the Galaxy Hub post.
         shell: python -u {0}
         run: |
           import json
-          import os
           import textwrap
 
           post = json.loads("""
@@ -152,14 +136,85 @@ jobs:
 
           """)[1:]
 
-          os.makedirs(f"./content/news/${{ matrix.name }}", exist_ok=True)
-          with open(f"./content/news/${{ matrix.name }}/index.md", "w") as file:
+          with open("index.md", "w") as file:
               file.write(post)
 
-      - name: Create pull request.
-        uses: peter-evans/create-pull-request@v5
-        with:
-          title: Publish post ${{ matrix.name }} from GTN
-          branch: ${{ matrix.name }}
-          commit-message: Post ${{ matrix.name }} from GTN
-          body: Publish post ${{ matrix.name }} from GTN.
+      - name: Create the PR branch.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Check if the PR branch exists.
+          set +e
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: ${{ env.github_api_version }}" \
+            /repos/${{ github.repository }}/git/ref/heads/${{ env.branch }}
+          test $? -ne 0 || exit 0
+          set -e
+
+          # Get commit sha of the tip of the base branch.
+          sha=$(\
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: ${{ env.github_api_version }}" \
+              /repos/${{ github.repository }}/git/ref/heads/${{ env.base }} \
+            | jq -r '.object.sha' \
+          )
+
+          # Create the PR branch.
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "X-GitHub-Api-Version: ${{ env.github_api_version }}" \
+            /repos/${{ github.repository }}/git/refs \
+            -f ref='refs/heads/${{ env.branch }}' \
+            -f sha=$sha
+
+      - name: Commit the Galaxy Hub post.
+        run: |
+          base64=$(base64 --wrap=0 < index.md)
+          commit='{
+            "message": "Post ${{ matrix.name }} from GTN",
+            "author": {
+              "name": "GitHub",
+              "email": "noreply@github.com"
+            },
+            "branch": "${{ env.branch }}",
+            "content": "'$base64'"
+          }'
+          echo $commit > data.json
+
+          curl -L \
+            -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: ${{ env.github_api_version }}" \
+            https://api.github.com/repos/${{ github.repository }}/contents/content/news/${{ matrix.name }}/index.md \
+            -d @data.json
+
+  pull_request:
+    name: Create pull request
+    runs-on: ubuntu-latest
+    needs: commit
+    if: always()
+    steps:
+      - name: Create a pull request.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Check if an open pull request already exists.
+          exists=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --head ${{ env.branch }} \
+            --state open \
+            --limit 1 \
+            --json number \
+          | jq '.[].number' | wc -l)
+          test $exists -ne 1 || exit 0
+
+          gh pr create \
+            --repo ${{ github.repository }} \
+            --base "${{ env.base }}" \
+            --head "${{ env.branch }}" \
+            --title "Publish latest news from the Galaxy Training Network" \
+            --body  "Publish the latest news from the Galaxy Training Network."


### PR DESCRIPTION
GitHub Actions workflow that automatically creates PRs to publish Galaxy Training Network news as external links.

Closes #1417. Folow-up of #2065.

An example PR created by this workflow is available [here](https://github.com/kysrpex/galaxy-hub/pull/21). An example workflow run is available [here](https://github.com/kysrpex/galaxy-hub/actions/runs/5477340935).

This PR hopefully addresses all the feedback from #2065, namely:
- Post template (@bgruening)
- Include authors (@hexylena)
- Batch all posts in one PR (@hexylena)

In addition, the whole approach has been reworked. The workflow uses now just feedparser and the GitHub REST API (through GitHub CLI and curl). Hopefully it is significantly faster (I cannot compare since I deleted the repo) as it avoids checking out the code. 