### PR TITLE
Fix news for Reyhane's news

### DIFF
--- a/content/news/2025-10-20-galaxy-guest-researcher/index.md
+++ b/content/news/2025-10-20-galaxy-guest-researcher/index.md
@@ -1,14 +1,12 @@
 ---
 title: "From Functional Nucleic Acids to Galaxy Training: Reflections on My Research Stay in Freiburg"
-contributions:
-  authorship: [Reyhaneh Tavakoli Koopaei]
+date: "2025-10-20"
+authors: "Reyhaneh Tavakoli Koopaei"
+tease: "Collaboration and innovation with the Galaxy Europe team"
 tags: [gtn, galaxy-europe, training, imaging, RNA, dnazyme, cleaveRNA]
-layout: news
-date: '2025-10-20'
-cover:
-  - news/images/galaxy-guest-researcher/sweet_memories_1.png
-  - news/images/galaxy-guest-researcher/sweet_memories_2.png
-coveralt: "Celebrating collaboration and innovation with the Galaxy Europe team."
+supporters: [unifreiburg, uniisfahan]
+subsites: [all]
+main_subsite: eu
 ---
 
 I am a PhD candidate in **Biochemistry** at the **University of Isfahan**, with a research focus on the application of **functional nucleic acids** in medicine — both for diagnostics and for theranostics.


### PR DESCRIPTION
Hopefully, it will work now.

ping: @reytakop, this change was suggested by @dadrasarmin. Please note for future reference:

>There are two things wrong [here](https://github.com/galaxyproject/galaxy-hub/blob/5d1de6d741cabfa2359ac230988273a0ef082973/content/news/2025-10-20-galaxy-guest-researcher/galaxy-europe-guest-researcher.md?plain=1#L4) (I think).
>
>The fine name should be "[index.md](http://index.md/)" instead of "[galaxy-europe-guest-researcher.md](http://galaxy-europe-guest-researcher.md/)"
You are using the Galaxy Training Network Metadata similar to [here](https://github.com/galaxyproject/training-material/blob/21935a3266876fc38a4ac68d45859c363533f2ec/news/_posts/2025-10-08-joined-teachV.md). However, Galaxy Hub has a different set of Metadata similar to [this](https://github.com/galaxyproject/galaxy-hub/pull/3389/files) post.
I guess, if you correct the 1st thing, it will appear on the website. For good practice, you should correct the second bullet as well.

Please check if the tease is correct and sth you like.