### PR TITLE
Added missing logo of University of Freiburg to the ESG landing page.

### DIFF
--- a/content/projects/esg/partners.yml
+++ b/content/projects/esg/partners.yml
@@ -70,3 +70,7 @@ partners:
     - name: ACK Cyfronet AGH
       image: ./partner-logos/CyfronetLogo.png
       website: https://www.cyfronet.pl/
+
+    - name: University of Freiburg
+      image: /images/logos/UFR-vorlage-designsystem-typo-farben-V1.94.png
+      website: https://www.uni-freiburg.de/


### PR DESCRIPTION
The logo of University of Freiburg was missing from the landing page of the EuroScienceGateway project. It is less beautiful now that we have 17 partners (prime number with challenging design). However, I believe we should include the logos from our partners.