### PR TITLE
Galaxy 23.1 upgrade banner

### DIFF
--- a/content/bare/eu/usegalaxy/notices.md
+++ b/content/bare/eu/usegalaxy/notices.md
@@ -5,13 +5,25 @@ For more information, please see our [blog post](https://galaxyproject.org/news/
 
 </div-->
 
-<div class="alert" style="background: #00d084;">
+<div class="alert" style="background: #ff8f2b;">
+
+#### **Galaxy 23.1 upgrade**
+
+[UseGalaxy.eu](https://usegalaxy.eu/) is undergoing an upgrade to Galaxy 23.1
+on Sunday, August 20th at night ([CEST](https://www.timeanddate.com/time/zones/cest)).
+
+Although it is not expected, downtime cannot be ruled out. Should it be the 
+case, we expect Galaxy to be back online on Monday, August 21st evening.
+
+</div>
+
+<!--div class="alert" style="background: #00d084;">
 
 #### **Act, don't criminalize!**
 
 Today, 21st of April 2023, a statement in support of peaceful, but resolved protest against insufficient climate politics got released and has been signed by more than 1000 scientists from German-speaking countries in Europe. Read [why members of the Freiburg, Germany branch of Galaxy Europe endorse this initiative](https://galaxyproject.org/news/2023-04-21-act-dont-criminalize/).
 
-</div>
+</div-->
 
 <div class="alert" style="background: #FFD500;">
 


### PR DESCRIPTION
Add a banner warning of potential disruption due to the upcoming Galaxy 23.1 upgrade on Sunday night (August 20th, CEST).

---

Temporarily replaces the "Handeln statt Kriminalisieren" statement banner.