### PR TITLE
Update community/wg/index.md

### DIFF
--- a/content/community/wg/index.md
+++ b/content/community/wg/index.md
@@ -81,7 +81,7 @@ Testing and hardening the Galaxy ecosystem, developing and maintaining test infr
 
 This group builds the standards and ecosystem for execution, testing, publishing and improving workflows, workflow features and workflow performance.
 
-* [GitHub Project](https://github.com/orgs/galaxyproject/projects/20)
+* [GitHub](https://github.com/galaxyproject/iwc)
 * [Google Drive](https://drive.google.com/drive/folders/1E8xG5u8mInGr5-GgfpKVTQYeo5xkRkAx?usp=sharing)
 * [Matrix Channel](https://matrix.to/#/#galaxyproject_iwc:gitter.im)
 * Organizers: Marius van den Beek, Alex Ostrovsky


### PR DESCRIPTION
Workflows and Tools has a broken link.

Propose changing the link label to just "Github" and sending people to the repository directly. Other ideas?

This page probably needs even more updates. Would someone like to work on this with me in this branch?