### PR TITLE
fixing affiliation and last name typos

### DIFF
--- a/content/events/gcc2024/training/teaching-gtn-tiaas/index.md
+++ b/content/events/gcc2024/training/teaching-gtn-tiaas/index.md
@@ -15,8 +15,8 @@ In this workshop, we will have a round-table discussion around teaching with Gal
 
 ### Saskia Hiltemann
 
-University of Freiburg, Germany; Erasmus Medical Center, The Netherlands
+University of Freiburg, Germany
 
-### Helena Raske
+### Helena Rasche
 
-University of Freiburg, Germany; Erasmus Medical Center, The Netherlands
+Erasmus Medical Center, The Netherlands


### PR DESCRIPTION
It looks like Both Helena's and Saskia's affiliations got grouped together. this minor change removes the incorrect affiliations and fixes a typo with Helena's last name. 