### PR TITLE
Add brc-analytics link to projects dropdown

### DIFF
--- a/content/belgium/navbar.yml
+++ b/content/belgium/navbar.yml
@@ -51,5 +51,7 @@ right:
     target: "/projects/mpxv/"
   - label: VGP
     target: "/projects/vgp/"
+  - label: BRC Analytics
+    target: "https://brc-analytics.org/"
 - label: "@jxtx"
   target: https://jxtxfoundation.org/

--- a/content/erasmusmc/navbar.yml
+++ b/content/erasmusmc/navbar.yml
@@ -60,5 +60,7 @@ right:
     target: "/projects/mpxv/"
   - label: VGP
     target: "/projects/vgp/"
+  - label: BRC Analytics
+    target: "https://brc-analytics.org/"
 - label: "@jxtx"
   target: https://jxtxfoundation.org/

--- a/content/eu/navbar.yml
+++ b/content/eu/navbar.yml
@@ -64,5 +64,7 @@ right:
     target: "/projects/mpxv/"
   - label: VGP
     target: "/projects/vgp/"
+  - label: BRC Analytics
+    target: "https://brc-analytics.org/"
 - label: "@jxtx"
   target: https://jxtxfoundation.org/

--- a/content/genouest/navbar.yml
+++ b/content/genouest/navbar.yml
@@ -65,5 +65,7 @@ right:
     target: "/projects/mpxv/"
   - label: VGP
     target: "/projects/vgp/"
+  - label: BRC Analytics
+    target: "https://brc-analytics.org/"
 - label: "@jxtx"
   target: https://jxtxfoundation.org/

--- a/content/ifb/navbar.yml
+++ b/content/ifb/navbar.yml
@@ -58,5 +58,7 @@ right:
     target: "/projects/mpxv/"
   - label: VGP
     target: "/projects/vgp/"
+  - label: BRC Analytics
+    target: "https://brc-analytics.org/"
 - label: "@jxtx"
   target: https://jxtxfoundation.org/

--- a/content/navbar.yml
+++ b/content/navbar.yml
@@ -60,5 +60,7 @@ right:
             target: "/projects/mpxv/"
           - label: VGP
             target: "/projects/vgp/"
+          - label: BRC Analytics
+            target: "https://brc-analytics.org/"
     - label: "@jxtx"
       target: https://jxtxfoundation.org/

--- a/content/pasteur/navbar.yml
+++ b/content/pasteur/navbar.yml
@@ -60,5 +60,7 @@ right:
     target: "/projects/mpxv/"
   - label: VGP
     target: "/projects/vgp/"
+  - label: BRC Analytics
+    target: "https://brc-analytics.org/"
 - label: "@jxtx"
   target: https://jxtxfoundation.org/

--- a/content/projects/brc/index.md
+++ b/content/projects/brc/index.md
@@ -1,0 +1,16 @@
+---
+description: "Analytics for pathogen, host, and vector data"
+autotoc: false
+title: "BRC Analytics"
+redirect: "https://brc-analytics.org/"
+---
+## Analytics for pathogen, host, and vector data
+
+Comprehensive tools for exploring and interpreting genomic annotations and
+functional insights into disease-causing organisms and their carriers
+
+BRC Analytics is your new destination for analysis of biological data related to
+pathogens. Building on the legacy of VEuPathDb the platform will provide access
+and analysis capabilities for 785 eukaryotic pathogens, hosts, and vectors. The
+functionality will be developed and made available incrementally over the
+following months.


### PR DESCRIPTION
… in primary and subsites w/ standard project grouping, highlighting BRC Analytics as a major galaxy community project.

I had initially included (redundant) content at `/content/projects/brc/index.md` to have a landing page, but for now, as content develops quickly, it makes a lot more more sense to link directly and only have this placeholder with a redirect.

xref https://github.com/galaxyproject/brc-analytics/issues/104