### PR TITLE
Use 'authors' instead of 'author'

### DIFF
--- a/content/news/2022-06-27-gcc2022-webinar-mode/index.md
+++ b/content/news/2022-06-27-gcc2022-webinar-mode/index.md
@@ -2,7 +2,7 @@
 title: 'GCC2022: Registration open for Webinar mode'
 tease: "For those that won't attend in person, the GCC Organizing Committee is happy to announce a virtual webinar-like option"
 date: "2022-06-27"
-author: beatrizserrano
+authors: beatrizserrano
 subsites: [global, all-eu]
 ---
 

--- a/content/news/2023-09-13-Galaxy-Newsletter/index.md
+++ b/content/news/2023-09-13-Galaxy-Newsletter/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Galaxy Newsletter: September 2023"
 tease: "Galaxy is excited to announce the relaunch of our Galaxy Newsletter! We are thrilled to share updates on Galaxy, including topics such as events, scientific successes, and general community announcements."
-author: "Natalie Whitaker"
+authors: "Natalie Whitaker"
 date: "2023-09-13"
 subsites: [global, all]
 ---

--- a/content/news/2023-09-29-tiaas-mgnify/index.md
+++ b/content/news/2023-09-29-tiaas-mgnify/index.md
@@ -5,7 +5,7 @@ date: '2023-09-29'
 tags: [TIaaS]
 supporters:
 - eosc
-author: Sandy Rogers
+authors: Sandy Rogers
 subsites: [all-eu, all]
 main_subsite: eu
 ---

--- a/content/news/2023-12-19-December2023-Newsletter/index.md
+++ b/content/news/2023-12-19-December2023-Newsletter/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Galaxy Newsletter: December 2023"
 tease: "Check out the December 2023 Galaxy Newsletter to learn about some of the highlights of 2023, take a look ahead into 2024, and read some of this year's top Galaxy Success Stories!"
-author: "Natalie Whitaker-Allen"
+authors: "Natalie Whitaker-Allen"
 date: "2023-12-19"
 subsites: [global, all]
 ---

--- a/content/news/2024-01-26-Galaxy Leaves Twitter/index.md
+++ b/content/news/2024-01-26-Galaxy Leaves Twitter/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Galaxy is Leaving Twitter/X"
 tease: "Effective March 31st, 2024, Galaxy will be leaving Twitter/X."
-author: "Natalie Whitaker-Allen"
+authors: "Natalie Whitaker-Allen"
 date: "2024-01-26"
 subsites: [global, all]
 ---

--- a/content/news/2024-03-18-Team-Meeting-Austin2024/index.md
+++ b/content/news/2024-03-18-Team-Meeting-Austin2024/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Galaxy Team Meeting in Austin, Texas"
 tease: "Check out what was accomplished when part of the Galaxy team got together in Austin, Texas, for a team meeting!"
-author: "Natalie Whitaker-Allen"
+authors: "Natalie Whitaker-Allen"
 date: "2024-03-19"
 subsites: [global, all]
 ---

--- a/content/news/2024-03-Galaxy-Newsletter-March2024/index.md
+++ b/content/news/2024-03-Galaxy-Newsletter-March2024/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Galaxy Newsletter: March 2024"
 tease: "Dive into the March 2024 Galaxy Newsletter!"
-author: "Natalie Whitaker-Allen"
+authors: "Natalie Whitaker-Allen"
 date: "2024-03-18"
 subsites: [global, all]
 ---

--- a/content/news/2024-06-21-Brussels/index.md
+++ b/content/news/2024-06-21-Brussels/index.md
@@ -1,7 +1,7 @@
 ---
 title: "EOSC Coordination Meeting, Brussels, Belgium"
 tease: "The Horizon Europe EOSC project EuroScienceGateway attended the EOSC coordination meeting"
-author: "Anika Erxleben-Eggenhofer & Björn Grüning"
+authors: "Anika Erxleben-Eggenhofer & Björn Grüning"
 date: "2024-06-20"
 subsites: [eu, all-eu, esg]
 tags: [esg, esg-wp1, eosc]

--- a/content/news/2024-11-28-deNBI-all-hands/index.md
+++ b/content/news/2024-11-28-deNBI-all-hands/index.md
@@ -1,7 +1,7 @@
 ---
 title: "de.NBI / ELIXIR-DE All Hands Meeting"
 tease: "The Freiburg Galaxy Team participated in the de.NBI / ELIXIR-DE All Hands Meeting"
-author: "Paul Zierep"
+authors: "Paul Zierep"
 date: "2024-11-28"
 subsites: [eu]
 ---


### PR DESCRIPTION
Just noticed multiple blog posts using 'author' instead of 'authors'.