### PR TITLE
Style adjustment for Learn section of home.

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -80,10 +80,6 @@ html {
             background-color: $home-accent-bright;
         }
 
-        .bgGradient {
-            background-image: linear-gradient($home-accent-bright, $home-body-bg 150%);
-        }
-
         .notification {
             padding: 10px;
             margin: 20px 15px 20px 0;

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -55,7 +55,7 @@
             </div>
         </div>
         <div class="container-fluid-real p-0">
-            <div class="container-fluid-real p-0 bgBright bgGradient">
+            <div class="container-fluid-real p-0 bgBright">
                 <div class="container-fluid-real p-0 overflow-hidden">
                     <div class="row area education overflow-hidden">
                         <svg viewBox="1 0 80 40" preserveAspectRatio="none" width="5000" height="100" class="wave top">


### PR DESCRIPTION
Drop gradient in Learn section on homepage -- easier to read the text this way (I doubt the previous version would pass a11y validation) and I think it looks nice and clean.

![image](https://github.com/galaxyproject/galaxy-hub/assets/155398/46f7c6ac-e86f-4f39-915f-415305bef624)
