### PR TITLE
Fix upcoming events on homepage.

### DIFF
--- a/content/home/research.yml
+++ b/content/home/research.yml
@@ -34,23 +34,6 @@ research3:
   - title: Quality Control
     url: "https://training.galaxyproject.org/training-material/topics/sequence-analysis/tutorials/quality-control/tutorial.html"
 
-research4:
-  title: Upcoming events
-  url: "/events/"
-  content: "The Galaxy community puts on a show every year with dozens of events around the world.<div class='mt-2'>Next up:</div>"
-  button:
-      title: Visit more
-      url: "https://galaxyproject.org/events/"
-  events:
-    - event: "Hackathon Image Analysis in Galaxy"
-      date: "Feb 26, 2024"
-      url: "https://galaxyproject.org/events/2024-02-26-hackathon-image-analysis-in-galaxy/"
-    - date: "Mar 4, 2024"
-      event: "Workshop on High-Throughput Data Analysis with Galaxy"
-      url: "https://galaxyproject.org/events/2024-03-04-galaxy-workshop-freiburg/"
-    - date: "Mar 5, 2024"
-      event: "Awareness in Data Management and Analysis for Industry and Research"
-      url: "https://www.cecam.org/workshop-details/1349"
 
 research5:
   title: "Research highlights"

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -391,7 +391,7 @@ query {
     }
 
     events: allParentArticle(
-        limit: 5, sortBy: "date", order: ASC,
+        limit: 3, sortBy: "date", order: ASC,
         filter: {
             category: {eq: "events"}, subsites: {contains: ["global"]}, has_date: {eq: true}, days_ago: {lte: 0},
             draft: {ne: true}

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -276,18 +276,19 @@
                         </div>
                         <table style="padding: 0">
                             <tbody>
-                                <tr v-for="t in this.$static.datasetResearch.research4.events" :key="t.event">
+                                <tr v-for="event in events" :key="event.id">
                                     <td>
-                                        <div>{{ t.date }}</div>
+                                        <div>{{ event.date }}</div>
                                     </td>
                                     <td>
                                         <a
-                                            :href="t.url"
+                                            :href="event.path"
                                             rel="noopener"
                                             target="_blank"
                                             class="text-white text-decoration-none"
-                                            >{{ t.event }}</a
                                         >
+                                            {{ event.title }}
+                                        </a>
                                     </td>
                                 </tr>
                             </tbody>
@@ -339,6 +340,11 @@ export default {
             prioritizedGalaxyLocales: [],
         };
     },
+    computed: {
+        events() {
+            return this.$page.events.edges.map((edge) => edge.node);
+        },
+    },
     methods: {
         slugify,
         setPrioritizedGalaxyLocales() {
@@ -383,6 +389,28 @@ query {
             url
         }
     }
+
+    events: allParentArticle(
+        limit: 5, sortBy: "date", order: ASC,
+        filter: {
+            category: {eq: "events"}, subsites: {contains: ["global"]}, has_date: {eq: true}, days_ago: {lte: 0},
+            draft: {ne: true}
+        }
+    ) {
+        totalCount
+        edges {
+            node {
+                id
+                title
+                tease
+                external_url
+                path
+                date (format: "MMM D")
+                end  (format: "MMM D")
+            }
+        }
+    }
+
 }
 </page-query>
 
@@ -442,20 +470,6 @@ query {
             },
             links {
                 title,
-                url
-            }
-        },
-        research4 {
-            title,
-            content,
-            url,
-            button {
-                title,
-                url
-            },
-            events {
-                event,
-                date,
                 url
             }
         },

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -267,10 +267,13 @@
                         </div>
                     </div>
                     <div class="area research events mt-3 h-40">
-                        <a :href="this.$static.datasetResearch.research4.url">
-                            <h3>{{ this.$static.datasetResearch.research4.title }}</h3>
+                        <a href="/events/">
+                            <h3>Upcoming events</h3>
                         </a>
-                        <div v-html="this.$static.datasetResearch.research4.content" class="text-white mb-2"></div>
+                        <div class="text-white mb-2">
+                            The Galaxy community puts on a show every year with dozens of events around the world.
+                            <div class="mt-2">Next up:</div>
+                        </div>
                         <table style="padding: 0">
                             <tbody>
                                 <tr v-for="t in this.$static.datasetResearch.research4.events" :key="t.event">
@@ -291,12 +294,12 @@
                         </table>
                         <div class="d-flex justify-content-center">
                             <a
-                                :href="this.$static.datasetResearch.research4.button.url"
+                                href="/events/"
                                 role="button"
                                 rel="noopener"
                                 target="_blank"
                                 class="btn text-decoration-none mt-3 mb-3 w-50"
-                                >{{ this.$static.datasetResearch.research4.button.title }}</a
+                                >Visit more</a
                             >
                         </div>
                     </div>


### PR DESCRIPTION
With the homepage content refresh the events box was swapped to a predefined static blob instead of dynamically updating, and it was quickly out of date.  This PR adds back dynamic event listing of the three next upcoming events.


Additionally I unpacked some of the content out of research.yml -- it's simply not useful to stuff all these fields in yaml when they are much easier to read, edit, etc., in the vue file.  How would one know what `research4` was anyway, in the contents?

I'm going to follow up and unpack the rest of the unnecessary yaml separately.