### PR TITLE
Fix slug generation in gtn import

### DIFF
--- a/utils/gtn-import.py
+++ b/utils/gtn-import.py
@@ -99,7 +99,8 @@ for entry in feed.get("entries", []):
                 duration = int(tag.split(":", 1)[1])
             elif tag.startswith("new event-external"):
                 gtn = False
-
+        if not gtn and link.startswith("https://galaxyproject.org/events/"):
+            continue
         if geo := entry.get("georss"):
             location_raw = (
                 Nominatim(user_agent="GTN")

--- a/utils/gtn-import.py
+++ b/utils/gtn-import.py
@@ -58,7 +58,7 @@ for entry in feed.get("entries", []):
     link = entry.get("link", "")
     summary = html.unescape(entry.get("summary", ""))
 
-    slug = os.path.splitext(os.path.basename(link))[0]
+    slug = os.path.splitext(os.path.basename(link.rstrip("/")))[0]
     folder = f"{date_ymd}-{slug}" if import_type == "news" else f"{slug}"
 
     pr_exists = False

--- a/utils/gtn-import.py
+++ b/utils/gtn-import.py
@@ -1,7 +1,6 @@
 import html
 import logging
 import os
-import re
 import sys
 from datetime import datetime
 


### PR DESCRIPTION
Ensure that slug generation correctly handles URLs by removing any trailing slashes before processing. This is particularly important for external links, which may not follow the same structure as GTN links. Additionally, skip external events that link to Galaxy Hub events to avoid duplication.
This addresses https://github.com/galaxyproject/galaxy-hub/issues/3124.