### PR TITLE
Drop Google Analytics from base page; 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,16 +1,6 @@
 <!DOCTYPE html>
 <html ${htmlAttrs}>
     <head>
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-KNS7RQJVRZ"></script>
-        <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-
-            gtag('config', 'G-KNS7RQJVRZ');
-        </script>
-        <!-- <script defer data-domain="galaxyproject.org" src="https://plausible.galaxyproject.eu/js/script.js"></script> -->
        <link href="https://mstdn.science/@galaxyproject" rel="me">
         ${head}
     </head>


### PR DESCRIPTION
We will add back incrementally on only certain pages on gridsome app mount.  This is to avoid the 'welcome' and potentially 'bare' pages that are served in iframes (from usegalay.org, etc) from including analytics code.