### PR TITLE
GTN News workflow: fix broken template

### DIFF
--- a/.github/workflows/gtn-news.yml
+++ b/.github/workflows/gtn-news.yml
@@ -124,12 +124,13 @@ jobs:
           """)["${{ matrix.name }}"]
           post = textwrap.dedent(f"""
               ---
-              site: [all]
+              subsites: [all]
+              main_subsite: global
               date: "{post['published']}"
               tags: [training, gtn-news]
               title: "{post['title']}"
               authors: "{post['author']}"
-              external: '{post["link"]}'
+              external_url: '{post["link"]}'
               ---
 
               {post["blurb"]}


### PR DESCRIPTION
The template of the GTN News workflow is wrong (news do not render). This PR fixes it.

Related: #2072.