### PR TITLE
I went through news and events and added esg tags where I found relevant.

### DIFF
--- a/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
+++ b/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
@@ -20,6 +20,7 @@ supporters:
 - elixir
 subsites: [eu, freiburg, esg]
 main_subsite: freiburg
+tags: [esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 ---
 
 Within the **European Galaxy Days**, the **EuroScienceGateway consortium of 18 partners** will get together in Freiburg, Germany, 

--- a/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
+++ b/content/events/2022-08-16-eurosciencegateway-kickoff-meeting/index.md
@@ -4,7 +4,7 @@ tease: "Within the European Galaxy Days, the EuroScienceGateway consortium of 18
 hide_tease: true
 date: "2022-10-06"
 end: "2022-10-07"
-tags: [conference]
+tags: [conference,esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 contacts:
 - name: Freiburg Galaxy Team
   email: galaxy@informatik.uni-freiburg.de
@@ -20,7 +20,6 @@ supporters:
 - elixir
 subsites: [eu, freiburg, esg]
 main_subsite: freiburg
-tags: [esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 ---
 
 Within the **European Galaxy Days**, the **EuroScienceGateway consortium of 18 partners** will get together in Freiburg, Germany, 

--- a/content/events/2022-10-06-euro-science-gateway-kickoff-meeting/index.md
+++ b/content/events/2022-10-06-euro-science-gateway-kickoff-meeting/index.md
@@ -2,7 +2,7 @@
 title: EuroScienceGateway Kick-off Meeting
 date: '2022-10-06'
 end: '2022-10-07'
-tags: [conference]
+tags: [conference, esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 continent: EU
 contacts:
 - email: galaxy@informatik.uni-freiburg.de
@@ -17,7 +17,7 @@ location:
 supporters:
 - eu
 - elixir
-subsites: [eu, freiburg, esg]
+subsites: [all-eu, freiburg, esg]
 main_subsite: freiburg
 ---
 

--- a/content/events/2022-10-egd/index.md
+++ b/content/events/2022-10-egd/index.md
@@ -9,7 +9,7 @@ location:
 gtn: false
 contact: Hans-Rudolf Hotz, Björn Grüning, Beatriz Serrano-Solano, Oana Marchis, Anika
   Erxleben
-tags: [training]
+tags: [training, esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 subsites: [all-eu, global, esg]
 ---
 

--- a/content/events/2023-02-20-Freiburg-Workshop/index.md
+++ b/content/events/2023-02-20-Freiburg-Workshop/index.md
@@ -8,11 +8,11 @@ location:
   name: "University of Freiburg, Germany"
 gtn: true
 contact: "Anika Erxleben"
-tags: ["workshop", "training"]
+tags: ["workshop", "training", "esg", "esg-wp1"]
 supporters:
 - dataplant
 - eurosciencegateway
-subsites: [all]
+subsites: [all, all-eu, esg]
 ---
 
 We are offering a Galaxy workshop on HTS Data analysis. This is a students workshop at the University of Freiburg where we have a few places left for other Galaxy users, e.g. PhD students and PostDocs. If you are interested or need more information, please contact Anika Erxleben (erxleben@informatik.uni-freiburg.de).

--- a/content/events/2023-07-17-Galaxy-Workshop-Freiburg/index.md
+++ b/content/events/2023-07-17-Galaxy-Workshop-Freiburg/index.md
@@ -8,11 +8,11 @@ location:
   name: "University of Freiburg, Germany"
 gtn: true
 contact: "Anika Erxleben"
-tags: [workshop, training]
+tags: [workshop, training, esg, esg-wp1]
 supporters:
 - dataplant
 - eurosciencegateway
-subsites: [all]
+subsites: [all, esg]
 ---
 
 # General information

--- a/content/events/2023-09-06/index.md
+++ b/content/events/2023-09-06/index.md
@@ -8,7 +8,7 @@ location:
 image: 
 location_url: "https://indico.skatelescope.org/event/1031/"
 contact: "Volodymyr Savchenko, François Antoine Morier-Genoud, Denys Savchenko, Andrii Neronov"
-subsites: [global]
+subsites: [global, all-eu, esg]
 tags: [esg-wp5, esg-wp2, esg, conference]
 ---
 

--- a/content/events/2023-10-egd/index.md
+++ b/content/events/2023-10-egd/index.md
@@ -8,7 +8,7 @@ location:
     name: Freiburg, Germany
 gtn: false
 contact: contact@usegalaxy.eu
-tags: [training]
+tags: [training, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 subsites: [all-eu, global, esg]
 ---
 

--- a/content/events/2024-03-04-Galaxy-Workshop-Freiburg/index.md
+++ b/content/events/2024-03-04-Galaxy-Workshop-Freiburg/index.md
@@ -8,12 +8,12 @@ location:
   name: "University of Freiburg, Germany"
 gtn: true
 contact: "Anika Erxleben"
-tags: [workshop, training]
+tags: [workshop, training, esg, esg-wp1]
 supporters:
 - dataplant
 - eurosciencegateway
 - denbi
-subsites: [all]
+subsites: [all, esg, all-eu]
 ---
 
 # General information

--- a/content/events/2024-04-25-ESG-annual-meeting/index.md
+++ b/content/events/2024-04-25-ESG-annual-meeting/index.md
@@ -1,6 +1,5 @@
 ---
 site: Berlin
-tags: meeting, General Assembly
 title: "EuroScienceGateway General Assembly Meeting 2024"
 starts: 2024-10-24
 ends: 2024-10-24
@@ -8,7 +7,7 @@ organiser: ALU Freiburg Team
 contact: Anika Erxleben-Eggenhofer
 location:  ParkInn Hotel, Alexanderplatz 7, 10178, Berlin
 supporters: EU
-tags: [esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5, esg]
+tags: [esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5, esg, meeting, GeneralAssembly]
 subsites: [all-eu, esg]
 ---
 

--- a/content/events/2024-04-25-ESG-annual-meeting/index.md
+++ b/content/events/2024-04-25-ESG-annual-meeting/index.md
@@ -8,6 +8,8 @@ organiser: ALU Freiburg Team
 contact: Anika Erxleben-Eggenhofer
 location:  ParkInn Hotel, Alexanderplatz 7, 10178, Berlin
 supporters: EU
+tags: [esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5, esg]
+subsites: [all-eu, esg]
 ---
 
 The annual meeting of the Horizon Europe project EOSC [EuroScienceGateway](https://eurosciencegateway.eu) takes place in Berlin after the EOSC Symposium.

--- a/content/events/2024-06-17-Galaxy-Workshop-Freiburg-June/index.md
+++ b/content/events/2024-06-17-Galaxy-Workshop-Freiburg-June/index.md
@@ -8,12 +8,12 @@ location:
   name: "University of Freiburg, Germany"
 gtn: true
 contact: "Anika Erxleben-Eggenhofer"
-tags: [workshop, training]
+tags: [workshop, training, esg, esg-wp1]
 supporters:
 - dataplant
 - eurosciencegateway
 - denbi
-subsites: [all]
+subsites: [all, esg, all-eu]
 ---
 
 # General information

--- a/content/events/2024-07-22-Galaxy-Workshop-Freiburg/index.md
+++ b/content/events/2024-07-22-Galaxy-Workshop-Freiburg/index.md
@@ -8,7 +8,7 @@ location:
   name: "University of Freiburg, Germany"
 gtn: true
 contact: "Anika Erxleben-Eggenhofer"
-tags: [workshop, training]
+tags: [workshop, training, esg, esg-wp1]
 supporters:
 - dataplant
 - eurosciencegateway

--- a/content/events/2024-10-21-EOSCSymposium/index.md
+++ b/content/events/2024-10-21-EOSCSymposium/index.md
@@ -7,5 +7,6 @@ continent: EU
 location: "Berlin, Germany"
 external_url: "https://eosc.eu/symposium2024"
 contact: "For EuroScienceGateway: Anika Erxleben-Eggenhofer (erxleben@informatik.uni-freiburg.de)"
-subsites: [all]
+subsites: [all, esg, all-eu]
+tags: [esg, esg-wp1]
 ---

--- a/content/events/2025-03-10-Galaxy-Workshop-Freiburg/index.md
+++ b/content/events/2025-03-10-Galaxy-Workshop-Freiburg/index.md
@@ -8,12 +8,12 @@ location:
   name: "University of Freiburg, Germany"
 gtn: true
 contact: "Daniela Schneider"
-tags: [workshop, training]
+tags: [workshop, training, esg, esg-wp1]
 supporters:
 - dataplant
 - eurosciencegateway
 - denbi
-subsites: [all]
+subsites: [all, esg, all-eu]
 ---
 
 # General information

--- a/content/events/2025-03-19-fairease-hackathon/index.md
+++ b/content/events/2025-03-19-fairease-hackathon/index.md
@@ -5,12 +5,12 @@ end: '2025-03-20'
 location:
   name: "Brest, France"
 contact: "Marie Jossé, Jérôme Detoc"
-tags: [Hackathon]
+tags: [Hackathon, esg, esg-wp1, esg-wp5, esg-wp3]
 organizers:
   - fair-ease
 supporters:
   - eurosciencegateway
-subsites: [eu]
+subsites: [eu,esg, all-eu]
 ---
 
 # FAIR-EASE Hackathon: Advancing Scientific & Technical Data Integration! 🚀

--- a/content/events/2025-10-01-egd2025/index.md
+++ b/content/events/2025-10-01-egd2025/index.md
@@ -13,6 +13,7 @@ supporters:
 - elixir
 - eu
 subsites: [all, eu, esg]
+tags: [esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 ---
 
 The **European Galaxy Days** will be held from the **1st to 3rd of October 2025** in Freiburg im Breisgau, Germany. This 3-day meeting will be similar to the events we held in [2023](https://galaxyproject.org/events/2023-10-egd/),  [2022](https://galaxyproject.org/events/2022-10-egd/), [2018](https://galaxyproject.org/events/2018-europe-dev/), [2016](https://galaxyproject.org//events/sg2016/), [2014](https://galaxyproject.org//events/sg2014/), and [2012](https://galaxyproject.org//events/switzerland2012/). The first two days will give an overview of the current state of the Galaxy framework and community with several talks, demonstrations, and Birds of a Feather sessions. As part of a CoFest, the third day offer the opportunity to continue the discussions, to code and hack as well as enjoy the Galaxy community.

--- a/content/events/gcc2024/index.md
+++ b/content/events/gcc2024/index.md
@@ -13,8 +13,8 @@ location:
   url: "/events/gcc2024/"
 gtn: true
 contact: "Organizing Committee"
-tags: ["cofest", "workshop", "training", "talk", "poster"]
-subsites: [all]
+tags: ["cofest", "workshop", "training", "talk", "poster", "esg", "esg-wp1"]
+subsites: [all, esg, all-eu]
 ---
 
 <slot name="/events/gcc2024/header" />

--- a/content/news/2020-12-03-galaxy-20-09/index.md
+++ b/content/news/2020-12-03-galaxy-20-09/index.md
@@ -1,7 +1,6 @@
 ---
 title: UseGalaxy.eu update to 20.09
 date: '2020-12-03'
-tags: [release]
 supporters:
 - denbi
 - elixir
@@ -9,7 +8,7 @@ authors: beatrizserrano
 authors_structured:
 - github: beatrizserrano
 subsites: [eu, pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest, esg]
-tags: [esg, esg-wp3, esp-wp4]
+tags: [release, esg, esg-wp3, esp-wp4]
 main_subsite: eu
 ---
 

--- a/content/news/2020-12-03-galaxy-20-09/index.md
+++ b/content/news/2020-12-03-galaxy-20-09/index.md
@@ -8,7 +8,8 @@ supporters:
 authors: beatrizserrano
 authors_structured:
 - github: beatrizserrano
-subsites: [eu, pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest]
+subsites: [eu, pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest, esg]
+tags: [esg, esg-wp3, esp-wp4]
 main_subsite: eu
 ---
 

--- a/content/news/2022-10-12-egd-outcome/index.md
+++ b/content/news/2022-10-12-egd-outcome/index.md
@@ -2,7 +2,8 @@
 title: 'Outcomes of the European Galaxy Days'
 tease: The European Galaxy Community gathered in Freiburg to discuss recent and future Galaxy developments
 date: '2022-10-12'
-subsites: [global, all-eu]
+subsites: [global, all-eu, esg]
+tags: [esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 authors: Beatriz Serrano-Solano
 author_github: beatrizserrano
 ---

--- a/content/news/2022-11-05-EuroScienceGateway/index.md
+++ b/content/news/2022-11-05-EuroScienceGateway/index.md
@@ -3,7 +3,7 @@ title: The start of the EuroScienceGateway - an EOSC project
 date: "2022-11-05"
 tease: "EuroScienceGateway will deliver a robust, scalable, seamlessly integrated open infrastructure for data-driven research"
 hide_tease: false
-tags: [esg]
+tags: [esg, esg-wp1, esp-wp2, esg-wp3, esg-wp4, esg-wp5]
 subsites: [all-eu, esg]
 main_subsite: eu
 ---

--- a/content/news/2022-11-06-EuroScienceGateway-Kickoff-Meeting/index.md
+++ b/content/news/2022-11-06-EuroScienceGateway-Kickoff-Meeting/index.md
@@ -3,7 +3,7 @@ title: EuroScienceGateway - Kickoff meeting
 date: "2022-11-06"
 tease: "The EuroScienceGateway project started officially with a 2 days kickoff meeting with all 17 partners"
 hide_tease: false
-tags: [esg]
+tags: [esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 subsites: [all-eu, esg]
 main_subsite: eu
 ---

--- a/content/news/2022-11-20-EOSC-Symposium/index.md
+++ b/content/news/2022-11-20-EOSC-Symposium/index.md
@@ -3,7 +3,7 @@ title: Annual EOSC Symposium 14-17th November 2022
 date: "2022-11-20"
 tease: "The European Open Science Cloud (EOSC) had its main EOSC annual event. Find photos and recordings here."
 hide_tease: false
-tags: [esg]
+tags: [esg, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 subsites: [all-eu, esg]
 main_subsite: eu
 ---

--- a/content/news/2022-11-24-esg-wp5/index.md
+++ b/content/news/2022-11-24-esg-wp5/index.md
@@ -3,7 +3,7 @@ title: "Use-cases from early adopters to embrace Open Science best practices"
 tease: Work Package 5 of the EuroScienceGateway project
 date: "2022-11-24"
 hide_tease: false
-tags: [esg-wp5, esg]
+tags: [esg-wp5, esg, esg-wp1]
 subsites: [all-eu, esg]
 main_subsite: eu
 ---

--- a/content/news/2023-01-beacon-integration/index.md
+++ b/content/news/2023-01-beacon-integration/index.md
@@ -2,7 +2,7 @@
 title: 'Simple and data privacy-aware publishing of genomic variance data from Galaxy to the Beacon project'
 date: "2023-01-24"
 tease: "Galaxy has gained a Beacon integration that enables users to publish genetic variance data conveniently via Beacon project"
-tags: [collaboration, usecase, esg]
+tags: [collaboration, usecase, esg, esg-wp3]
 subsites: [global,all,esg]
 ---
 

--- a/content/news/2023-02-07-eosc-esg-fair-ease/index.md
+++ b/content/news/2023-02-07-eosc-esg-fair-ease/index.md
@@ -2,7 +2,7 @@
 title: 'Stronger together: FAIR-EASE and EuroScienceGateway join forces'
 tease: 'Two Horizon Europe projects directed toward the development and deployment of the European Open Science Cloud (EOSC)—FAIR-EASE and EuroScienceGateway (ESG)­—have agreed to closely cooperate over the next three years.'
 date: '2023-02-07'
-tags: [esg]
+tags: [esg, esg-wp1, esg-wp5]
 supporters:
 - denbi
 - elixir

--- a/content/news/2023-05-05-eosc-esg-openaire/index.md
+++ b/content/news/2023-05-05-eosc-esg-openaire/index.md
@@ -2,7 +2,7 @@
 title: 'Joining forces in EOSC: OpenAIRE and EuroScienceGateway sign Memorandum of Understanding'
 tease: 'EuroScienceGateway and OpenAIRE team up to enhance accessibility and FAIRness of scientific data from the Galaxy project.'
 date: '2023-05-05'
-tags: [esg]
+tags: [esg, esg-wp1, esg-wp2]
 supporters:
 - denbi
 - elixir

--- a/content/news/2023-05-21-Fair-Ease-EuroScienceGateway/index.md
+++ b/content/news/2023-05-21-Fair-Ease-EuroScienceGateway/index.md
@@ -3,7 +3,7 @@ title: "Stronger together: first FAIR-EASE and EuroScienceGateway workshop"
 tease: "Presenting some outcomes from the first joined FAIR-EASE / EuroScienceGateway workshop"
 authors: "Marie Jossé, Björn Grüning and Yvan Le Bras"
 date: "2023-05-22"
-tags: [esg, esg-wp5]
+tags: [esg, esg-wp5, esg-wp1]
 subsites: [all-eu, esg]
 main_subsite: eu
 ---

--- a/content/news/2023-06-16-eosc-coordination/index.md
+++ b/content/news/2023-06-16-eosc-coordination/index.md
@@ -6,8 +6,8 @@ hide_tease: false
 authors: "Anika Erxleben"
 authors_structured:
 - github: erxleben
-tags: [EU]
-subsites: [all-eu]
+tags: [EU, esg, esg-wp1, eosc]
+subsites: [all-eu, global, esg]
 main_subsite: eu
 ---
 

--- a/content/news/2023-06-24-elixir-annual-report-2022/index.md
+++ b/content/news/2023-06-24-elixir-annual-report-2022/index.md
@@ -5,7 +5,7 @@ tease: "2022 as a year of growth for ELIXIR, and Galaxy being a part of it."
 hide_tease: false
 subsites: [all-eu, esg]
 main_subsite: eu
-tags: [elixir, report, eurosciencegateway]
+tags: [elixir, report, eurosciencegateway, esg, esg-wp3, esg-wp2, esg-wp1, esg-wp3, esg-wp5]
 authors: Sebastian Schaaf
 authors_structured:
 - github: sebastian-schaaf

--- a/content/news/2023-06-26-elixir-ahm/index.md
+++ b/content/news/2023-06-26-elixir-ahm/index.md
@@ -3,7 +3,8 @@ title: 'Freiburg Galaxy team at the ELIXIR All Hands Meeting 2023'
 date: "2023-06-16"
 tease: "From June 5th to 8th, several members from the Freiburg Galaxy team travelled to Dublin, Ireland to participant and present their work at the ELIXIR All Hands Meeting 2023"
 hide_tease: false
-subsites: [all-eu]
+subsites: [all-eu, esg]
+tags: [esg, esg-wp1]
 main_subsite: eu
 ---
 

--- a/content/news/2023-07-07-PASC-conference/index.md
+++ b/content/news/2023-07-07-PASC-conference/index.md
@@ -2,7 +2,8 @@
 title: 'Platform for Advanced Scientific Computing Conference 2023'
 tease: Several Galaxy Community members gathered in Davos
 date: '2023-07-07'
-subsites: [global, all-eu]
+subsites: [global, all-eu, esg]
+tags: [esg, esg-wp5]
 authors: Hans-Rudolf Hotz
 author_github: hrhotz
 ---

--- a/content/news/2023-07-24-egi2023/index.md
+++ b/content/news/2023-07-24-egi2023/index.md
@@ -3,7 +3,7 @@ title: 'Freiburg Galaxy team at the EGI 2023'
 date: "2023-07-24"
 tease: "From June 19th to 23rd, members from the Freiburg Galaxy team traveled to Poznań, Poland to participate and present the EuroScienceGateway (ESG) project at the EGI2023 meeting"
 hide_tease: false
-subsites: [all-eu]
+subsites: [all-eu, esg, esg-wp1, esg-wp4, esg-wp3]
 main_subsite: eu
 ---
 

--- a/content/news/2023-09-12-cordi/index.md
+++ b/content/news/2023-09-12-cordi/index.md
@@ -4,7 +4,7 @@ date: '2023-10-12'
 tease: "The Galaxy Europe Team active at NFDI's CoRDI (Karlsruhe, Germany, Sep 12th to 14th)"
 location:
   name: Karlsruhe, Germany
-tags: [conference, talk, poster, nfdi, rdm]
+tags: [conference, talk, poster, nfdi, rdm, esg, esg-wp1]
 authors: Sebastian Schaaf, Sanjay Kumar Srikakulam
 authors_structured:
 - github: sebastian-schaaf
@@ -15,7 +15,7 @@ supporters:
 - NFDI4Plants
 - ELIXIR
 components: true
-subsites: [all-eu]
+subsites: [all-eu, esg]
 ---
 
 Being a well-known infrastructure for scientific data handling, Galaxy gets increasingly recognized as a powerful solution for research data management (RDM). Thus, it simply _had_ to be represented at [CoRDI, the first 'Conference on Research Data Infrastructure'](https://www.nfdi.de/cordi-2023/?lang=en) in Karlsruhe/Germany. Starting from Sep 12th, the three-day event was geographically close to the Freiburg Team, and organized by [NFDI, the National initiative for Research Data Infrastructure](https://www.nfdi.de/?lang=en). NFDI now involves 27 consortia from three funding rounds and various scientific fields; it aims for both streamlining German RDM efforts, but also with European initiatives like EOSC. Obviously, 'joining forces' is a principle from Galaxy's center of gravity, and less obviously, Galaxy is already participating in two projects from the NFDI space...

--- a/content/news/2023-10-06-qgis/index.md
+++ b/content/news/2023-10-06-qgis/index.md
@@ -5,6 +5,7 @@ authors: Marie Jossé and Yvan Le Bras
 tease: "Use QGIS in Galaxy Europe as an interactive tool"
 hide_tease: true
 subsites: [all-eu,global,esg]
+tags: [esg, esg-wp5]
 ---
 
 ## QGIS ? What does it do ?

--- a/content/news/2023-10-10-sla-esg-egi/index.md
+++ b/content/news/2023-10-10-sla-esg-egi/index.md
@@ -5,7 +5,7 @@ tease: "Elevating FAIR data analytics in EOSC: SLA between ESG and EGI; IISAS to
 hide_tease: false
 subsites: [all-eu, esg]
 main_subsite: eu
-tags: [eurosciencegateway, sla, egi, service level agreement]
+tags: [eurosciencegateway, sla, egi, service level agreement, esg, esg-wp1, esg-wp4]
 authors: Sebastian Schaaf
 authors_structured:
 - github: sebastian-schaaf

--- a/content/news/2023-10-13-EGD-2023-the-wrapup/index.md
+++ b/content/news/2023-10-13-EGD-2023-the-wrapup/index.md
@@ -4,7 +4,7 @@ date: '2023-10-13'
 tease: "...but we look back with a relaxed smile. Let's draw the balance!"
 location:
   name: Freiburg, Germany
-tags: [meeting, esg, egd, community, elixir]
+tags: [meeting, esg, egd, community, elixir, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 authors: Sebastian Schaaf, Anika Erxleben-Eggenhofer, Björn Grüning, Hans-Rudolf Hotz
 authors_structured:
 - github: sebastian-schaaf

--- a/content/news/2023-10-18-odv/index.md
+++ b/content/news/2023-10-18-odv/index.md
@@ -4,7 +4,8 @@ date: "2023-10-18"
 authors: Marie Jossé
 tease: "Use Ocean Data View (ODV) in Galaxy Europe as an interactive tool"
 hide_tease: true
-subsites: [all-eu,global]
+subsites: [all-eu,global, esg]
+tags: [esg, esg-wp5]
 ---
 
 ## ODV ? What does it do ?

--- a/content/news/2023-10-30-bwhpc-symposium/index.md
+++ b/content/news/2023-10-30-bwhpc-symposium/index.md
@@ -4,12 +4,12 @@ date: '2023-10-30'
 tease: "Introducing Galaxy: A new cloud and HPC gateway for data-driven computational research"
 location:
   name: Mannheim, Germany
-tags: [conference, talk]
+tags: [conference, talk,esg, esg-wp1, esg-wp4]
 authors: Sanjay Kumar Srikakulam
 authors_structured:
 - github: sanjaysrikakulam
 components: true
-subsites: [all-eu]
+subsites: [all-eu,esg]
 ---
 
 The [9th bwHPC Symposium](https://indico.scc.kit.edu/event/3635/) took place on October 23 2023 at the University of Mannheim and offered a unique opportunity to present [Galaxy as a new cloud and HPC gateway for data-driven computational research](https://indico.scc.kit.edu/event/3635/contributions/14431/) to an actively engaged bwHPC community. The focus of the Symposium was to present scientific projects, research infrastructures, and platforms in the HPC realm and to share success stories. Galaxy fits very well into this context and the talk was a great opportunity to present Galaxy, its new features, and what all [usegalaxy.eu](https://usegalaxy.eu) offers including GTN, and TIaaS to a larger audience. The talk was well received and triggered a brief discussion on Galaxy's new features Bring Your Own Compute (BYOC) and Bring Your Own Storage (BYOS) concepts.

--- a/content/news/2023-11-13-run-in-galaxy-button-workflowhub/index.md
+++ b/content/news/2023-11-13-run-in-galaxy-button-workflowhub/index.md
@@ -5,7 +5,7 @@ tease: "Find solutions and templates in WorkflowHub, immediately import to Galax
 hide_tease: false
 subsites: [all-eu, esg]
 main_subsite: eu
-tags: [eosc-life, workflows, workflowhub.eu, repository, catalog, import, RO-crate, research object]
+tags: [eosc-life, workflows, workflowhub.eu, repository, catalog, import, RO-crate, research object, esg, esg-wp2]
 authors: Sebastian Schaaf
 authors_structured:
 - github: sebastian-schaaf

--- a/content/news/2023-11-20-workflow-search/index.md
+++ b/content/news/2023-11-20-workflow-search/index.md
@@ -1,8 +1,8 @@
 ---
-subsites: [all]
+subsites: [all, esg, all-eu]
 main_subsite: global
 date: "2023-11-20"
-tags: [training, gtn-news]
+tags: [training, gtn-news, esg, esg-wp2, esg-wp3]
 title: "[GTN news] Update: Workflow List now searches WorkflowHub.eu, advanced query syntax"
 authors: "Helena Rasche"
 external_url: 'https://training.galaxyproject.org/training-material/news/2023/11/20/workflow-search.html'

--- a/content/news/2023-12-12-tutorial-run-wfh-ds/index.md
+++ b/content/news/2023-12-12-tutorial-run-wfh-ds/index.md
@@ -1,8 +1,8 @@
 ---
-subsites: [all]
+subsites: [all, esg]
 main_subsite: global
 date: "2023-12-12"
-tags: [training, gtn-news]
+tags: [training, gtn-news, esg, esg-wp2]
 title: "[GTN news] Tutorial Feature: Easier launching of WorkflowHub &amp; Dockstore Workflows"
 authors: "Helena Rasche"
 external_url: 'https://training.galaxyproject.org/training-material/news/2023/12/12/tutorial-run-wfh-ds.html'

--- a/content/news/2023-12-14-ELIXIR-RIR-for-Galaxy-Europe/index.md
+++ b/content/news/2023-12-14-ELIXIR-RIR-for-Galaxy-Europe/index.md
@@ -2,7 +2,7 @@
 title: Galaxy Europe has been added as a new ELIXIR RIR
 date: '2023-12-14'
 tease: "usegalaxy.eu is now an ELIXIR Recommended Interoperability Resource!"
-tags: [ELIXIR, RIR, interoperability]
+tags: [ELIXIR, RIR, interoperability, esg, esg-wp1]
 authors: Sebastian Schaaf, Björn Grüning
 authors_structured:
 - github: sebastian-schaaf
@@ -12,7 +12,6 @@ supporters:
 components: true
 autotoc: true
 subsites: [all, eu, esg]
-tags: [esg, esg-wp1]
 ---
 <div class="float-right" style="max-width: 400px">
 	

--- a/content/news/2023-12-14-ELIXIR-RIR-for-Galaxy-Europe/index.md
+++ b/content/news/2023-12-14-ELIXIR-RIR-for-Galaxy-Europe/index.md
@@ -12,6 +12,7 @@ supporters:
 components: true
 autotoc: true
 subsites: [all, eu, esg]
+tags: [esg, esg-wp1]
 ---
 <div class="float-right" style="max-width: 400px">
 	

--- a/content/news/2023-12-30-annual-report-eu-galaxy/index.md
+++ b/content/news/2023-12-30-annual-report-eu-galaxy/index.md
@@ -8,7 +8,7 @@ supporters:
   - unifreiburg
   - elixir
 subsites: [freiburg, eu, esg]
-tags: [esg,elixir,galaxy]
+tags: [esg,elixir,galaxy, esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 main_subsite: eu
 ---
 The Freiburg Galaxy Team took several opportunities to present Galaxy as a FAIR 

--- a/content/news/2024-02-04-jupyterlabs/index.md
+++ b/content/news/2024-02-04-jupyterlabs/index.md
@@ -4,7 +4,8 @@ date: "2024-02-04"
 authors: Marie Jossé
 tease: "Jupyterlabs and Notebooks for earth, environment, and climate sciences"
 hide_tease: false
-subsites: [all-eu,global]
+subsites: [all-eu,global, esg]
+tags: [esg, esg-wp5]
 ---
 
 Some news on the progression of the [earth-system.usegalaxy.eu](https://earth-system.usegalaxy.eu). 

--- a/content/news/2024-02-06-oscars-project-starting/index.md
+++ b/content/news/2024-02-06-oscars-project-starting/index.md
@@ -3,7 +3,7 @@ title: The start of OSCARS - an EOSC project
 date: "2024-02-06"
 tease: "Galaxy Europe being part of the new 'Open Science Clusters' Action for Research & Society' (OSCARS)"
 hide_tease: false
-tags: [oscars]
+tags: [oscars, esg, esg-wp1]
 subsites: [all-eu, esg]
 main_subsite: eu
 ---

--- a/content/news/2024-02-27-eosc-winter-school-2024/index.md
+++ b/content/news/2024-02-27-eosc-winter-school-2024/index.md
@@ -2,7 +2,8 @@
 title: "Horizon Europe project EOSC EuroScienceGateway at EOSC Winter School 2024"
 date: "2024-02-27"
 authors: "Anika Erxleben"
-subsites: [all-eu, global]
+subsites: [all-eu, global, esg]
+tags: [esg-wp1, esg-wp2, esg-wp3, esg-wp4, esg-wp5]
 main_subsite: eu
 ---
 

--- a/content/news/2024-04-28-egu2024/index.md
+++ b/content/news/2024-04-28-egu2024/index.md
@@ -3,7 +3,8 @@ title: "Poster highlight: Implementation of a reproducible pipeline for producin
 tease: We are thrilled to highlight the poster presentation by Vanessa Stoeckl at the European Geoscience Union (EGU) Conference 2024. "
 authors: "Vanessa Stoeckl, Bjoern Gruening, Anne Fouilloux, Jean Iaquinta, Alejandro Coca-Castro"
 date: "2024-04-28"
-subsites: [global, all]
+subsites: [global, all, esg]
+tags: [esg, esg-wp5, esg-wp1]
 ---
 
 Hello, Galaxy Community!

--- a/content/news/2024-05-13-egu2024/index.md
+++ b/content/news/2024-05-13-egu2024/index.md
@@ -9,8 +9,8 @@ location:
   url: https://www.egu24.eu/
 gtn: true
 contact: "Marie Josse: marie.josse@ifremer.fr"
-tags: [conference]
-subsites: [all]
+tags: [conference, esg, esg-wp5]
+subsites: [all, esg, all-eu]
 ---
 
 The European Geosciences Union (EGU) was held at the Austria Center Vienna (ACV) and online, from the 14–19th April 2024.

--- a/content/news/2024-05-27-gtn-training-data-onedata/index.md
+++ b/content/news/2024-05-27-gtn-training-data-onedata/index.md
@@ -3,8 +3,8 @@ title: 'All GTN training data in one basket'
 date: '2024-05-27'
 tease: "Providing effortless access to GTN training data via Onedata"
 authors: Polina Polunina
-tags: [esg-wp4, esg]
-subsites: [global, all, esg]
+tags: [esg-wp4, esg, esg-wp1]
+subsites: [global, all, esg, all-eu]
 main_subsite: eu
 ---
 

--- a/content/news/2024-06-03-onedata/index.md
+++ b/content/news/2024-06-03-onedata/index.md
@@ -3,16 +3,9 @@ authors: ''
 date: '2024-06-03'
 external_url: https://training.galaxyproject.org/training-material/news/2024/06/03/onedata.html
 main_subsite: global
-subsites:
-- all
-tags:
-- training
-- gtn-news
-- news
-- esg-wp4
-- esg
-tease: As part of the EuroScienceGateway and in cooperation with Onedata and EGI we
-  are providing all GTN training data on a publicly accessible cloud storage
+subsites: [all-eu, esg, global]
+tags: [training, gtn-news, news, esg-wp4, esg]
+tease: 'As part of the EuroScienceGateway and in cooperation with Onedata and EGI we are providing all GTN training data on a publicly accessible cloud storage'
 title: All GTN training data are now automatically mirrored via Onedata
 
 ---

--- a/content/news/2024-06-10-elixir-all-hands-meeting/index.md
+++ b/content/news/2024-06-10-elixir-all-hands-meeting/index.md
@@ -8,7 +8,7 @@ supporters:
   - unifreiburg
   - elixir
 subsites: [global, freiburg, eu, esg]
-tags: [esg,elixir]
+tags: [esg,elixir,esg-wp1,esg-wp3, esg-wp4,esg-wp2, esg-wp5]
 main_subsite: eu
 ---
 The [10th ELIXIR All Hands meeting](https://elixir-events.eventscase.com/EN/ahm2024) was held in Uppsala, Sweden, from June 10 to 12, 2024. The Galaxy Europe team attended this meeting,

--- a/content/news/2024-06-21-Brussels/index.md
+++ b/content/news/2024-06-21-Brussels/index.md
@@ -3,7 +3,8 @@ title: "EOSC Coordination Meeting, Brussels, Belgium"
 tease: "The Horizon Europe EOSC project EuroScienceGateway attended the EOSC coordination meeting"
 author: "Anika Erxleben-Eggenhofer & Björn Grüning"
 date: "2024-06-20"
-subsites: [eu]
+subsites: [eu, all-eu, esg]
+tags: [esg, esg-wp1, eosc]
 ---
 
 # EOSC Coordination Meeting, Brussels: June 20-21, 2024

--- a/content/news/2024-07-01-GCC2024/index.md
+++ b/content/news/2024-07-01-GCC2024/index.md
@@ -11,8 +11,8 @@ supporters:
 - KWS
 - Limagrain
 - deNBI
-subsites: [all-eu, global, us]
-tags: [GCC-2024, CoFest, training, Elixir, EOSC, Brno]
+subsites: [all-eu, global, us, esg]
+tags: [GCC-2024, CoFest, training, Elixir, EOSC, Brno, esg, esg-wp1]
 main_subsite: eu
 ---
 

--- a/content/news/2024-07-19-GCC2024-Meeting-Report/index.md
+++ b/content/news/2024-07-19-GCC2024-Meeting-Report/index.md
@@ -4,7 +4,8 @@ tease: "Discover the highlights from GCC2024, where the Galaxy community gathere
 hide-tease: false
 authors: "Natalie Whitaker-Allen, Marisa Loach, Morgan Howells, Stuart Jackson, Julia Jakiela, Engy Nasr, Natalia Padillo-Anthemides, Shweta Pandey, Polina Polunina"
 date: "2024-07-19"
-subsites: [global,all]
+subsites: [global,all, all-eu, esg]
+tags: [esg, esg-wp1, esg-wp5]
 ---
 
 ![GCC2024 Logo](gcc2024-banner.png)

--- a/content/news/2024-09-24-Galaxy_Newsletter_Sep2024/index.md
+++ b/content/news/2024-09-24-Galaxy_Newsletter_Sep2024/index.md
@@ -4,7 +4,7 @@ tease: "Discover exciting updates, including the Galaxy Training Academy 2024, C
 hide-tease: false
 authors: "Natalie Whitaker-Allen"
 date: "2024-09-24"
-tags: ["highlight"]
+tags: [highlight, esg, esg-wp1]
 subsites: [global,all]
 ---
 

--- a/content/news/2024-10-10-egi2024/index.md
+++ b/content/news/2024-10-10-egi2024/index.md
@@ -3,7 +3,8 @@ title: 'Freiburg Galaxy team at the EGI 2024'
 date: "2024-10-10"
 tease: "Members from the Freiburg Galaxy team traveled to Lecce, Italy to participate and present the EuroScienceGateway (ESG) project at the EGI2024 meeting from 1st-3rd October."
 hide_tease: false
-subsites: [all-eu]
+subsites: [all-eu, esg]
+tags: [esg, esg-wp1, esg-wp3, esg-wp4]
 main_subsite: eu
 ---
 

--- a/content/news/2024-10-21-eoscxnfdi-joint-symposium/index.md
+++ b/content/news/2024-10-21-eoscxnfdi-joint-symposium/index.md
@@ -6,8 +6,8 @@ hide_tease: false
 supporters:
   - eurosciencegateway
   - unifreiburg
-subsites: [freiburg, eu, esg]
-tags: [esg]
+subsites: [freiburg, eu, esg, global, all-eu]
+tags: [esg, esg-wp1]
 main_subsite: eu
 ---
 

--- a/content/news/2024-12-03-eudat-conference/index.md
+++ b/content/news/2024-12-03-eudat-conference/index.md
@@ -6,8 +6,8 @@ hide_tease: false
 supporters:
 - eurosciencegateway
 - unifreiburg
-subsites: [global, freiburg, eu, esg]
-tags: [esg]
+subsites: [global, freiburg, eu, esg, all-eu]
+tags: [esg, esg-wp1, esg-wp3, esg-wp4, esg-wp2]
 main_subsite: eu
 ---
 

--- a/content/news/2024-12-30-annual-report-eu-galaxy/index.md
+++ b/content/news/2024-12-30-annual-report-eu-galaxy/index.md
@@ -8,7 +8,7 @@ supporters:
   - unifreiburg
   - elixir
 subsites: [freiburg, eu, esg]
-tags: [esg,elixir,galaxy]
+tags: [esg,elixir,galaxy, esg-wp1]
 main_subsite: eu
 ---
 The Freiburg Galaxy Team took several opportunities to present Galaxy as a FAIR 


### PR DESCRIPTION
One of our EU project ([EuroScienceGateway](https://eurosciencegateway.eu/)) use the Galaxy Hub for dissemination and outreach of its results. It has a specific [project](https://galaxyproject.org/projects/esg/) and multiple tags that are used to collect information from different Working Packages ([WP1](https://galaxyproject.org/projects/esg/news/?tag=esg-wp1), [WP2](https://galaxyproject.org/projects/esg/news/?tag=esg-wp2), [WP3](https://galaxyproject.org/projects/esg/news/?tag=esg-wp3), [WP4](https://galaxyproject.org/projects/esg/news/?tag=esg-wp4), [WP5](https://galaxyproject.org/projects/esg/news/?tag=esg-wp5)).

We noticed that there are missing news and events for some of these WPs, therefore, I went through all files that have a related keyword, and manually checked them. If they were related to EuroScienceGateway (not just exclusive EuroScienceGateway but also related posts) in my opinion, I added `esg` or appropriate `esg-wpX` tag. I grabbed the files as follows:
```
grep -rlE "EuroScienceGateway|Pulsar|EOSC|ESG|federated|WorkflowHub|esg-wp|bring-your-own|BYO|bidiversity|materials sciecne|astrophysics|TES|GA4GH" --include="*.md" .
```

Since it was a semi-manual effort, and subjective, maybe I have missed something or add a tag where I shouldn't. Please fill free to remove tags, if you find them inappropriate. Also, if you think there is a keyword that I could use to  find the missing posts (excepts those I mentioned above in the code), please let me know.