### PR TITLE
converted TIaaS to lowercase for tag search.

### DIFF
--- a/content/news/2018-10-31-tiaas-feedback/index.md
+++ b/content/news/2018-10-31-tiaas-feedback/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Maria Doyle
 date: '2018-10-31'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 subsites: [eu, pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest]

--- a/content/news/2018-11-01-elixirnl-workshop/index.md
+++ b/content/news/2018-11-01-elixirnl-workshop/index.md
@@ -2,7 +2,7 @@
 title: Enthusiastic Response to the First ELIXIR-NL Galaxy Training Course in the
   Netherlands
 date: '2018-11-01'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 - TIaaS

--- a/content/news/2019-01-25-feedback-genomics-master-course/index.md
+++ b/content/news/2019-01-25-feedback-genomics-master-course/index.md
@@ -2,7 +2,7 @@
 title: Galaxy enhances Introduction to Genomics as part of Master program in Belgrade,
   by Nevena Veljkovic
 date: '2019-01-25'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 location:
   name: Galaxy Europe
 supporters:

--- a/content/news/2019-05-20-tiaas-feedback/index.md
+++ b/content/news/2019-05-20-tiaas-feedback/index.md
@@ -1,7 +1,7 @@
 ---
 title: Another successful Galaxy workshop in Melbourne
 date: '2019-05-20'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 - TIaaS

--- a/content/news/2019-05-melbourne-workshop/index.md
+++ b/content/news/2019-05-melbourne-workshop/index.md
@@ -4,4 +4,5 @@ tease: "using UseGalaxy.eu’s Training infrastructure as a Service (TIaaS)."
 date: "2019-05-20"
 external_url: "https://usegalaxy-eu.github.io/posts/2019/05/20/tiaas-feedback/"
 subsites: [global, us]
+tags: [tiaas]
 ---

--- a/content/news/2019-06-10-tiaas-feedback/index.md
+++ b/content/news/2019-06-10-tiaas-feedback/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Nevena Veljkovic
 date: '2019-06-10'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Nevena Veljkovic

--- a/content/news/2019-06-tiaas-queue/index.md
+++ b/content/news/2019-06-tiaas-queue/index.md
@@ -2,7 +2,7 @@
 title: TIaaS Queue Status
 date: '2019-06-17'
 tease: using UseGalaxy.eu’s Training infrastructure as a Service (TIaaS).
-tags: [TIaaS, devops]
+tags: [tiaas, devops]
 location:
   name: Freiburg, Germany
 authors: hexylena

--- a/content/news/2019-08-06-gcc/index.md
+++ b/content/news/2019-08-06-gcc/index.md
@@ -2,7 +2,7 @@
 title: Galaxy Community Conference - a brief summary!
 date: '2019-08-06'
 tease: A brief summary
-tags: [TIaaS, training, GCC]
+tags: [tiaas, training, GCC]
 supporters:
 - galaxy-europe
 - TIaaS

--- a/content/news/2019-08-28-tiaa-s-update/index.md
+++ b/content/news/2019-08-28-tiaa-s-update/index.md
@@ -1,7 +1,7 @@
 ---
 title: TIaaS Queue Status Update
 date: '2019-08-28'
-tags: [devops, TIaaS]
+tags: [devops, tiaas]
 location:
   name: Freiburg, Germany
 authors: hexylena

--- a/content/news/2019-10-15-tiaas-feedback-embl-course/index.md
+++ b/content/news/2019-10-15-tiaas-feedback-embl-course/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Charles Girardot
 date: '2019-10-15'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Jelle Scholtalbers, Charles Girardot

--- a/content/news/2019-11-02-tomas-klingstroem-training-update/index.md
+++ b/content/news/2019-11-02-tomas-klingstroem-training-update/index.md
@@ -3,7 +3,7 @@ title: Training update from Tomas Klingström
 date: '2019-11-02'
 tease: Agricultural Sciences collaboration between Swedish University of Agricultural
   sciences researchers and the Agricultural Research Council in South Africa
-tags: [TIaaS, training]
+tags: [tiaas, training]
 supporters:
 - galaxy-europe
 - TIaaS

--- a/content/news/2019-11-07-tiaas-feedback-uea-course/index.md
+++ b/content/news/2019-11-07-tiaas-feedback-uea-course/index.md
@@ -1,7 +1,7 @@
 ---
 title: RNA-Seq Training feedback from Simon Moxon
 date: '2019-11-07'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 - TIaaS

--- a/content/news/2019-11-30-denbi-elixirtraining-paper/index.md
+++ b/content/news/2019-11-30-denbi-elixirtraining-paper/index.md
@@ -3,7 +3,7 @@ title: The de.NBI / ELIXIR-DE training platform - Bioinformatics training in Ger
   and across Europe within ELIXIR
 date: '2019-11-30'
 doi: 10.12688/f1000research.20244.1
-tags: [paper, training]
+tags: [paper, training, tiaas]
 supporters:
 - denbi
 - elixir

--- a/content/news/2019-12-01-tiaas-feedback-aracatuba/index.md
+++ b/content/news/2019-12-01-tiaas-feedback-aracatuba/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Giovanni Widmer
 date: '2019-12-01'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 subsites: [eu, pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest]

--- a/content/news/2019-12-03-tiaas-feedback-m2-genomics/index.md
+++ b/content/news/2019-12-03-tiaas-feedback-m2-genomics/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Ambre Jousselin
 date: '2019-12-03'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: gmauro

--- a/content/news/2019-12-10-gallantries-popup/index.md
+++ b/content/news/2019-12-10-gallantries-popup/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from the Gallantries Project
 date: '2019-12-10'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: hexylena

--- a/content/news/2020-01-20-tiaas-feedback-popp/index.md
+++ b/content/news/2020-01-20-tiaas-feedback-popp/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Denny Popp
 date: '2020-01-20'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Denny Popp

--- a/content/news/2020-02-10-tiaas-feedback-scholtz/index.md
+++ b/content/news/2020-02-10-tiaas-feedback-scholtz/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Beata Scholtz
 date: '2020-02-10'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Beata Scholtz

--- a/content/news/2020-02-tiaas/index.md
+++ b/content/news/2020-02-tiaas/index.md
@@ -2,7 +2,7 @@
 title: TIaaS Calendar and Stats site
 date: '2020-02-27'
 tease: Training Infrastructure as a Service
-tags: [devops]
+tags: [devops, tiaas]
 location:
   name: Freiburg, Germany
 authors: bgruening

--- a/content/news/2020-03-admin-finishes/index.md
+++ b/content/news/2020-03-admin-finishes/index.md
@@ -2,7 +2,7 @@
 title: de.NBI Training Infrastructure Feedback from Helena Rasche
 date: '2020-03-06'
 tease: and was wildly successful
-tags: [TIaaS, training]
+tags: [tiaas, training]
 supporters:
 - galaxy-europe
 - denbi

--- a/content/news/2020-06-08-tiaas-feedback-schulz/index.md
+++ b/content/news/2020-06-08-tiaas-feedback-schulz/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Training Infrastructure Feedback from Marcel Schulz '
 date: '2020-06-08'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Marcel Schulz

--- a/content/news/2020-07-25-tiaas-feedback-rodrigo/index.md
+++ b/content/news/2020-07-25-tiaas-feedback-rodrigo/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Rodrigo Ortega Polo
 date: '2020-07-25'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Rodrigo Ortega Polo

--- a/content/news/2020-07-27-climate-at-bcc/index.md
+++ b/content/news/2020-07-27-climate-at-bcc/index.md
@@ -2,7 +2,7 @@
 title: Climate Science at BCC2020
 date: '2020-07-27'
 tease: July has been a very busy month for Galaxy Climate
-tags: [GCC]
+tags: [GCC, tiaas]
 supporters:
 - galaxy-europe
 - eosc

--- a/content/news/2020-07-30-galaxy-africa/index.md
+++ b/content/news/2020-07-30-galaxy-africa/index.md
@@ -1,7 +1,7 @@
 ---
 title: Galaxy Africa Community Update
 date: '2020-07-30'
-tags: [training, TIaaS, GCC]
+tags: [training, tiaas, GCC]
 location:
   name: online
 supporters:

--- a/content/news/2020-09-15-ml-lessons-learned/index.md
+++ b/content/news/2020-09-15-ml-lessons-learned/index.md
@@ -2,7 +2,7 @@
 title: Remote training using Galaxy
 date: '2020-09-15'
 tease: Lessons learned from our ELIXIR Galaxy Machine Learning Workshop
-tags: [training, FAQ, TIaaS, COVID-19, report]
+tags: [training, FAQ, tiaas, COVID-19, report]
 supporters:
 - elixir
 - denbi

--- a/content/news/2020-10-14-tiaas-feedback-leighton/index.md
+++ b/content/news/2020-10-14-tiaas-feedback-leighton/index.md
@@ -2,7 +2,7 @@
 title: Training Infrastructure Feedback from Leighton Pritchard
 date: '2020-10-14'
 tease: Addressing challenges the global coronavirus pandemic
-tags: [TIaaS, training]
+tags: [tiaas, training]
 supporters:
 - galaxy-europe
 authors: Leighton Pritchard

--- a/content/news/2020-10-21-20000user/index.md
+++ b/content/news/2020-10-21-20000user/index.md
@@ -1,7 +1,7 @@
 ---
 title: 20,000 users
 date: '2020-10-21'
-tags: [galaxy, TIaaS]
+tags: [galaxy, tiaas]
 supporters:
 - denbi
 - elixir

--- a/content/news/2020-11-24-5years-report/index.md
+++ b/content/news/2020-11-24-5years-report/index.md
@@ -2,7 +2,7 @@
 title: Activity report of the last 5 years of the Freiburg Galaxy Team
 date: '2020-11-24'
 tease: Crucial infrastructure  serving more than 22,000 researchers
-tags: [data, training, tools, streetscience, COVID-19, report]
+tags: [data, training, tools, streetscience, COVID-19, report, tiaas]
 supporters:
 - unifreiburg
 - elixir

--- a/content/news/2020-11-27-eosc-nordic-article/index.md
+++ b/content/news/2020-11-27-eosc-nordic-article/index.md
@@ -1,7 +1,7 @@
 ---
 title: Insights from the first cross-training between EOSC-Life and EOSC-Nordic
 date: '2020-11-27'
-tags: [training, press, TIaaS]
+tags: [training, press, tiaas]
 supporters:
 - unifreiburg
 - elixir

--- a/content/news/2020-11-27-tiaas-feedback-ambre/index.md
+++ b/content/news/2020-11-27-tiaas-feedback-ambre/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Ambre Jousselin
 date: '2020-11-27'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Ambre Jousselin

--- a/content/news/2020-12-08-tiaas-feedback-melanie-matthias/index.md
+++ b/content/news/2020-12-08-tiaas-feedback-melanie-matthias/index.md
@@ -2,7 +2,7 @@
 title: 'Training Infrastructure Feedback on the ELIXIR Belgium workshop “DDA and DIA
   proteomic analysis in Galaxy” '
 date: '2020-12-08'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Matthias313, foellmelanie

--- a/content/news/2021-01-28-tiaas-lachlan/index.md
+++ b/content/news/2021-01-28-tiaas-lachlan/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Lachlan Gray
 date: '2021-01-28'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Lachlan Gray

--- a/content/news/2021-02-22-tiaas-mali-salmon/index.md
+++ b/content/news/2021-02-22-tiaas-mali-salmon/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Mali Salmon-Divon
 date: '2021-02-22'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Mali Salmon-Divon

--- a/content/news/2021-03-19-tiaas-tuan/index.md
+++ b/content/news/2021-03-19-tiaas-tuan/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Dr. Tuan Leng Tay
 date: '2021-03-19'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Dr. Tuan Leng Tay

--- a/content/news/2021-03-22-tiaas-martin-cech/index.md
+++ b/content/news/2021-03-22-tiaas-martin-cech/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Martin Čech
 date: '2021-03-22'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: martenson

--- a/content/news/2021-03-25-tiaas-ricardo-gonzalo-sanz/index.md
+++ b/content/news/2021-03-25-tiaas-ricardo-gonzalo-sanz/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Dr. Ricardo Gonzalo Sanz
 date: '2021-03-25'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Dr. Ricardo Gonzalo Sanz

--- a/content/news/2021-03-28-tiaas-fotis-psomopoulos/index.md
+++ b/content/news/2021-03-28-tiaas-fotis-psomopoulos/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Dr. Fotis Psomopoulos
 date: '2021-03-28'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: fpsom

--- a/content/news/2021-04-03-tiaas-simon-gladman/index.md
+++ b/content/news/2021-04-03-tiaas-simon-gladman/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Simon Gladman
 date: '2021-04-03'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 - eosc

--- a/content/news/2021-05-training-papers/index.md
+++ b/content/news/2021-05-training-papers/index.md
@@ -3,7 +3,7 @@ title: Two New Teaching Papers using Galaxy
 date: '2021-05-14'
 tease: Two hand-in-hand teaching papers have been published this week using Galaxy
   as a teaching platform.
-tags: [TIaaS, training, paper, COVID-19]
+tags: [tiaas, training, paper, COVID-19]
 authors: beatrizserrano
 authors_structured:
 - github: beatrizserrano

--- a/content/news/2021-06-10-tiaas-abdus-salam/index.md
+++ b/content/news/2021-06-10-tiaas-abdus-salam/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Infrastructure Feedback from Abdus Salam
 date: '2021-06-10'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 - eosc

--- a/content/news/2021-08-tiass-eosc-life/index.md
+++ b/content/news/2021-08-tiass-eosc-life/index.md
@@ -2,7 +2,7 @@
 title: Training Infrastructure as a Service (TIaaS) is sponsored by EOSC-Life
 date: '2021-08-24'
 tease: Anyone providing training is eligible to request the use of this service.
-tags: [TIaaS, training]
+tags: [tiaas, training]
 supporters:
 - eosc
 authors: beatrizserrano

--- a/content/news/2021-09-15-eu-server-cross-disciplinary/index.md
+++ b/content/news/2021-09-15-eu-server-cross-disciplinary/index.md
@@ -1,7 +1,7 @@
 ---
 title: UseGalaxy.eu as a cross-disciplinary platform for European researchers
 date: '2021-09-15'
-tags: [report]
+tags: [report, tiaas]
 authors: beatrizserrano
 authors_structured:
 - github: beatrizserrano

--- a/content/news/2021-10-01-tiaas-tomas/index.md
+++ b/content/news/2021-10-01-tiaas-tomas/index.md
@@ -2,7 +2,7 @@
 title: Teaching bioinformatics through blood, mucus and tears
 date: '2021-10-01'
 tease: 'Watch out for that My Little Pony baby stroller.'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: TKlingstrom

--- a/content/news/2021-10-18-tiaas-theodora-tsirka/index.md
+++ b/content/news/2021-10-18-tiaas-theodora-tsirka/index.md
@@ -3,7 +3,7 @@ title: Training Infrastructure Feedback from Dr. Theodora Tsirka
 date: '2021-10-18'
 tease: We have received feedback about TIaaS from Dr. Theodora Tsirka, during the Training School on Microbiome Sequencing and Data Analysis
 hide_tease: true
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 - eosc

--- a/content/news/2021-11-13-tiaas-anne/index.md
+++ b/content/news/2021-11-13-tiaas-anne/index.md
@@ -2,7 +2,7 @@
 title: 'Training Infrastructure feedback: FORCeS eScience course'
 date: '2021-11-13'
 tease: 'Tools in Climate Science: Linking Observations with Modelling'
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 - eosc

--- a/content/news/2022-04-28-tiaas-hans-rudolf-lucille/index.md
+++ b/content/news/2022-04-28-tiaas-hans-rudolf-lucille/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Training Infrastructure Feedback from Hans-Rudolf Hotz and Lucille Delisle'
 date: "2022-04-28"
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 tease: 'After 2 years running the SIB "Galaxy Introduction for Life Scientists" course only online, we were super happy to stand in front of a crowd and meet again the students in person.'

--- a/content/news/2022-06-07-tiaas-stefanie-dukowic-schulze/index.md
+++ b/content/news/2022-06-07-tiaas-stefanie-dukowic-schulze/index.md
@@ -3,7 +3,7 @@ title: Training Infrastructure Feedback from Stefanie Dukowic-Schulze
 date: '2022-06-07'
 tease: Dr.
 hide_tease: true
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 authors: Stefanie Dukowic-Schulze

--- a/content/news/2023-01-10-gtn-paper/index.md
+++ b/content/news/2023-01-10-gtn-paper/index.md
@@ -3,7 +3,7 @@ title: 'New Paper "Galaxy Training: A powerful framework for teaching!"'
 date: "2023-01-10"
 tease: "Our new paper about the Galaxy Training Network has been published this week in Plos Computational Biology."
 hide_tease: true
-tags: [paper]
+tags: [paper, tiaas]
 subsites: [global]
 ---
 

--- a/content/news/2023-02-20-tlaas-training-infrastructure-as-a-service/index.md
+++ b/content/news/2023-02-20-tlaas-training-infrastructure-as-a-service/index.md
@@ -2,7 +2,7 @@
 title: 'Success Story: “TIaaS: Training Infrastructure as a Service”'
 tease: 'TIaaS allows trainees’ jobs to be run preferentially and avoids long execution times, depending on the server load. By providing access to this service, the Galaxy Training Network ensured that TIaaS would be freely available to anyone and facilitated access to an extensive catalogue of FAIR training materials.'
 date: '2023-02-20'
-tags: [TIaaS]
+tags: [tiaas]
 supporters:
 - eosc
 external_url: "https://www.eosc-life.eu/news/success-story-tlaas-training-infrastructure-as-a-service"

--- a/content/news/2023-03-29-physalia-assembly-annotation/index.md
+++ b/content/news/2023-03-29-physalia-assembly-annotation/index.md
@@ -2,7 +2,7 @@
 title: 'Using Galaxy & TIaaS to teach hands-on genome assembly and annotation'
 tease: 'On Feb. 27 to Mar. 3, we (several VGP-associated instructors) used the UseGalaxy EU infrastructure to aid in teaching an online Physalia course of 40+ students how to assemble and annotate their own genome from their browser.'
 date: '2023-03-31'
-tags: [assembly, news]
+tags: [assembly, news, tiaas]
 authors: Linelle Abueg
 authors_structured:
 - github: abueg

--- a/content/news/2023-09-12-cordi/index.md
+++ b/content/news/2023-09-12-cordi/index.md
@@ -15,7 +15,7 @@ supporters:
 - NFDI4Plants
 - ELIXIR
 components: true
-subsites: [all-eu, esg]
+subsites: [all-eu, esg, tiaas]
 ---
 
 Being a well-known infrastructure for scientific data handling, Galaxy gets increasingly recognized as a powerful solution for research data management (RDM). Thus, it simply _had_ to be represented at [CoRDI, the first 'Conference on Research Data Infrastructure'](https://www.nfdi.de/cordi-2023/?lang=en) in Karlsruhe/Germany. Starting from Sep 12th, the three-day event was geographically close to the Freiburg Team, and organized by [NFDI, the National initiative for Research Data Infrastructure](https://www.nfdi.de/?lang=en). NFDI now involves 27 consortia from three funding rounds and various scientific fields; it aims for both streamlining German RDM efforts, but also with European initiatives like EOSC. Obviously, 'joining forces' is a principle from Galaxy's center of gravity, and less obviously, Galaxy is already participating in two projects from the NFDI space...

--- a/content/news/2023-09-28-biont-workshop/index.md
+++ b/content/news/2023-09-28-biont-workshop/index.md
@@ -7,7 +7,7 @@ authors_structured:
 - github: teresa-m
 - github: bebatut
 hide_tease: false
-tags: [training]
+tags: [training, tiaas]
 subsites: [all-eu]
 main_subsite: eu
 ---

--- a/content/news/2023-09-29-tiaas-mgnify/index.md
+++ b/content/news/2023-09-29-tiaas-mgnify/index.md
@@ -2,7 +2,7 @@
 title: 'Success Story: “TIaaS: Training Infrastructure as a Service for an MGnify training”'
 tease: 'The MGnify team of EMBL-EBI have used TIaaS to run the MGnify Interactive Tool on scale'
 date: '2023-09-29'
-tags: [TIaaS]
+tags: [tiaas]
 supporters:
 - eosc
 authors: Sandy Rogers

--- a/content/news/2023-12-14-ELIXIR-RIR-for-Galaxy-Europe/index.md
+++ b/content/news/2023-12-14-ELIXIR-RIR-for-Galaxy-Europe/index.md
@@ -2,7 +2,7 @@
 title: Galaxy Europe has been added as a new ELIXIR RIR
 date: '2023-12-14'
 tease: "usegalaxy.eu is now an ELIXIR Recommended Interoperability Resource!"
-tags: [ELIXIR, RIR, interoperability, esg, esg-wp1]
+tags: [ELIXIR, RIR, interoperability, esg, esg-wp1, tiaas]
 authors: Sebastian Schaaf, Björn Grüning
 authors_structured:
 - github: sebastian-schaaf

--- a/content/news/2023-12-19-December2023-Newsletter/index.md
+++ b/content/news/2023-12-19-December2023-Newsletter/index.md
@@ -3,6 +3,7 @@ title: "Galaxy Newsletter: December 2023"
 tease: "Check out the December 2023 Galaxy Newsletter to learn about some of the highlights of 2023, take a look ahead into 2024, and read some of this year's top Galaxy Success Stories!"
 authors: "Natalie Whitaker-Allen"
 date: "2023-12-19"
+tags: [tiaas]
 subsites: [global, all]
 ---
 

--- a/content/news/2024-11-15-tiaas-hans-rudolf-lucille/index.md
+++ b/content/news/2024-11-15-tiaas-hans-rudolf-lucille/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Training Infrastructure Feedback from Hans-Rudolf Hotz and Lucille Delisle'
 date: "2024-11-15"
-tags: [training, TIaaS]
+tags: [training, tiaas]
 supporters:
 - galaxy-europe
 tease: 'We were super happy to stand in front of a group of highly motivated people to teach them galaxy and workflows.'

--- a/content/news/2025-03-18-assembly-galaxy/index.md
+++ b/content/news/2025-03-18-assembly-galaxy/index.md
@@ -4,7 +4,7 @@ date: "2025-03-18"
 authors: Saim Momin
 tease: "Know how Galaxy is contributing towards Genome Assembly and Annotation with cutting-edge tools, global biodiversity projects, and training initiatives"
 subsites: [global,eu,us,freiburg,esg]
-tags: [esg, esg-wp5]
+tags: [esg, esg-wp5, tiaas]
 ---
 
 The field of genomics has been transformed by high-throughput sequencing and computational platforms, with Galaxy emerging as a pivotal resource for genome assembly and annotation. Developed as an open-source, web-based platform, Galaxy facilitates reproducible, scalable, and accessible genomic analyses. Its contributions span tailored tools, involvement in landmark biodiversity projects, innovative quality control developments, and extensive training initiatives.

--- a/content/news/2025-05-05-Empowering-Wet-Lab-Scientists-with-NGS-Analysis-Skills-Without-Coding-Barriers/index.md
+++ b/content/news/2025-05-05-Empowering-Wet-Lab-Scientists-with-NGS-Analysis-Skills-Without-Coding-Barriers/index.md
@@ -2,7 +2,7 @@
 title: "Empowering Wet Lab Scientists with NGS Analysis Skills Without Coding Barriers"
 tease: "Teaching NGS to wet lab scientists got a whole lot easier once I discovered TIaaS and the Galaxy platform."
 date: "2025-05-08"
-tags: [TIaaS, esg-wp1, esg]
+tags: [tiaas, esg-wp1, esg]
 supporters: [eosc, unifreiburg, denbi, elixir, eurosciencegateway]
 subsites: [eu, esg]
 main_subsite: eu

--- a/content/news/2025-05-12-tiaas-success-story-morard/index.md
+++ b/content/news/2025-05-12-tiaas-success-story-morard/index.md
@@ -2,7 +2,7 @@
 title: "Empowering Genomics Education with Galaxy TIaaS"
 tease: "TIaaS and Galaxy are transforming how we teach genomics—making hands-on bioinformatics accessible to every student, no coding required."
 date: "2025-05-12"
-tags: [TIaaS, esg-wp1, esg, gtn]
+tags: [tiaas, esg-wp1, esg, gtn]
 supporters: [eosc, unifreiburg, denbi, elixir, eurosciencegateway]
 subsites: [eu, esg]
 main_subsite: eu

--- a/content/news/2025-05-15-tiaas-success-story-davila/index.md
+++ b/content/news/2025-05-15-tiaas-success-story-davila/index.md
@@ -2,7 +2,7 @@
 title: "Streamlining Bioinformatics Training with Galaxy TIaaS: A Wet Lab Success Story"
 tease: "No more setup headaches—TIaaS lets us deliver scalable, hands-on bioinformatics training that just works."
 date: "2025-05-15"
-tags: [TIaaS, esg-wp1, esg, gtn]
+tags: [tiaas, esg-wp1, esg, gtn]
 supporters: [eosc, unifreiburg, denbi, elixir, eurosciencegateway]
 subsites: [eu, esg]
 main_subsite: eu

--- a/content/news/2025-05-18-tiaas-success-story-dukowic-schulze/index.md
+++ b/content/news/2025-05-18-tiaas-success-story-dukowic-schulze/index.md
@@ -2,7 +2,7 @@
 title: 'Training Infrastructure Feedback from the MSc Program „Translational Medical Research“ (TMR), Medical Faculty of Mannheim, University of Heidelberg; WS 2024/25'
 tease: "From sequencing to R scripting—TIaaS helped us turn RNA-Seq into a hands-on learning success for future medical researchers."
 date: "2025-05-18"
-tags: [TIaaS, esg-wp1, esg, gtn]
+tags: [tiaas, esg-wp1, esg, gtn]
 supporters: [eosc, unifreiburg, denbi, elixir, eurosciencegateway]
 subsites: [eu, esg]
 main_subsite: eu

--- a/content/news/2025-05-19-bge-workshops/index.md
+++ b/content/news/2025-05-19-bge-workshops/index.md
@@ -4,6 +4,7 @@ date: "2025-05-19"
 authors: Tom Brown, Diego De Panis
 tease: "Using the Galaxy infrastructure and workflows to teach de-novo genome assembly and annotation"
 subsites: [global,eu,all]
+tags: [tiaas]
 main_subsite: eu
 ---
 

--- a/content/news/2025-05-23-tiaas-success-story-toivonen/index.md
+++ b/content/news/2025-05-23-tiaas-success-story-toivonen/index.md
@@ -2,7 +2,7 @@
 title: "Training Infrastructure as a service (TIaaS) Feedback from Dr. Janne M. Toivonen"
 tease: "Thanks to TIaaS, our RNA-Seq workshops run smoothly—no more delays, just effective hands-on learning."
 date: "2025-05-23"
-tags: [TIaaS, esg-wp1, esg, gtn]
+tags: [tiaas, esg-wp1, esg, gtn]
 supporters: [eosc, unifreiburg, denbi, elixir, eurosciencegateway]
 subsites: [eu, esg]
 main_subsite: eu


### PR DESCRIPTION
There was a [PR](https://github.com/galaxyproject/galaxy-hub/pull/3130) by Laila to add search tag feature. Unfortunately, it did not work with https://galaxyproject.org/news/?tag=TIaaS but worked for other searches such as https://galaxyproject.org/news/?tag=paper . Our guess was the case sensitive search. For this specific case, I changed the files that had TIaaS as a tag with the following search: `grep -FRl 'TIaaS' content/events/ --include='*.md'`. I have added it for a few posts that the tag was missing. It works now when I built the website locally.

I believe this PR will fix [this issue](https://github.com/galaxyproject/galaxy-hub/issues/2524).