### PR TITLE
Sig page - update index 

### DIFF
--- a/content/community/sig/index.md
+++ b/content/community/sig/index.md
@@ -30,7 +30,7 @@ You can read more about the [GCB and SIGs](/community/governance/gcb/) or learn 
 <!-- Climate -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://climate.usegalaxy.eu">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Climate</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Climate</div>
 </a>
 
 The Climate Science workbench is a comprehensive set of analysis tools and consolidated workflow.
@@ -40,7 +40,7 @@ The Climate Science workbench is a comprehensive set of analysis tools and conso
 <!-- Computational Chemistry -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/computationalchemistry/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Computational Chemistry</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Computational Chemistry</div>
 </a>
 
 Group of computational chemistry tool developers, trainers and users to help connect outreach, user needs, and computationalists.
@@ -50,7 +50,7 @@ Group of computational chemistry tool developers, trainers and users to help con
 <!-- Earth -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/earth/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Earth</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Earth</div>
 </a>
 
 A web platform to get, process, analyze and visualize earth data.
@@ -60,7 +60,7 @@ A web platform to get, process, analyze and visualize earth data.
 <!-- Ecology -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://ecology.usegalaxy.eu">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Ecology</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Ecology</div>
 </a>
 
 A web platform to get, process, analyze and visualize ecological data.
@@ -70,7 +70,7 @@ A web platform to get, process, analyze and visualize ecological data.
 <!-- Genome Annotation -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/genome-annotation/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Genome Annotation</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Genome Annotation</div>
 </a>
 
 Galaxy as a platform for the annotation of genomes.
@@ -80,7 +80,7 @@ Galaxy as a platform for the annotation of genomes.
 <!-- Materials Science -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://materials.usegalaxy.eu">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Materials Science</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Materials Science</div>
 </a>
 
 A Galaxy workbench with tools and workflows for materials science, including muon spectroscopy.
@@ -90,7 +90,7 @@ A Galaxy workbench with tools and workflows for materials science, including muo
 <!-- MicroGalaxy -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/microbial#microgalaxy-community">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>MicroGalaxy</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>MicroGalaxy</div>
 </a>
 
 Anything regarding microbial data analysis in Galaxy, with meetings, working groups, chat and mailing list
@@ -100,7 +100,7 @@ Anything regarding microbial data analysis in Galaxy, with meetings, working gro
 <!-- Public Health -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Public Health</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Public Health</div>
 </a>
 
 Announcements and discussion in the Galaxy Public Health Community.
@@ -119,7 +119,7 @@ Announcements and discussion in the Galaxy Public Health Community.
 <!-- Machine Learning -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://ml.usegalaxy.eu">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Machine Learning</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Machine Learning</div>
 </a>
 
 A comprehensive set of data preprocessing, machine learning, deep learning and visualisation tools, and consolidated workflows for end-to-end machine learning analysis.
@@ -129,7 +129,7 @@ A comprehensive set of data preprocessing, machine learning, deep learning and v
 <!-- Metabolomics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://metabolomics.usegalaxy.eu">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Metabolomics</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Metabolomics</div>
 </a>
 
 Community-driven metabolomics Galaxy service. The main aim is to give people a public space to discover and run metabolomics tools.
@@ -139,7 +139,7 @@ Community-driven metabolomics Galaxy service. The main aim is to give people a p
 <!-- Natural Language Processing -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Natural Language Processing</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Natural Language Processing</div>
 </a>
 
 An open, interoperable web service platform for natural language processing (NLP) research and development.
@@ -149,7 +149,7 @@ An open, interoperable web service platform for natural language processing (NLP
 <!-- Proteomics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://proteore.org/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Proteomics</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Proteomics</div>
 </a>
 
 Galaxy-based platform for the functional analysis and the interpretation of proteomics and transcriptomics data in biomedical research.
@@ -159,7 +159,7 @@ Galaxy-based platform for the functional analysis and the interpretation of prot
 <!-- Single cell & sPatial Omics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/singlecell/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Single cell & sPatial Omics</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Single cell & sPatial Omics</div>
 </a>
 
 The Single cell and sPatial Omics Community (🖖🏾SPOC) unites tool developers, trainers and users to help connect outreach, user needs, and computationalists.
@@ -169,7 +169,7 @@ The Single cell and sPatial Omics Community (🖖🏾SPOC) unites tool developer
 <!-- Image Analysis -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/image-analysis/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Image Analysis</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Image Analysis</div>
 </a>
 
 This community gathers image analysis enthusiasts across different scientific disciplines.
@@ -187,7 +187,7 @@ This community gathers image analysis enthusiasts across different scientific di
 <!-- Small Scale Admins -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/small-scale-admins/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Small Scale Admins</div>
+<div class="card-header bg-sig-service text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Small Scale Admins</div>
 </a>
 
 Admins of small scale Galaxy servers.
@@ -206,7 +206,7 @@ Admins of small scale Galaxy servers.
 <!-- Galaxy Africa -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Africa</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Africa</div>
 </a>
 
 Galaxy African community.
@@ -216,7 +216,7 @@ Galaxy African community.
 <!-- Arabic -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/arabic/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Arabic</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Arabic</div>
 </a>
 
 The Galaxy Arabic speaking community supports Galaxy activity for the Arabic speaking community and Arabic speaking regions of the world.
@@ -226,7 +226,7 @@ The Galaxy Arabic speaking community supports Galaxy activity for the Arabic spe
 <!-- Australia -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://site.usegalaxy.org.au">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Australia</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Australia</div>
 </a>
 
 Australian Galaxy community.
@@ -236,7 +236,7 @@ Australian Galaxy community.
 <!-- Czech -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/czech/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Czech</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Czech</div>
 </a>
 
 Česká komunita Galaxy / Czech Galaxy Community.
@@ -247,7 +247,7 @@ Australian Galaxy community.
 <!-- Europe -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/eu/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Europe</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Europe</div>
 </a>
 
 The European Galaxy Community and the European Galaxy Server.
@@ -258,7 +258,7 @@ The European Galaxy Community and the European Galaxy Server.
 <!-- France -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>France</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>France</div>
 </a>
 
 Galaxy in the French-speaking world.
@@ -268,7 +268,7 @@ Galaxy in the French-speaking world.
 <!-- India -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://www.galaxyproject.in">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>India</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>India</div>
 </a>
 
 Indian Galaxy Community.
@@ -310,7 +310,7 @@ Galaxy-NL in the Netherlands.
 <!-- Galaxy Switzerland -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/switzerland/">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Switzerland</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Switzerland</div>
 </a>
 
 Galaxy community in Switzerland
@@ -320,7 +320,7 @@ Galaxy community in Switzerland
 <!-- UK -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>UK</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>UK</div>
 </a>
 
 Galaxy in the United Kingdom.
@@ -353,7 +353,7 @@ The global community is running a set of scientific multi-year-long projects whi
 
 <!-- Cancer -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
-<div class="card-header bg-wg-applied text-white text-center">Cancer Informatics</div>
+<div class="card-header bg-sig-projects text-white text-center">Cancer Informatics</div>
 
 This project emphasizes applying Galaxy in cancer research.
 
@@ -367,7 +367,7 @@ This project emphasizes applying Galaxy in cancer research.
 
 <!-- Human Genetics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
-<div class="card-header bg-wg-applied text-white text-center">Human Genetics</div>
+<div class="card-header bg-sig-projects text-white text-center">Human Genetics</div>
 
 This project emphasizes applying Galaxy in human research.
 
@@ -380,7 +380,7 @@ This project emphasizes applying Galaxy in human research.
 
 <!-- COVID-19 -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
-<div class="card-header bg-wg-applied text-white text-center">COVID-19</div>
+<div class="card-header bg-sig-projects text-white text-center">COVID-19</div>
 
 This project emphasizes analysis of SARS-CoV-2.
 
@@ -390,7 +390,7 @@ This project emphasizes analysis of SARS-CoV-2.
 
 <!-- VGP -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
-<div class="card-header bg-wg-applied text-white text-center">VGP</div>
+<div class="card-header bg-sig-projects text-white text-center">VGP</div>
 
 Collaboration Between VGP and Galaxy Project for free and easy access to large genome assembly workflows.
 

--- a/content/community/sig/index.md
+++ b/content/community/sig/index.md
@@ -10,7 +10,7 @@ Active Galaxy communities are encouraged to participate in (or form) their own S
 # Galaxy Communities Calendar
 Check out the upcoming meetings across the communities.
 
-<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=Europe%2FLondon&showPrint=0&showCalendars=0&mode=AGENDA&src=OGE3NjI4OTBmYmU3MjRlOWQyOWI2NzkxNWFhMDE5N2EzNTI2NDJmOTRiMjJlYzY0YTg1NDMwZGFhZjFhYmI1ZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%234285F4" style="border-width:0" width="800" height="400" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=Europe%2FLondon&showPrint=0&showCalendars=0&mode=AGENDA&src=OGE3NjI4OTBmYmU3MjRlOWQyOWI2NzkxNWFhMDE5N2EzNTI2NDJmOTRiMjJlYzY0YTg1NDMwZGFhZjFhYmI1ZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%234285F4" style="border-width:0" width="600" height="300" frameborder="0" scrolling="no"></iframe>
 
 *Please note: The Galaxy Community Board introduced this in December 2024, so we are still collecting communities to add to it! Do you not see your community? [Follow this FAQ](https://training.galaxyproject.org/training-material/topics/community/faqs/community_activites_calendar.html) to add it!*
 

--- a/content/community/sig/index.md
+++ b/content/community/sig/index.md
@@ -119,79 +119,61 @@ Announcements and discussion in the Galaxy Public Health Community.
 <!-- Machine Learning -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://ml.usegalaxy.eu">
-<div class="card-header bg-wg-applied text-white text-center">Machine Learning</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Machine Learning</div>
 </a>
 
 A comprehensive set of data preprocessing, machine learning, deep learning and visualisation tools, and consolidated workflows for end-to-end machine learning analysis.
-
-* [<i class="fa fa-solid fa-graduation-cap">&nbsp; &nbsp;GTN</i>](https://training.galaxyproject.org/training-material/topics/statistics/)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://ml.usegalaxy.eu)
 
 </div>
 
 <!-- Metabolomics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://metabolomics.usegalaxy.eu">
-<div class="card-header bg-wg-applied text-white text-center">Metabolomics</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Metabolomics</div>
 </a>
 
 Community-driven metabolomics Galaxy service. The main aim is to give people a public space to discover and run metabolomics tools.
 
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/metabolomics.lists.galaxyproject.org/)
-* [<i class="fa fa-solid fa-graduation-cap">&nbsp; &nbsp;GTN</i>](https://training.galaxyproject.org/training-material/topics/metabolomics/)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://metabolomics.usegalaxy.eu/)
 </div>
 
 <!-- Natural Language Processing -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center">Natural Language Processing</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Natural Language Processing</div>
 </a>
 
 An open, interoperable web service platform for natural language processing (NLP) research and development.
 
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/galaxy-nlp@lists.galaxyproject.org)
 </div>
 
 <!-- Proteomics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://proteore.org/">
-<div class="card-header bg-wg-applied text-white text-center">Proteomics</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Proteomics</div>
 </a>
 
 Galaxy-based platform for the functional analysis and the interpretation of proteomics and transcriptomics data in biomedical research.
-
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/galaxy-proteomics.lists.galaxyproject.org/)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Link</i>](https://proteore.org)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://proteomics.usegalaxy.eu)
 
 </div>
 
 <!-- Single cell & sPatial Omics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/singlecell/">
-<div class="card-header bg-wg-applied text-white text-center">Single cell & sPatial Omics</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Single cell & sPatial Omics</div>
 </a>
 
 The Single cell and sPatial Omics Community (🖖🏾SPOC) unites tool developers, trainers and users to help connect outreach, user needs, and computationalists.
 
-* [<b>[m]&nbsp; &nbsp;Matrix</b>](https://matrix.to/#/#spoc3:matrix.org)
-* [<i class="fa fa-solid fa-graduation-cap">&nbsp; &nbsp;GTN</i>](https://training.galaxyproject.org/training-material/topics/single-cell/)
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/single-cell-cop.lists.galaxyproject.org/)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://singlecell.usegalaxy.eu)
 </div>
 
 <!-- Image Analysis -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/image-analysis/">
-<div class="card-header bg-wg-applied text-white text-center">Image Analysis</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Image Analysis</div>
 </a>
 
 This community gathers image analysis enthusiasts across different scientific disciplines.
 
-* [<b>[m]&nbsp; &nbsp;Matrix</b>](https://matrix.to/#/#imaging:matrix.org)
-* [<i class="fa fa-solid fa-graduation-cap">&nbsp; &nbsp;GTN</i>](https://training.galaxyproject.org/training-material/topics/imaging/)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://imaging.usegalaxy.eu)
 </div>
 
 <!-- CoP Methodologies SIGs Card-div end -->
@@ -205,13 +187,10 @@ This community gathers image analysis enthusiasts across different scientific di
 <!-- Small Scale Admins -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/small-scale-admins/">
-<div class="card-header bg-wg-applied text-white text-center">Small Scale Admins</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Small Scale Admins</div>
 </a>
 
 Admins of small scale Galaxy servers.
-
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/small-scale-admins.lists.galaxyproject.org/)
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Matrix</i>](https://matrix.to/#/#galaxyproject_admins:gitter.im)
 
 </div>
 
@@ -227,52 +206,40 @@ Admins of small scale Galaxy servers.
 <!-- Galaxy Africa -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center">Africa</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Africa</div>
 </a>
 
 Galaxy African community.
 
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/galaxy-africa@lists.galaxyproject.org)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://africa.usegalaxy.eu)
 </div>
 
 <!-- Arabic -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/arabic/">
-<div class="card-header bg-wg-applied text-white text-center">Arabic</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Arabic</div>
 </a>
 
 The Galaxy Arabic speaking community supports Galaxy activity for the Arabic speaking community and Arabic speaking regions of the world.
-
-* [<i class="fab fa-twitter" aria-hidden="true">&nbsp; &nbsp;Twitter</i>](http://twitter.com/galaxy_arabic)
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/galaxy-arabic.lists.galaxyproject.org/)
-* [<i class="fab fa-facebook-square" aria-hidden="true">&nbsp; &nbsp;Facebook</i>](http://bit.ly/2ek7fTh)
 
 </div>
 
 <!-- Australia -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://site.usegalaxy.org.au">
-<div class="card-header bg-wg-applied text-white text-center">Australia</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Australia</div>
 </a>
 
 Australian Galaxy community.
-
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Link</i>](https://usegalaxy.org.au/)
-* [<i class="fab fa-twitter" aria-hidden="true">&nbsp; &nbsp;Twitter</i>](http://twitter.com/galaxyaustralia)
 
 </div>
 
 <!-- Czech -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/czech/">
-<div class="card-header bg-wg-applied text-white text-center">Czech</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Czech</div>
 </a>
 
 Česká komunita Galaxy / Czech Galaxy Community.
-
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/galaxy-czech.lists.galaxyproject.org/)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://usegalaxy.cz)
 
 </div>
 
@@ -280,17 +247,10 @@ Australian Galaxy community.
 <!-- Europe -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/eu/">
-<div class="card-header bg-wg-applied text-white text-center">Europe</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Europe</div>
 </a>
 
 The European Galaxy Community and the European Galaxy Server.
-
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Link</i>](https://elixir-europe.org/communities/galaxy)
-* [<b style="font-size:0.9em" aria-hidden="true">[m]&nbsp; &nbsp;Matrix</b>](https://matrix.to/#/#usegalaxy.eu:matrix.org)
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](mailto:contact@usegalaxy.eu)
-* [<i class="fab fa-github" aria-hidden="true">&nbsp; &nbsp;GitHub</i>](https://github.com/usegalaxy-eu)
-* [<i class="fab fa-mastodon" aria-hidden="true">&nbsp; &nbsp;Mastodon</i>](https://xn--baw-joa.social/@galaxyfreiburg)
-* [<i class="fa fa-rss" aria-hidden="true">&nbsp; &nbsp;RSS</i>](/eu/feed.atom)
 
 </div>
 
@@ -298,33 +258,20 @@ The European Galaxy Community and the European Galaxy Server.
 <!-- France -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center">France</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>France</div>
 </a>
 
 Galaxy in the French-speaking world.
-
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Link</i>](https://community.france-bioinformatique.fr/c/galaxy/8)
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Galaxy Instance</i>](https://usegalaxy.fr)
-
 
 </div>
 
 <!-- India -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://www.galaxyproject.in">
-<div class="card-header bg-wg-applied text-white text-center">India</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>India</div>
 </a>
 
 Indian Galaxy Community.
-
-* [<i class="fa fa-external-link-alt" aria-hidden="true">&nbsp; &nbsp;Link</i>](https://www.galaxyproject.in/)
-* [<i class="fab fa-whatsapp" aria-hidden="true">&nbsp; &nbsp;Whatsapp</i>](https://chat.whatsapp.com/CCXT7t97ZX5D3MiD7MVmun)
-* [<i class="fab fa-whatsapp" aria-hidden="true">&nbsp; &nbsp;Whatsapp</i>](https://chat.whatsapp.com/LYAWg6Yah1i4QbMU0sktqB)
-* [<i class="fab fa-gitter" aria-hidden="true">&nbsp; &nbsp;Gitter</i>](https://gitter.im/usegalaxy-in/adda)
-* [<i class="fab fa-twitter" aria-hidden="true">&nbsp; &nbsp;Twitter</i>](http://twitter.com/GxyIndia)
-* [<i class="fab fa-twitter" aria-hidden="true">&nbsp; &nbsp;Twitter</i>](http://twitter.com/useGalaxyIndia)
-* [<i class="fab fa-github" aria-hidden="true">&nbsp; &nbsp;GitHub</i>](https://github.com/usegalaxy-in/)
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/india.lists.galaxyproject.org/)
 
 </div>
 
@@ -363,24 +310,20 @@ Galaxy-NL in the Netherlands.
 <!-- Galaxy Switzerland -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/switzerland/">
-<div class="card-header bg-wg-applied text-white text-center">Switzerland</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Switzerland</div>
 </a>
 
 Galaxy community in Switzerland
-
-* [<i class="fa fa-envelope" aria-hidden="true">&nbsp; &nbsp;Mailing List</i>](https://lists.galaxyproject.org/lists/galaxy-switzerland@lists.galaxyproject.org)
 
 </div>
 
 <!-- UK -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-wg-applied text-white text-center">UK</div>
+<div class="card-header bg-wg-applied text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>UK</div>
 </a>
 
 Galaxy in the United Kingdom.
-
-* [<i class="fab fa-twitter" aria-hidden="true">&nbsp; &nbsp;Twitter</i>](http://twitter.com/galaxyukfriends)
 
 </div>
 

--- a/content/community/sig/index.md
+++ b/content/community/sig/index.md
@@ -30,7 +30,7 @@ You can read more about the [GCB and SIGs](/community/governance/gcb/) or learn 
 <!-- Climate -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://climate.usegalaxy.eu">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Climate</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Climate</div>
 </a>
 
 The Climate Science workbench is a comprehensive set of analysis tools and consolidated workflow.
@@ -40,7 +40,7 @@ The Climate Science workbench is a comprehensive set of analysis tools and conso
 <!-- Computational Chemistry -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/computationalchemistry/">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Computational Chemistry</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Computational Chemistry</div>
 </a>
 
 Group of computational chemistry tool developers, trainers and users to help connect outreach, user needs, and computationalists.
@@ -50,7 +50,7 @@ Group of computational chemistry tool developers, trainers and users to help con
 <!-- Earth -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/earth/">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Earth</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Earth</div>
 </a>
 
 A web platform to get, process, analyze and visualize earth data.
@@ -60,7 +60,7 @@ A web platform to get, process, analyze and visualize earth data.
 <!-- Ecology -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://ecology.usegalaxy.eu">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Ecology</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Ecology</div>
 </a>
 
 A web platform to get, process, analyze and visualize ecological data.
@@ -70,7 +70,7 @@ A web platform to get, process, analyze and visualize ecological data.
 <!-- Genome Annotation -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/genome-annotation/">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Genome Annotation</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Genome Annotation</div>
 </a>
 
 Galaxy as a platform for the annotation of genomes.
@@ -80,7 +80,7 @@ Galaxy as a platform for the annotation of genomes.
 <!-- Materials Science -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://materials.usegalaxy.eu">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Materials Science</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Materials Science</div>
 </a>
 
 A Galaxy workbench with tools and workflows for materials science, including muon spectroscopy.
@@ -90,7 +90,7 @@ A Galaxy workbench with tools and workflows for materials science, including muo
 <!-- MicroGalaxy -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/microbial#microgalaxy-community">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>MicroGalaxy</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;MicroGalaxy</div>
 </a>
 
 Anything regarding microbial data analysis in Galaxy, with meetings, working groups, chat and mailing list
@@ -100,7 +100,7 @@ Anything regarding microbial data analysis in Galaxy, with meetings, working gro
 <!-- Public Health -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Public Health</div>
+<div class="card-header bg-sig-field text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Public Health</div>
 </a>
 
 Announcements and discussion in the Galaxy Public Health Community.
@@ -119,7 +119,7 @@ Announcements and discussion in the Galaxy Public Health Community.
 <!-- Machine Learning -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://ml.usegalaxy.eu">
-<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Machine Learning</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Machine Learning</div>
 </a>
 
 A comprehensive set of data preprocessing, machine learning, deep learning and visualisation tools, and consolidated workflows for end-to-end machine learning analysis.
@@ -129,7 +129,7 @@ A comprehensive set of data preprocessing, machine learning, deep learning and v
 <!-- Metabolomics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://metabolomics.usegalaxy.eu">
-<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Metabolomics</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Metabolomics</div>
 </a>
 
 Community-driven metabolomics Galaxy service. The main aim is to give people a public space to discover and run metabolomics tools.
@@ -139,7 +139,7 @@ Community-driven metabolomics Galaxy service. The main aim is to give people a p
 <!-- Natural Language Processing -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Natural Language Processing</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Natural Language Processing</div>
 </a>
 
 An open, interoperable web service platform for natural language processing (NLP) research and development.
@@ -149,7 +149,7 @@ An open, interoperable web service platform for natural language processing (NLP
 <!-- Proteomics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://proteore.org/">
-<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Proteomics</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Proteomics</div>
 </a>
 
 Galaxy-based platform for the functional analysis and the interpretation of proteomics and transcriptomics data in biomedical research.
@@ -159,7 +159,7 @@ Galaxy-based platform for the functional analysis and the interpretation of prot
 <!-- Single cell & sPatial Omics -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/singlecell/">
-<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Single cell & sPatial Omics</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Single cell & sPatial Omics</div>
 </a>
 
 The Single cell and sPatial Omics Community (🖖🏾SPOC) unites tool developers, trainers and users to help connect outreach, user needs, and computationalists.
@@ -169,7 +169,7 @@ The Single cell and sPatial Omics Community (🖖🏾SPOC) unites tool developer
 <!-- Image Analysis -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/image-analysis/">
-<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Image Analysis</div>
+<div class="card-header bg-sig-method text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Image Analysis</div>
 </a>
 
 This community gathers image analysis enthusiasts across different scientific disciplines.
@@ -187,7 +187,7 @@ This community gathers image analysis enthusiasts across different scientific di
 <!-- Small Scale Admins -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/small-scale-admins/">
-<div class="card-header bg-sig-service text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Small Scale Admins</div>
+<div class="card-header bg-sig-service text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Small Scale Admins</div>
 </a>
 
 Admins of small scale Galaxy servers.
@@ -206,7 +206,7 @@ Admins of small scale Galaxy servers.
 <!-- Galaxy Africa -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Africa</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Africa</div>
 </a>
 
 Galaxy African community.
@@ -216,7 +216,7 @@ Galaxy African community.
 <!-- Arabic -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/arabic/">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Arabic</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Arabic</div>
 </a>
 
 The Galaxy Arabic speaking community supports Galaxy activity for the Arabic speaking community and Arabic speaking regions of the world.
@@ -226,7 +226,7 @@ The Galaxy Arabic speaking community supports Galaxy activity for the Arabic spe
 <!-- Australia -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://site.usegalaxy.org.au">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Australia</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Australia</div>
 </a>
 
 Australian Galaxy community.
@@ -236,7 +236,7 @@ Australian Galaxy community.
 <!-- Czech -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/czech/">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Czech</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Czech</div>
 </a>
 
 Česká komunita Galaxy / Czech Galaxy Community.
@@ -247,7 +247,7 @@ Australian Galaxy community.
 <!-- Europe -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/eu/">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Europe</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Europe</div>
 </a>
 
 The European Galaxy Community and the European Galaxy Server.
@@ -258,7 +258,7 @@ The European Galaxy Community and the European Galaxy Server.
 <!-- France -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>France</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;France</div>
 </a>
 
 Galaxy in the French-speaking world.
@@ -268,7 +268,7 @@ Galaxy in the French-speaking world.
 <!-- India -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="https://www.galaxyproject.in">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>India</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;India</div>
 </a>
 
 Indian Galaxy Community.
@@ -310,7 +310,7 @@ Galaxy-NL in the Netherlands.
 <!-- Galaxy Switzerland -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="/community/sig/switzerland/">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>Switzerland</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;Switzerland</div>
 </a>
 
 Galaxy community in Switzerland
@@ -320,7 +320,7 @@ Galaxy community in Switzerland
 <!-- UK -->
 <div class="card" style="min-width: 12rem; max-width: 20rem">
 <a href="">
-<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>UK</div>
+<div class="card-header bg-sig-region text-white text-center"><i class="fa fa-external-link-alt" aria-hidden="true"></i>&nbsp;UK</div>
 </a>
 
 Galaxy in the United Kingdom.

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -824,7 +824,7 @@ h6:hover .heading-anchor span:before {
 }
 
 .bg-sig-field {
-    background-color: #006B15 !important;
+    background-color: #006b15 !important;
 }
 
 .bg-sig-method {
@@ -832,20 +832,16 @@ h6:hover .heading-anchor span:before {
 }
 
 .bg-sig-service {
-    background-color: #77072F !important;
+    background-color: #77072f !important;
 }
 
 .bg-sig-region {
-    background-color: #CC4D00 !important;
+    background-color: #cc4d00 !important;
 }
 
 .bg-sig-projects {
     background-color: #150276 !important;
 }
-
-
-
-
 
 /*********
    Gridsome-era additions.

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -823,6 +823,30 @@ h6:hover .heading-anchor span:before {
     background-color: #d87e55 !important;
 }
 
+.bg-sig-field {
+    background-color: #006B15 !important;
+}
+
+.bg-sig-method {
+    background-color: #630177 !important;
+}
+
+.bg-sig-service {
+    background-color: #77072F !important;
+}
+
+.bg-sig-region {
+    background-color: #CC4D00 !important;
+}
+
+.bg-sig-projects {
+    background-color: #150276 !important;
+}
+
+
+
+
+
 /*********
    Gridsome-era additions.
  *********/


### PR DESCRIPTION
<img width="708" alt="Screenshot 2025-03-14 at 12 55 47" src="https://github.com/user-attachments/assets/484f249f-1e1d-4701-b28d-60050946fb96" />

As per our previous GCB meetings, I have simplified the SIG index page and updated the cards to make it clearer they are links. Then SiGs can put all their information (and keep it updated) on their required SiG page, rather than on both the index and their SiG page.