### PR TITLE
updating the admin docs link

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -9,7 +9,7 @@ Each new Galaxy is released with extensive [notes](https://docs.galaxyproject.or
 
 ## Administration
 
-Documentation for administering Galaxy can be found [here](/admin/).
+Documentation for administering Galaxy can be found [here](https://docs.galaxyproject.org/en/master/admin/index.html).
 
 ## Docs with code
 


### PR DESCRIPTION
@jdavcs After sitting with this a little while, I think that this page should continue to exist. It's really an index page, trying to answer the question "but WHAT docs are you looking for?"  I updated the admin link to point to the readthedocs output, and really, the biggest problem I currently have with this page is really the admin docs it's pointing to, where the text 

`This documentation is in the midst of being ported and unified based on resources from [old wiki](https://moin.galaxyproject.org/Admin/) and [new hub](https://galaxyproject.org/admin/). These resources should be used together for now.`

Given that this bit of text is 8 years old (https://github.com/galaxyproject/galaxy/blame/5d197246ff7d9718f9a7cc645663a2b087d4d872/doc/source/admin/index.rst#L4) and `moin.galaxyproject.org` doesn't appear to exist any more, I suspect it's out of date. I would guess that bit of text should be removed, and then all will be well.