### PR TITLE
Update Makefile for latest conda and yarn packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ create-env: ## create galaxyproject-hub conda environment
 	if ${CONDA} env list | grep '^${CONDA_ENV}'; then \
 	    ${CONDA} env update -f environment.yml; \
 	else \
-	    ${CONDA} env create --force -f environment.yml; \
+	    ${CONDA} env create -f environment.yml; \
 	fi
 .PHONY: create-env
 


### PR DESCRIPTION
Note that you may have to do `make build` twice for some reason. Afterwhich `make run` works fine, at least on Mint 21.3.