### PR TITLE
Trigger Galaxy Social on feed update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,19 +35,25 @@ jobs:
           AWS_REGION: "us-east-2" # optional: defaults to us-east-1
           SOURCE_DIR: "dist" # optional: defaults to entire repository
 
+  galaxy-social-assistant:
+    needs: publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Check for news/events content changes
+        uses: dorny/paths-filter@v3
         id: check_changes
-        run: |
-          if git diff --name-only HEAD~1 HEAD | grep -E '^content/(news|events)/' > /dev/null; then
-            echo "changes_detected=true" >> $GITHUB_OUTPUT
-          else
-            echo "changes_detected=false" >> $GITHUB_OUTPUT
-          fi
+        with:
+          filters: |
+            content:
+              - 'content/news/**'
+              - 'content/events/**'
       - name: Wait for feeds to be available
-        if: steps.check_changes.outputs.changes_detected == 'true'
+        if: steps.check_changes.outputs.content == 'true'
         run: sleep 30
       - name: Create Galaxy Social Assistant Token
-        if: steps.check_changes.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@v2
         id: galaxy-social-assistant-token
         with:
@@ -56,7 +62,7 @@ jobs:
           owner: "usegalaxy-eu"
           repositories: "galaxy-social-assistant"
       - name: Trigger Galaxy Social Assistant
-        if: steps.check_changes.outputs.changes_detected == 'true'
+        if: steps.check_changes.outputs.content == 'true'
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: feed_bot.yml


### PR DESCRIPTION
Implement checks to detect changes in the news and events content, and trigger the Galaxy Social Assistant when changes are detected.

Before this gets merged, the [GitHub app](https://github.com/apps/galaxy-social-assistant-bot) `GALAXY_SOCIAL_ASSISTANT_PRIVATE_KEY` and `GALAXY_SOCIAL_ASSISTANT_APP_ID` need to be added to the GitHub secrets and variables of this repository (Already done).
