### PR TITLE
add plausible analytics

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
 
             gtag('config', 'G-KNS7RQJVRZ');
         </script>
+        <script defer data-domain="galaxyproject.org" src="https://plausible.galaxyproject.eu/js/script.js"></script>
        <link href="https://mstdn.science/@galaxyproject" rel="me">
         ${head}
     </head>


### PR DESCRIPTION
It would be helpful for the rest of us to have live access to stats, like we do for the training website, to help us know what resources are getting accessed and if we can optimise them.

It wouldn't have to be public (though I'd strongly argue for it for transparency), but can also be shared with individuals via link.

(If i don't see complaints by the end of the week, I'll merge this.)