### PR TITLE
Prevent GTN News workflow from failing when there are no items to publish

### DIFF
--- a/.github/workflows/gtn-news.yml
+++ b/.github/workflows/gtn-news.yml
@@ -212,9 +212,11 @@ jobs:
           | jq '.[].number' | wc -l)
           test $exists -ne 1 || exit 0
 
+          set +e
           gh pr create \
             --repo ${{ github.repository }} \
             --base "${{ env.base }}" \
             --head "${{ env.branch }}" \
             --title "Publish latest news from the Galaxy Training Network" \
             --body  "Publish the latest news from the Galaxy Training Network."
+          true


### PR DESCRIPTION
The pull request creation is intended to fail when there are no changes to be merged, but it is better if it fails silently :)

```shell
pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between master and gtn-news, Head ref must be a branch (createPullRequest)
```