### PR TITLE
Create index.md for the community on-boarding cookbook

### DIFF
--- a/‎content/get-started/new-leads/index.md
+++ b/‎content/get-started/new-leads/index.md
@@ -1,0 +1,4 @@
+---
+title: Set up your own community
+redirect: "/community/"
+---


### PR DESCRIPTION
Hi,
We have a EuroScienceGateway deliverable that has been submitted and I cannot change it. It is basically one line and points to the following link: https://galaxyproject.org/get-started/new-leads/. The page has been removed since galaxy governance (community onboarding cookbook) has been updated (https://github.com/galaxyproject/galaxy-hub/commit/1e705eb4d58905314fdc682fb0c290779dd43a88). I added a redirect so those who want to reach the old link will end up to the correct updated page.

This also helps for the last line of the following page in the current version of Galaxy Hub which points to the same page: https://github.com/galaxyproject/galaxy-hub/blob/7b776de855545bdbb962f450e8410547daf37544/content/community/contributing/index.md?plain=1#L36