### PR TITLE
Adjust static file staging location handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ics": "^2.35.0",
     "jiti": "^1.12.0",
     "lodash": "^4.17.21",
-    "lodash.kebabcase": "^4.1.1",
     "magic-snowflakes": "^6.1.0",
     "markdownlint": "^0.24.0",
     "markdownlint-cli": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ics": "^2.35.0",
     "jiti": "^1.12.0",
     "lodash": "^4.17.21",
+    "lodash.kebabcase": "^4.1.1",
     "magic-snowflakes": "^6.1.0",
     "markdownlint": "^0.24.0",
     "markdownlint-cli": "^0.29.0",

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -53,7 +53,15 @@ function stageStaticContent(srcDir, destDir) {
         // Compute the new destination path
         const relativePath = path.relative(srcDir, file);
 
-        const destPath = path.join(destDir, kebabCase(path.dirname(relativePath)), path.basename(relativePath));
+        const fileName = path.basename(relativePath);
+        const filePath = path.dirname(relativePath);
+
+        // break part path, map kebab-case, and rejoin
+        const parts = filePath.split(path.sep);
+        const kebabParts = parts.map((part) => kebabCase(part));
+        const kebabPath = kebabParts.join(path.sep);
+
+        const destPath = path.join(destDir, kebabPath, fileName);
 
         // Ensure the directory structure exists
         fs.ensureDir(path.dirname(destPath))

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -10,7 +10,6 @@ import { PathInfo } from "../lib/paths.mjs";
 import { CONTENT_TYPES } from "./partition-content.mjs";
 // Direct importing of JSON files isn't supported yet in ES modules. This is a workaround.
 import { createRequire } from "module";
-import kebabCase from "lodash.kebabcase";
 
 const require = createRequire(import.meta.url);
 const CONFIG = require("../../config.json");
@@ -42,6 +41,16 @@ if (code) {
     process.exitCode = code;
 }
 
+function formatURLPart(str) {
+    // Defines formatting of URL parts for static content staging
+    return (
+        str
+            .replace(/([a-z])([A-Z])/g, "$1-$2")
+            // .replace(/_/g, "-") (test w/o underscore to kebab)
+            .toLowerCase()
+    );
+}
+
 // Stage static files, standardizing to kebab-lowercase paths but leaving filenames alone
 function stageStaticContent(srcDir, destDir) {
     // Build glob pattern from defined copyFileExts (image, mov, etc. extensions)
@@ -58,7 +67,7 @@ function stageStaticContent(srcDir, destDir) {
 
         // break part path, map kebab-case, and rejoin
         const parts = filePath.split(path.sep);
-        const kebabParts = parts.map((part) => kebabCase(part));
+        const kebabParts = parts.map((part) => formatURLPart(part));
         const kebabPath = kebabParts.join(path.sep);
 
         const destPath = path.join(destDir, kebabPath, fileName);

--- a/src/build/run.mjs
+++ b/src/build/run.mjs
@@ -10,6 +10,8 @@ import { PathInfo } from "../lib/paths.mjs";
 import { CONTENT_TYPES } from "./partition-content.mjs";
 // Direct importing of JSON files isn't supported yet in ES modules. This is a workaround.
 import { createRequire } from "module";
+import kebabCase from "lodash.kebabcase";
+
 const require = createRequire(import.meta.url);
 const CONFIG = require("../../config.json");
 
@@ -40,7 +42,7 @@ if (code) {
     process.exitCode = code;
 }
 
-// Stage static files, standardizing to lowercase paths but leaving filenames alone
+// Stage static files, standardizing to kebab-lowercase paths but leaving filenames alone
 function stageStaticContent(srcDir, destDir) {
     // Build glob pattern from defined copyFileExts (image, mov, etc. extensions)
     const pattern = path.join(srcDir, `**/*.{${CONFIG.build.copyFileExts.join(",")}}`);
@@ -51,7 +53,7 @@ function stageStaticContent(srcDir, destDir) {
         // Compute the new destination path
         const relativePath = path.relative(srcDir, file);
 
-        const destPath = path.join(destDir, path.dirname(relativePath).toLowerCase(), path.basename(relativePath));
+        const destPath = path.join(destDir, kebabCase(path.dirname(relativePath)), path.basename(relativePath));
 
         // Ensure the directory structure exists
         fs.ensureDir(path.dirname(destPath))

--- a/yarn.lock
+++ b/yarn.lock
@@ -13738,6 +13738,7 @@ stringify-entities@^3.0.1:
     xtend "^4.0.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9892,7 +9892,7 @@ lodash.flatten@~4.4.0:
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
-  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
+  integrity sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -13737,7 +13737,7 @@ stringify-entities@^3.0.1:
     character-entities-legacy "^1.0.0"
     xtend "^4.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13778,13 +13778,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -15844,7 +15837,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15865,15 +15858,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Uses lodash.kebabcase to handle paths like:

```
news-2024-08-14-GalaxyInResearch/GalaxyInResearch_Jain2024.png
Which should be:
news-2024-08-14-galaxy-in-research/GalaxyInResearch_Jain2024.png
And not the simple lower(), like:
news-2024-08-14-galaxyinresearch/GalaxyInResearch_Jain2024.png
```