### PR TITLE
Show all events on the ESG page

### DIFF
--- a/src/pages/projects/esg/Events.vue
+++ b/src/pages/projects/esg/Events.vue
@@ -86,8 +86,7 @@ query {
 
     recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
-            category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true},
-            has_date: {eq: true}, days_ago: {between: [1, 365]}
+            category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true}
         }
     ) {
         edges {


### PR DESCRIPTION
Unfortunately, the filter is not showing all events and there is also no way/link to get all events.

In addition, ESG is soon over, so I assume no new events/posts will be added, in this case the events page will be empty in a years time.

I have removed the filter, I hope that is ok.