### PR TITLE
Drop plausible (temporarily?)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@
 
             gtag('config', 'G-KNS7RQJVRZ');
         </script>
-        <script defer data-domain="galaxyproject.org" src="https://plausible.galaxyproject.eu/js/script.js"></script>
+        <!-- <script defer data-domain="galaxyproject.org" src="https://plausible.galaxyproject.eu/js/script.js"></script> -->
        <link href="https://mstdn.science/@galaxyproject" rel="me">
         ${head}
     </head>


### PR DESCRIPTION
It's down and shouldn't be interfering with pageloads but this is, and is why the tests are failing currently.

todo: figure out why that's actually blocking when it shouldn't be, inject into head post-load maybe?