### PR TITLE
Fix malformed HTML tags in legacy content

### DIFF
--- a/content/cloudman/aws/capacity-planning/index.md
+++ b/content/cloudman/aws/capacity-planning/index.md
@@ -80,7 +80,7 @@ Which [EC2 instance type(s)](http://aws.amazon.com/ec2/#instance) should you use
   </tr>
   <tr>
     <td> </td>
-    <td> <rowclass="th"style="text-align:center">1 </td>
+    <td style="text-align:center">1</td>
     <td> </td>
     <td style=" text-align:center;"> 2 </td>
     <td> </td>

--- a/content/cloudman/sharing/index.md
+++ b/content/cloudman/sharing/index.md
@@ -77,9 +77,9 @@ Below is a list of CloudMan clusters that have been shared publicly. Feel free t
 
 
 <table>
-  <tr>
-    <td> <tablewidth="100%" rowclass="th">Cluster share string</td>
-    <td> Contact info (URL, email)</td>
+  <tr class="th">
+    <th>Cluster share string</th>
+    <th>Contact info (URL, email)</th>
   </tr>
   <tr>
     <td style=" width: 65%;"> cm-d276b27d9c82cfd56c5bf3cdead0fa0b/shared/2016-06-23--00-36/</td>
@@ -87,7 +87,7 @@ Below is a list of CloudMan clusters that have been shared publicly. Feel free t
   </tr>
   <tr>
     <td> </td>
-    <td> <rowstyle="background-color: #EEE; font-weight: bold;" style="text-align: left;">Description</td>
+    <td style="background-color: #EEE; font-weight: bold; text-align: left;">Description</td>
   </tr>
   <tr>
     <td> </td>
@@ -102,7 +102,7 @@ Below is a list of CloudMan clusters that have been shared publicly. Feel free t
   </tr>
   <tr>
     <td> </td>
-    <td> <rowstyle="background-color: #EEE; font-weight: bold;" style="text-align: left;">Description</td>
+    <td style="background-color: #EEE; font-weight: bold; text-align: left;">Description</td>
   </tr>
   <tr>
     <td> </td>
@@ -117,7 +117,7 @@ Below is a list of CloudMan clusters that have been shared publicly. Feel free t
   </tr>
   <tr>
     <td> </td>
-    <td> <rowstyle="background-color: #EEE; font-weight: bold;" style="text-align: left;">Description</td>
+    <td style="background-color: #EEE; font-weight: bold; text-align: left;">Description</td>
   </tr>
   <tr>
     <td> </td>

--- a/content/people/nate/sandbox/index.md
+++ b/content/people/nate/sandbox/index.md
@@ -46,13 +46,8 @@ The DRMAA runner takes four optional plugin parameters in addition to `drmaa_lib
 These parameters control the way in which a job will be considered terminal, since different DRMs behave in different ways.  For example, DRMAA specifies a "job finished normally" state, but not all DRMs will report this state, and instead, job completion can only determined by checking job state and encountering a drmaa `InvalidJobException` exception.  These parameters are explained below:
 
 <table>
-  <tr>
-    <td> </td>
-    <td> </td>
-    <td> </td>
-    <td> </td>
-    <td> </td>
-    <td> <rowclass="th"> <code>DRMAAJobRunner <param></code>s </td>
+  <tr class="th">
+    <th colspan="6"><code>DRMAAJobRunner &lt;param&gt;</code>s</th>
   </tr>
   <tr class="th" >
     <th> <code>id</code> </th>


### PR DESCRIPTION
## Summary

Fixes genuinely broken/malformed HTML tags in legacy content files. These were likely introduced through wiki migrations or copy-paste errors and result in invalid HTML that doesn't render correctly.

**Files fixed:**
- `content/cloudman/aws/capacity-planning/index.md` - `<rowclass="th"style=...>` → proper `<td style=...>`
- `content/cloudman/sharing/index.md` - `<tablewidth=...>` and `<rowstyle=...>` → proper `<th>` and `<td style=...>`
- `content/people/nate/sandbox/index.md` - `<rowclass="th">` → proper `<th colspan=...>`

These malformed tags include:
- `<rowclass="th">` - invalid tag name (should be `<tr class="th">` or `<th>`)
- `<rowstyle="...">` - invalid tag name
- `<tablewidth="...">` - invalid attributes inside a `<td>` element

## Test plan

- [x] Verified changes don't alter intended table structure
- [ ] Pages render correctly with existing build