### PR TITLE
Drop github action for gtn news to daily, 3am.  This also needs to be…

### DIFF
--- a/.github/workflows/gtn-news.yml
+++ b/.github/workflows/gtn-news.yml
@@ -6,7 +6,7 @@ name: Galaxy Training Network news
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 3 * * *
 
 jobs:
   collect:


### PR DESCRIPTION
… fixed like the last one to not open multiple PRs.