### PR TITLE
Fix Node 22 url.parse() error on navbar keys

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -373,12 +373,12 @@ function parseNavbarItem(rawItem, pathPrefix) {
         } else {
             item.to = rawItem.target;
         }
-        item.key = `${item.type}:${rawItem.relativeTo}:${rawItem.target}`;
+        item.key = `${item.type}|${rawItem.relativeTo}|${rawItem.target}`;
     } else if (rawItem.contents) {
         item.type = "dropdown";
         item.label = rawItem.label;
         item.contents = rawItem.contents.map((subitem) => parseNavbarItem(subitem, pathPrefix));
-        item.key = `${item.type}:` + item.contents.map((subitem) => subitem.key).join(":");
+        item.key = `${item.type}|` + item.contents.map((subitem) => subitem.key).join("|");
     }
     return item;
 }


### PR DESCRIPTION
Change navbar item key separator from : to | to avoid ERR_INVALID_ARG_VALUE when Node 22's stricter url.parse() encounters keys like "link:subsite:news/"

🤖 Generated with [Claude Code](https://claude.com/claude-code)