### PR TITLE
Fix Cypress accessibility test script Year value in order so Year val…

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -3,6 +3,7 @@ const CYPRESS_ACCESSIBILITY_CONFIG = {
     ancestry: true,
     includedImpacts: ["serious", "critical"],
 };
+const GCC_CURRENT = "GCC2022";
 
 describe("Accessibility Testing", () => {
     it("Homepage has no detectable a11y violations on load", () => {
@@ -22,8 +23,8 @@ describe("Accessibility Testing", () => {
         cy.wait(500);
         cy.checkA11y("#app", CYPRESS_ACCESSIBILITY_CONFIG);
     });
-    it("GCC2022 page has no detectable a11y violations on load", () => {
-        cy.visit("/events/gcc2022/").get("#app").injectAxe();
+    it(`${GCC_CURRENT} page has no detectable a11y violations on load`, () => {
+        cy.visit(`/events/${GCC_CURRENT.toLowerCase()}/`).get("#app").injectAxe();
         // Ensure masthead has loaded
         cy.get("#masthead-logo").should("be.visible");
         // Only check for #app; ignores twitter and sidecar.

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -3,7 +3,8 @@ const CYPRESS_ACCESSIBILITY_CONFIG = {
     ancestry: true,
     includedImpacts: ["serious", "critical"],
 };
-const GCC_CURRENT = "GCC2022";
+
+const CURRENT_DATE = new Date();
 
 describe("Accessibility Testing", () => {
     it("Homepage has no detectable a11y violations on load", () => {
@@ -23,8 +24,8 @@ describe("Accessibility Testing", () => {
         cy.wait(500);
         cy.checkA11y("#app", CYPRESS_ACCESSIBILITY_CONFIG);
     });
-    it(`${GCC_CURRENT} page has no detectable a11y violations on load`, () => {
-        cy.visit(`/events/${GCC_CURRENT.toLowerCase()}/`).get("#app").injectAxe();
+    it(`GCC${CURRENT_DATE.getUTCFullYear()} page has no detectable a11y violations on load`, () => {
+        cy.visit(`/events/gcc${CURRENT_DATE.getUTCFullYear()}/`).get("#app").injectAxe();
         // Ensure masthead has loaded
         cy.get("#masthead-logo").should("be.visible");
         // Only check for #app; ignores twitter and sidecar.


### PR DESCRIPTION
Fix Cypress accessibility test script Year value in order so Year value updates automatically because: (1) it's artificially creating Google Analytics traffic (ie. why we have so many hits for gcc2022 here in the year '2024') (2) so the actual most recent Galaxy conference page is checked for accessibility