### PR TITLE
removing the reg link for GCC2024 and adding GBCC2025

### DIFF
--- a/content/eu/jumbotron.md
+++ b/content/eu/jumbotron.md
@@ -1,3 +1,4 @@
 <!-- Color palette: https://www.color-hex.com/color-palette/9983 -->
 
-[![GCC2024](/images/events/gcc2024/gcc2024-banner-5.png){width=430}](/events/gcc2024/)
+[![GBCC2025](https://gbcc2025.bioconductor.org/img/gbcc_logo_transparent.png){width=430}](/events/2025-06-23-gbc-c2025/)
+<p style="text-align: center">Registration is now open for <a href="http://gbcc2025.org/">GBCC2025</a></p>


### PR DESCRIPTION
@bgruening I noticed that https://galaxyproject.org/eu/ had a link to GCC2024 registration, so I removed it and replaced it with a reg link for GBCC2025.