### PR TITLE
Update slug generation to use entry ID

### DIFF
--- a/utils/gtn-import.py
+++ b/utils/gtn-import.py
@@ -57,7 +57,8 @@ for entry in feed.get("entries", []):
     link = entry.get("link", "")
     summary = html.unescape(entry.get("summary", ""))
 
-    slug = os.path.splitext(os.path.basename(link.rstrip("/")))[0]
+    id = entry.get("id", "")
+    slug = os.path.splitext(os.path.basename(id.rstrip("/")))[0]
     folder = f"{date_ymd}-{slug}" if import_type == "news" else f"{slug}"
 
     pr_exists = False


### PR DESCRIPTION
Change slug generation to utilize the entry ID instead of the link for improved consistency.
This should fix the folder name problem in external events like this https://github.com/galaxyproject/galaxy-hub/pull/3235