### PR TITLE
Add github author and increase image sizes in carbon emissions post

### DIFF
--- a/content/news/2023-07-11-carbon-emissions-reporting/index.md
+++ b/content/news/2023-07-11-carbon-emissions-reporting/index.md
@@ -3,6 +3,7 @@ title: "Carbon Emissions Reporting in Galaxy"
 tease: "Dynamic carbon emissions reporting for jobs in Galaxy"
 hide_tease: false
 authors: "Rendani Gangazhe"
+author_github: Renni771
 date: "2023-07-11"
 tags: ["UI/UX", highlight"]
 subsites: [global, all]
@@ -31,7 +32,7 @@ detailing the estimated CO2 output and energy usage of that job. Additionally, w
 or the amount of smartphones you could have charged given your job's energy usage. This helps make the numbers more relatable. Here's an example carbon emissions report:
 
 <div style="display: flex; justify-content: center; align-items: center;">
-    <img src="./ui.png" alt="An image of carbon emissions reporting UI" width="60%" />
+    <img src="./ui.png" alt="An image of carbon emissions reporting UI" width="80%" />
 </div>
 
 ## Implementation details
@@ -105,7 +106,7 @@ As mentioned, we assume that jobs are run in the same geographical location as t
 configured with a location looks as follows:
 
 <div style="display: flex; justify-content: center; align-items: center;">
-    <img src="./set-location.png" alt="" width="50%"/>
+    <img src="./set-location.png" alt="" width="80%"/>
 </div>
 
 ## Next steps


### PR DESCRIPTION
This PR adds github author information and increases the sizes of images in the carbon emissions reporting post.

An issue tracking the progress of the feature can be found in the Galaxy repo https://github.com/galaxyproject/galaxy/issues/15046.