### PR TITLE
Updating the event section of the EuroScienceGateway project

### DIFF
--- a/src/pages/projects/esg/Events.vue
+++ b/src/pages/projects/esg/Events.vue
@@ -86,8 +86,7 @@ query {
 
     recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
-            category: {eq: "events"}, subsites: {contains: ["esg"]}, draft: {ne: true},
-            has_date: {eq: true}, date: {between: ["2022-07-01", "2025-12-30"]}
+            category: {eq: "events"}, subsites: {contains: ["esg"]}, draft: {ne: true}
         }
     ) {
         edges {

--- a/src/pages/projects/esg/Events.vue
+++ b/src/pages/projects/esg/Events.vue
@@ -23,7 +23,7 @@
             <a href="#recent-events" aria-hidden="true"><span class="icon icon-link"></span></a>
             Recent Events
         </h2>
-        <p>Events in the past 12 months:</p>
+        <p>Events related to this project:</p>
         <table class="table table-striped">
             <thead>
                 <tr>

--- a/src/pages/projects/esg/Events.vue
+++ b/src/pages/projects/esg/Events.vue
@@ -23,7 +23,7 @@
             <a href="#recent-events" aria-hidden="true"><span class="icon icon-link"></span></a>
             Recent Events
         </h2>
-        <p>Events related to this project:</p>
+        <p>Events (co-)organized by the EuroScienceGateway:</p>
         <table class="table table-striped">
             <thead>
                 <tr>
@@ -87,7 +87,7 @@ query {
     recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
             category: {eq: "events"}, subsites: {contains: ["esg"]}, draft: {ne: true},
-            has_date: {eq: true}, days_ago: {between: [1, 1300]}
+            has_date: {eq: true}, date: {between: ["2022-07-01", "2025-12-30"]}
         }
     ) {
         edges {

--- a/src/pages/projects/esg/Events.vue
+++ b/src/pages/projects/esg/Events.vue
@@ -73,7 +73,7 @@ query {
 
     upcoming: allParentArticle(
         sortBy: "date", order: ASC, filter: {
-            category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true},
+            category: {eq: "events"}, subsites: {contains: ["esg"]}, draft: {ne: true},
             has_date: {eq: true}, days_ago: {lte: 0}
         }
     ) {
@@ -86,8 +86,8 @@ query {
 
     recent: allParentArticle(
         sortBy: "date", order: DESC, filter: {
-            category: {eq: "events"}, subsites: {contains: ["eu"]}, draft: {ne: true},
-            has_date: {eq: true}, days_ago: {between: [1, 365]}
+            category: {eq: "events"}, subsites: {contains: ["esg"]}, draft: {ne: true},
+            has_date: {eq: true}, days_ago: {between: [1, 1300]}
         }
     ) {
         edges {


### PR DESCRIPTION
I noticed two problems at EuroScienceGateway subsite.
1. When I navigated to the events page, there were many events that are not related to ESG directly, however, they are related to the Europe subsite.
2. I can only look at the events for the last 12 months.

I changed the a few things to address both. It seems fine when I build it locally.

Maybe for future: I feel there are meetings and events related to EuroScienceGateway that are available on Europe subsite and we have to find them and add metadata to them.