### PR TITLE
Fix CloudFront invalidation by specifying us-east-1 region

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/events/feed.json" "/news/feed.json"
+            --paths "/events/feed.json" "/news/feed.json" \
+            --region us-east-1
       - name: Wait for cache invalidation
         if: steps.check_changes.outputs.content == 'true'
         run: sleep 90


### PR DESCRIPTION
CloudFront API operations require the us-east-1 region, I think. When we refactored to use aws-actions/configure-aws-credentials, we lost the explicit region specification for CloudFront that was in the original implementation. This caused the invalidation to fail with exit code 254 because it was trying to use us-east-2.

S3 operations correctly use us-east-2, but CloudFront operations must use us-east-1 as per AWS requirements.