### PR TITLE
Update cron schedule for GTN news/events workflow

### DIFF
--- a/.github/workflows/gtn-import.yml
+++ b/.github/workflows/gtn-import.yml
@@ -6,7 +6,7 @@ name: Galaxy Training Network news/events
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 0,8,16 * * *"
 
 jobs:
   collect:


### PR DESCRIPTION
Change the cron schedule to run the GTN news/events workflow.

| **UTC** | **CET** | **PST** |
|---------|---------|---------|
| 00:00   | 02:00   | 17:00   |
| 08:00   | 10:00   | 01:00   |
| 16:00   | 18:00   | 09:00   |