### PR TITLE
Add CloudFront cache invalidation for feed files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,20 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      has_new_content: ${{ steps.check_changes.outputs.content }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Check for news/events content changes
+        uses: dorny/paths-filter@v3
+        id: check_changes
+        with:
+          list-files: json
+          filters: |
+            content:
+              - added: 'content/news/**/index.md'
+              - added: 'content/events/**/index.md'
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -34,70 +45,26 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-2" # optional: defaults to us-east-1
           SOURCE_DIR: "dist" # optional: defaults to entire repository
+      - name: Invalidate CloudFront cache for feeds
+        if: steps.check_changes.outputs.content == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-1"
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/events/feed.json" "/news/feed.json"
+      - name: Wait for cache invalidation
+        if: steps.check_changes.outputs.content == 'true'
+        run: sleep 90
 
   galaxy-social-assistant:
     needs: publish
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.publish.outputs.has_new_content == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check for news/events content changes
-        uses: dorny/paths-filter@v3
-        id: check_changes
-        with:
-          list-files: json
-          filters: |
-            content:
-              - added: 'content/news/**/index.md'
-              - added: 'content/events/**/index.md'
-      - name: Wait for updated feeds to be available
-        if: steps.check_changes.outputs.content == 'true'
-        shell: python
-        run: |
-          import json
-          import re
-          import time
-          import urllib.request
-
-          files = json.loads("${{ steps.check_changes.outputs.content_files }}")
-          print(f"Checking {len(files)} new posts in feeds...")
-
-          timeout = 3600
-          start_time = time.time()
-          wait_time = 10.0
-
-          while time.time() - start_time < timeout:
-              try:
-                  all_found = True
-                  for file in files:
-                      match = re.match(r"content/(news|events)/([^/]+)/", file)
-                      if not match:
-                          print(f"Skipping invalid file path: {file}")
-                          continue
-                      feed_type, dir_name = match.groups()
-                      req = urllib.request.Request(
-                          f"https://galaxyproject.org/{feed_type}/feed.json"
-                      )
-                      with urllib.request.urlopen(req, timeout=30) as response:
-                          feed = json.load(response)
-                      if not any(
-                          f"/{feed_type}/{dir_name}/" in item["path"] for item in feed[feed_type]
-                      ):
-                          print(f"Waiting for /{feed_type}/{dir_name}/")
-                          all_found = False
-                          break
-                  if all_found:
-                      print("All content found in feeds!")
-                      exit(0)
-              except Exception as e:
-                  print(f"Error fetching feed: {e}")
-              time.sleep(wait_time)
-              wait_time = min(wait_time * 1.5, 300.0)
-          print("Timeout waiting for feeds")
-          exit(1)
       - name: Create Galaxy Social Assistant Token
-        if: steps.check_changes.outputs.content == 'true'
         uses: actions/create-github-app-token@v2
         id: galaxy-social-assistant-token
         with:
@@ -106,10 +73,10 @@ jobs:
           owner: "usegalaxy-eu"
           repositories: "galaxy-social-assistant"
       - name: Trigger Galaxy Social Assistant
-        if: steps.check_changes.outputs.content == 'true'
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: feed_bot.yml
           repo: usegalaxy-eu/galaxy-social-assistant
           token: ${{ steps.galaxy-social-assistant-token.outputs.token }}
           ref: main
+          inputs: '{"days": "1"}'


### PR DESCRIPTION
Replace polling logic with proactive CloudFront cache invalidation. Instead of waiting up to 1 hour for feeds to naturally propagate, we now invalidate the cache for feed.json files after S3 sync and wait 90 seconds for the invalidation to complete.

Changes:
- Move content change detection to publish job
- Add AWS CLI cloudfront invalidation for /events/feed.json and /news/feed.json
- Replace Python polling script with simple cache invalidation
- Simplify galaxy-social-assistant trigger to only run when new content exists
- Pass days: "1" to social bot since we just published

This builds on top of PR #3430 which identified the CloudFront caching issue.