### PR TITLE
Astro: Add marked dependency for news feed build

### DIFF
--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -23,6 +23,7 @@
         "glob": "^13.0.0",
         "gray-matter": "^4.0.3",
         "lucide-vue-next": "^0.555.0",
+        "marked": "^17.0.1",
         "nanostores": "^1.1.0",
         "reka-ui": "^2.6.1",
         "remark-frontmatter": "^5.0.0",
@@ -7271,6 +7272,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/astro/package.json
+++ b/astro/package.json
@@ -37,6 +37,7 @@
     "glob": "^13.0.0",
     "gray-matter": "^4.0.3",
     "lucide-vue-next": "^0.555.0",
+    "marked": "^17.0.1",
     "nanostores": "^1.1.0",
     "reka-ui": "^2.6.1",
     "remark-frontmatter": "^5.0.0",


### PR DESCRIPTION
Fixes #3552.
This PR adds the missing package, [marked](https://www.npmjs.com/package/marked), required by astro/src/pages/news/feed.json.ts.