### PR TITLE
Fix for link to Galaxy servers from Home Page for experienced Galaxy users

### DIFF
--- a/content/us/lead.md
+++ b/content/us/lead.md
@@ -9,7 +9,10 @@
 The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
 
 <div class="row justify-content-center">
-  <a href="/get-started/" class="btn w-75 btn-primary btn-lg">
+  <a href="/use/?utm_source=homepage" class="btn w-25 mr-2 btn-outline-info btn-lg">
+    Use Galaxy
+  </a>
+  <a href="/get-started/?utm_source=homepage" class="btn pr-4 pl-4 btn-primary btn-lg">
     Get Started: First Steps with Galaxy
   </a>
 </div>

--- a/content/us/lead.md
+++ b/content/us/lead.md
@@ -9,7 +9,7 @@
 The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
 
 <div class="row justify-content-center">
-  <a href="/use/?utm_source=homepage" class="btn w-25 mr-2 btn-outline-info btn-lg">
+  <a href="/use/?utm_source=homepage" class="btn w-25 mr-2 btn-info btn-lg">
     Use Galaxy
   </a>
   <a href="/get-started/?utm_source=homepage" class="btn pr-4 pl-4 btn-primary btn-lg">


### PR DESCRIPTION
![mockup_hotfix_Link_to_Servers v2](https://github.com/galaxyproject/galaxy-hub/assets/3672779/afbd33dd-c407-4000-b4d6-e093dd61f679)

_For experienced users, added "Use Galaxy" button that links directly to the list of servers page. Also added very basic source tracking so we know how helpful these buttons are._
