### PR TITLE
Wrote a blog post and improved two previous posts.

### DIFF
--- a/content/news/2023-09-12-cordi/index.md
+++ b/content/news/2023-09-12-cordi/index.md
@@ -4,7 +4,7 @@ date: '2023-10-12'
 tease: "The Galaxy Europe Team active at NFDI's CoRDI (Karlsruhe, Germany, Sep 12th to 14th)"
 location:
   name: Karlsruhe, Germany
-tags: [conference, talk, poster, nfdi, rdm, esg, esg-wp1]
+tags: [conference, talk, poster, nfdi, rdm, esg, esg-wp1, tiaas]
 authors: Sebastian Schaaf, Sanjay Kumar Srikakulam
 authors_structured:
 - github: sebastian-schaaf
@@ -15,7 +15,7 @@ supporters:
 - NFDI4Plants
 - ELIXIR
 components: true
-subsites: [all-eu, esg, tiaas]
+subsites: [all-eu, esg]
 ---
 
 Being a well-known infrastructure for scientific data handling, Galaxy gets increasingly recognized as a powerful solution for research data management (RDM). Thus, it simply _had_ to be represented at [CoRDI, the first 'Conference on Research Data Infrastructure'](https://www.nfdi.de/cordi-2023/?lang=en) in Karlsruhe/Germany. Starting from Sep 12th, the three-day event was geographically close to the Freiburg Team, and organized by [NFDI, the National initiative for Research Data Infrastructure](https://www.nfdi.de/?lang=en). NFDI now involves 27 consortia from three funding rounds and various scientific fields; it aims for both streamlining German RDM efforts, but also with European initiatives like EOSC. Obviously, 'joining forces' is a principle from Galaxy's center of gravity, and less obviously, Galaxy is already participating in two projects from the NFDI space...

--- a/content/news/2025-02-27-rspace-talk/index.md
+++ b/content/news/2025-02-27-rspace-talk/index.md
@@ -4,10 +4,7 @@ date: '2025-02-27'
 days: 1
 tease: "Meeting Dr. Mathes from RSpace, the Galaxy Freiburg team explored new ways to streamline research data management."
 tags: [talk,esg]
-supporters:
-- eurosciencegateway
-- denbi
-- unifreiburg
+supporters: [eurosciencegateway, denbi, unifreiburg]
 subsites: [all, esg, eu]
 ---
 On February 27, 2025, the Galaxy Freiburg team hosted Dr. Tilo Mathes from RSpace, who gave a talk titled "Research Data Management with RSpace and Galaxy".
@@ -16,10 +13,9 @@ inventory and sample management systems, and tool integration services to teams,
 RSpace has been completely open-source under [AGPL 3.0 license on GitHub](https://github.com/rspace-os) and is open for individual contributions. In this talk, Dr. Mathes presented various solutions related to
 RDM by RSpace and engaged the audience for a brainstorming session on potential Galaxy-RSpace collaboration.
 
-<figure class="figure">
-	<g-image src="./rspace1.jpg" class="figure-img img-fluid rounded" />
-	<figcaption class="figure-caption">Dr. Tilo Mathes presenting Research Data Management with RSpace and Galaxy</figcaption>
-</figure>
+![Dr. Tilo Mathes presenting Research Data Management with RSpace and Galaxy](./rspace1.jpg)
+
+*Figure: Dr. Tilo Mathes presenting Research Data Management with RSpace and Galaxy*
 
 The first part of this talk focused on vertical interoperability and how different research tools could be connected within the
 [RSpace framework](https://www.researchspace.com/blog/the-time-is-now-vertical-interoperability-between-research-tools-an-essential-enabler-for-the-fairification-of-data).
@@ -37,15 +33,20 @@ Furthermore, while the use of Persistent IDentifiers (PIDs) has become a norm fo
 PIDs are essential for connecting data, metadata, and context, as well as ensuring research reproducibility. RSpace offers various PID options such as International Generic Sample Numbers ([IGSNs](https://ev.igsn.org/)), Open Researcher and Contributor ID ([ORCID](https://orcid.org/)), Research Activity Identifier ([RAiD](https://raid.org/)), Research Organization Registry ([ROR](https://ror.org/)), and Persistent Identification of Instruments ([PIDINST](https://docs.pidinst.org/en/latest/)). Having said that, there are still unresolved issues, such as the extra focus on the design of a specific tool rather than considering the broader ecosystem, the burden that RDM can bring without a proper automation in the workflow, and a late start in a project. These could be solved via integration of existing APIs, workflows, and improving the interoperability of the new tools.
 
 <figure class="figure">
-	<g-image src="https://cdn.prod.website-files.com/60215038b8c6126015a54745/67a379b756739a12d9ef507f_data-src-image-f7fc857f-fbd5-4f0b-b5f5-0111053f19f7.png" class="figure-img img-fluid rounded" />
-	<figcaption class="figure-caption">RSpace Ecosystem Graphic (source: https://www.researchspace.com/blog/the-time-is-now-vertical-interoperability-between-research-tools-an-essential-enabler-for-the-fairification-of-data)</figcaption>
+    <img src="https://cdn.prod.website-files.com/60215038b8c6126015a54745/67a379b756739a12d9ef507f_data-src-image-f7fc857f-fbd5-4f0b-b5f5-0111053f19f7.png" 
+         class="figure-img img-fluid rounded">
+    <figcaption class="figure-caption">
+        RSpace Ecosystem Graphic (source: 
+        <a href="https://www.researchspace.com/blog/the-time-is-now-vertical-interoperability-between-research-tools-an-essential-enabler-for-the-fairification-of-data" target="_blank">
+            ResearchSpace.com
+        </a>)
+    </figcaption>
 </figure>
 
 To increase the FAIRification of research data, Galaxy and RSpace will focus on computational research with a particular emphasis on workflow integration between Galaxy and RSpace frameworks.
 This necessitates ongoing collaboration from both parties to provide feedback from various angles and to develop user-friendly tools and interfaces to reduce the technical burden.
 To accomplish this, we decided to focus on a few examples of Galaxy and RSpace integration to identify strengths and areas for improvement.
 
-<figure class="figure">
-    <g-image src="./rspace2.png" class="figure-img img-fluid rounded" />
-    <figcaption class="figure-caption">Brainstorming session between RSpace and Galaxy</figcaption>
-</figure>
+![Brainstorming session between RSpace and Galaxy](./rspace2.png)
+
+*Figure: Brainstorming session between RSpace and Galaxy*

--- a/content/news/2025-04-07-data-commons/index.md
+++ b/content/news/2025-04-07-data-commons/index.md
@@ -1,0 +1,51 @@
+---
+title: "Galaxy Team joined the EOSC Data Commons Kick-off to advance open Data Science in Europe"
+date: "2025-04-07"
+tease: "Galaxy is participating in the EOSC Data Commons project to make Science more accessible and reusable across Europe."
+tags: [eosc, meeting]
+supporters: [eosc, egi, unifreiburg]
+subsites: [all]
+main_subsite: eu
+---
+
+From 7th to 9th of April 2025, Björn Grüning and Armin Dadras attended the [kick-off meeting of the EOSC Data Commons project](https://www.egi.eu/article/eosc-data-commons-kicks-off-to-boost-open-science-in-europe/), a [EU-funded initiative (Grant No. 101188179)](https://cordis.europa.eu/project/id/101188179) aimed at enhancing research data discovery, access, and reuse across Europe. As part of [the European Galaxy team](https://usegalaxy-eu.github.io/people), we are excited to contribute our expertise in scalable, user-friendly data analysis to this collaborative effort.
+
+<figure class="figure">
+    <img src="https://www.egi.eu/_next/image/?url=https%3A%2F%2Fcdn.egi.eu%2Fapp%2Fuploads%2F2025%2F04%2FEOSC-Data-Commons-KOM-1024x683.png&w=3840&q=75" 
+         class="figure-img img-fluid rounded">
+</figure>
+
+Key goals include:
+- **AI-based Analytics-Oriented Metadata Warehouse and Discovery Service**
+- **Federation of data repositories** enhanced with scientific applications and data analytics tools
+- **Catalogue of data analytics tools** for seamless integration
+- **Execution Service** enabling the deployment and execution of analytical tools
+- **Metadata specifications** to ensure reproducibility and interoperability
+- **FAIRness assessment and reproducibility tools**, along with related policies
+
+The Galaxy team is involved in key work packages:
+
+**WP5: Data Commons Preparation (Led by [SWITCH](https://www.switch.ch/en))**
+
+We're contributing to:
+- Developing harmonized APIs for tool and data registries
+- Creating a federated Catalogue of tools
+- Implementing specifications for processing requests
+- Building applications to match datasets with suitable tools
+
+**WP6: Data Analysis Orchestration and Deployment (Led by [CESNET](https://www.cesnet.cz/en))**
+
+Our work includes:
+- Supporting deployment of analysis packages across compute infrastructures
+- Integrating established deployment mechanisms
+- Developing abstraction layers for data access
+
+These contributions leverage Galaxy's extensive experience in creating accessible, reproducible analysis platforms that serve diverse research communities.
+
+Stay tuned for more details on how Galaxy supports open and collaborative research infrastructure!
+
+Project website: https://www.eosc-data-commons.eu
+
+Official announcement: [EGI News](https://www.egi.eu/article/eosc-data-commons-kicks-off-to-boost-open-science-in-europe/)
+
+EU project details: [CORDIS](https://cordis.europa.eu/project/id/101188179)


### PR DESCRIPTION
I did:
1. Write a blog post about the Data Commons Kick off meeting.
2. Discovered that for an unknown reason to me, some pages that have images do not show the "sponsors" on the bottom of the page. An example is this post: https://galaxyproject.org/news/2025-02-27-rspace-talk/
This is the format that interfere with the sponsors widget:
```
<figure class="figure">
	<g-image src="./rspace1.jpg" class="figure-img img-fluid rounded" />
	<figcaption class="figure-caption">Dr. Tilo Mathes presenting Research Data Management with RSpace and Galaxy</figcaption>
</figure>
```
however, this:
```
<figure class="figure">
    <img src="https://cdn.prod.website-files.com/60215038b8c6126015a54745/67a379b756739a12d9ef507f_data-src-image-f7fc857f-fbd5-4f0b-b5f5-0111053f19f7.png" 
         class="figure-img img-fluid rounded">
    <figcaption class="figure-caption">
        RSpace Ecosystem Graphic (source: 
        <a href="https://www.researchspace.com/blog/the-time-is-now-vertical-interoperability-between-research-tools-an-essential-enabler-for-the-fairification-of-data" target="_blank">
            ResearchSpace.com
        </a>)
    </figcaption>
</figure>
```
and this:
```
![Dr. Tilo Mathes presenting Research Data Management with RSpace and Galaxy](./rspace1.jpg)
```
works well with the sponsers adds-on at the end of the page. From now on, I will use the simple markdown one (the last one).
3. I learned that a post has `tiaas` as a `subsite` while it should be a `tag`.