### PR TITLE
Outbound links metrics for better exit-page analysis

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -92,7 +92,7 @@ const PLAUSIBLE_PLUGIN = {
     options: {
         customDomain: "plausible.galaxyproject.eu",
         dataDomain: "galaxyproject.org",
-        outboundLinkTracking: false,
+        outboundLinkTracking: true,
     },
 };
 


### PR DESCRIPTION
@dannon I am hoping to get the full picture of where visitors are clicking (if at all) on three highly visited landing pages (`/usegalaxy/welcome/`, `/bare/eu/usegalaxy/main/`, `/ifb/`) encapsulated in the `usegalaxy.*` top-level domains. However, Plausible's exit-page metrics don't automatically capture outbound links. Instead, Plausible manages them in its Custom Goals section as a separate thing. Is [the commit](https://github.com/galaxyproject/galaxy-hub/commit/81a46c0abed4f7cdb6fde551ce617f2a6882c9d0) in this PR the equivalent of turning on Outbound Links in Plausible's Site Settings (sample screen below)...? 

![HOW-TO - Plausible - Install - Track Outbound Links 2](https://github.com/user-attachments/assets/2b8eeab3-0cc3-4630-9afe-e00758882b28)
