### PR TITLE
Add CloudFront rewrites function, test, and deployment workflow

### DIFF
--- a/.github/workflows/rewrites.yml
+++ b/.github/workflows/rewrites.yml
@@ -1,0 +1,52 @@
+name: Deploy CloudFront Rewrites Function
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'deploy/rewrites.js'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'deploy/rewrites.js'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Run tests
+        run: node deploy/test-rewrites.js
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Deploy CloudFront Rewrites Function
+        uses: dhollerbach/actions.deploy-cloudfront-function@v1
+        with:
+          function-name: hub-rewrites
+          comment: Deployed from GitHub Actions
+          source-file: ./deploy/rewrites.js

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,3 @@
+# Galaxy Hub Deployment
+
+The [rewrites.js](rewrites.js) function contains a [CloudFront Viewer Request function](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html) to intercept requests and perform rewrites (redirects). See the existing rewrites for syntax. The function is automatically deployed with the [rewrites.yml](../.github/workflows/rewrites.yml) workflow.

--- a/deploy/rewrites.js
+++ b/deploy/rewrites.js
@@ -1,0 +1,25 @@
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  var patterns = [
+    { pattern: "^/bushman/?$", target: "https://usegalaxy.org/bushman/" },
+    { pattern: "^/learn/api/?$", target: "/develop/api/" },
+    { pattern: "^/admin/api/?$", target: "/develop/api/" },
+  ];
+
+  for (var i = 0; i < patterns.length; i++) {
+    var re = new RegExp(patterns[i].pattern);
+    var m = uri.match(re);
+    if (m) {
+      var dest = patterns[i].target.replace("$1", m[1]);
+      return {
+        statusCode: 302,
+        statusDescription: "Found",
+        headers: { location: { value: dest } },
+      };
+    }
+  }
+
+  return request;
+}

--- a/deploy/test-rewrites.js
+++ b/deploy/test-rewrites.js
@@ -1,0 +1,112 @@
+// deploy/test-rewrites.js
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// Load and evaluate the CloudFront function
+const functionCode = fs.readFileSync(path.join(__dirname, 'rewrites.js'), 'utf8');
+
+// CloudFront functions don't use module.exports, so we need to eval it
+// and extract the handler function
+const handler = eval(`(function() { ${functionCode}; return handler; })()`);
+
+// Helper to create test events
+function createEvent(uri) {
+  return {
+    request: {
+      uri: uri,
+      method: 'GET',
+      querystring: {},
+      headers: {}
+    }
+  };
+}
+
+// Test suite
+console.log('Running CloudFront Rewrite Function Tests...\n');
+
+let passed = 0;
+let failed = 0;
+
+function test(description, testFn) {
+  try {
+    testFn();
+    console.log(`✓ ${description}`);
+    passed++;
+  } catch (error) {
+    console.log(`✗ ${description}`);
+    console.log(`  Error: ${error.message}`);
+    failed++;
+  }
+}
+
+// Test 1: /bushman redirect
+test('Redirects /bushman to https://usegalaxy.org/bushman/', () => {
+  const event = createEvent('/bushman');
+  const result = handler(event);
+  assert.strictEqual(result.statusCode, 302);
+  assert.strictEqual(result.headers.location.value, 'https://usegalaxy.org/bushman/');
+});
+
+// Test 2: /bushman/ redirect (with trailing slash)
+test('Redirects /bushman/ to https://usegalaxy.org/bushman/', () => {
+  const event = createEvent('/bushman/');
+  const result = handler(event);
+  assert.strictEqual(result.statusCode, 302);
+  assert.strictEqual(result.headers.location.value, 'https://usegalaxy.org/bushman/');
+});
+
+// Test 3: /learn/api redirect
+test('Redirects /learn/api to /develop/api/', () => {
+  const event = createEvent('/learn/api');
+  const result = handler(event);
+  assert.strictEqual(result.statusCode, 302);
+  assert.strictEqual(result.headers.location.value, '/develop/api/');
+});
+
+// Test 4: /learn/api/ redirect (with trailing slash)
+test('Redirects /learn/api/ to /develop/api/', () => {
+  const event = createEvent('/learn/api/');
+  const result = handler(event);
+  assert.strictEqual(result.statusCode, 302);
+  assert.strictEqual(result.headers.location.value, '/develop/api/');
+});
+
+// Test 5: Non-matching URI passes through
+test('Passes through non-matching URI /other/path', () => {
+  const event = createEvent('/other/path');
+  const result = handler(event);
+  assert.strictEqual(result.uri, '/other/path');
+  assert.strictEqual(result.statusCode, undefined);
+});
+
+// Test 6: Root path passes through
+test('Passes through root path /', () => {
+  const event = createEvent('/');
+  const result = handler(event);
+  assert.strictEqual(result.uri, '/');
+  assert.strictEqual(result.statusCode, undefined);
+});
+
+// Test 7: /bushman with additional path should not match
+test('Does not redirect /bushman/extra', () => {
+  const event = createEvent('/bushman/extra');
+  const result = handler(event);
+  assert.strictEqual(result.uri, '/bushman/extra');
+  assert.strictEqual(result.statusCode, undefined);
+});
+
+// Test 8: /learn/api with additional path should not match
+test('Does not redirect /learn/api/extra', () => {
+  const event = createEvent('/learn/api/extra');
+  const result = handler(event);
+  assert.strictEqual(result.uri, '/learn/api/extra');
+  assert.strictEqual(result.statusCode, undefined);
+});
+
+// Summary
+console.log(`\n${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
The hub is currently served via nginx on an EC2 instance proxying the Hub S3 bucket. I'm moving this to CloudFront but needed a way to implement the [nginx-based rewrites](https://github.com/galaxyproject/infrastructure-playbook/blob/7a1d7068c21f370f39296f3cef2ebecc6b9e58eb/templates/nginx/galaxyproject.j2), which is now done via this function. I only added a couple testing rewrites for now and will follow up with the full set if everything works.