### PR TITLE
Updating 'redirect' link for Galaxy connections

### DIFF
--- a/content/tutorials/collections/index.md
+++ b/content/tutorials/collections/index.md
@@ -1,7 +1,7 @@
 ---
 autotoc: true
 title: Processing many samples at once with collections
-redirect: "/learn"
+redirect: "/training-material/topics/galaxy-interface/tutorials/collections/tutorial.html"
 ---
 
 <div class="alert alert-info trim-p" role="alert"><i class="fa fa-exclamation-circle" aria-hidden="true"></i>Note: we assume that the person reading this tutorial


### PR DESCRIPTION
Redirect updated from /learn to link to the "Using dataset collection" tutorial instead.