### PR TITLE
Drop twitter embed

### DIFF
--- a/content/cards.md
+++ b/content/cards.md
@@ -5,13 +5,12 @@ list:
   title: News
   link: /news/
   icon: fas fa-bullhorn
+  width: 2
 - name: events
   type: dynamic
   title: Events
   link: /events/
   icon: far fa-calendar-alt
-- name: twitter
-  type: static
 - name: videos
   type: static
 - name: blog

--- a/src/lib/client.mjs
+++ b/src/lib/client.mjs
@@ -59,10 +59,6 @@ export function addAltmetricsScript(window) {
     addScript(window, "https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js");
 }
 
-export function addTwitterScript(window) {
-    addScript(window, "https://platform.twitter.com/widgets.js", { async: true, charset: "utf-8" });
-}
-
 export function addFlickrScript(window) {
     addScript(window, "https://embedr.flickr.com/assets/client-code.js", { async: true, charset: "utf-8" });
 }

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -72,7 +72,7 @@ import {
     gatherCards,
     makeCardRows,
 } from "~/lib/pages.mjs";
-import { addTwitterScript, addAltmetricsScript } from "~/lib/client.mjs";
+import { addAltmetricsScript } from "~/lib/client.mjs";
 export default {
     components: {
         HomeTop,
@@ -101,10 +101,6 @@ export default {
         },
     },
     mounted() {
-        // Insert Twitter feed.
-        if (this.cards.twitter) {
-            addTwitterScript(window);
-        }
         // Add altmetrics stats badges to publications.
         if (this.cards.pubs) {
             addAltmetricsScript(window);


### PR DESCRIPTION
Drops (broken) twitter embed, expanding news and shifting events over to keep the grid intact.

![image](https://github.com/galaxyproject/galaxy-hub/assets/155398/32211293-49d2-44c0-96a9-c95209f3509d)
