### PR TITLE
update node to 18

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - name: Install project dependencies
         run: yarn --prefer-offline


### PR DESCRIPTION
I assume this is not enough/proper. 


This PR is in a naive attempt to fix publish workflow, throwing:

```
error linkinator@6.1.2: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"
error Found incompatible module.
```


xref: https://github.com/galaxyproject/galaxy-hub/actions/runs/15577800186/job/43865985577