### PR TITLE
Amend Galaxy EU 15.09.23 climate strike notification

### DIFF
--- a/content/bare/eu/usegalaxy/notices.md
+++ b/content/bare/eu/usegalaxy/notices.md
@@ -1,4 +1,6 @@
-<div class="alert" style="background: #FFD500;">
+<div class="alert" style="background: #68d4ff;">
+
+#### **Global Climate Strike on September 15th 2023**
 
 The Freiburg Galaxy team will be striking on 15.09.2023. The job queue will be paused for a few hours on Friday. This means that you will still be able to visit our website, but new jobs will not start. Running jobs will remain unaffected. For more information, please see our [blog post](https://galaxyproject.org/news/2023-09-11-climate-strike/).
 

--- a/content/news/2023-09-11-climate-strike/index.md
+++ b/content/news/2023-09-11-climate-strike/index.md
@@ -17,6 +17,6 @@ This means that you can still visit our website, but the server will not start n
 We encourage all of you to use that time to join one of the huge number of strikes that will be [taking place worldwide](https://fridaysforfuture.org/september15/) on this day!
 
 <div class="multiple-img">
-    <iframe width="1000" height="600" src="https://globalclimatestrike.net/#map" frameborder="0" allowfullscreen></iframe>
+    <iframe width="1000" height="600" src="https://fridaysforfuture.org/september15/" frameborder="0" allowfullscreen></iframe>
 </div>
 


### PR DESCRIPTION
After looking at the outcome of #2159, I think it is very confusing that two banners have the same color and more importantly, that the strike banner has no title.

In addition, thinking it twice I think it makes better sense to link to the page specific to the action on Friday rather than the main page of Fridays for Future.