### PR TITLE
render supporters on news and event pages

### DIFF
--- a/astro/src/components/content/SupporterGrid.astro
+++ b/astro/src/components/content/SupporterGrid.astro
@@ -1,0 +1,161 @@
+---
+import type { SupporterProfile } from '../../utils/supporters';
+
+interface Props {
+  supporters: SupporterProfile[];
+  title?: string;
+}
+
+const { supporters = [], title = 'Supporters' } = Astro.props;
+---
+
+{
+  supporters.length > 0 && (
+    <section class="supporter-section" aria-label={title}>
+      <h2 class="supporter-heading">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-5 w-5 text-galaxy-primary"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M7 8h10M7 12h4m1 8l-4-2-4 2V5a2 2 0 012-2h12a2 2 0 012 2v13l-4-2-4 2z"
+          />
+        </svg>
+        {title}
+      </h2>
+
+      <div class="supporter-grid">
+        {supporters.map((supporter) => (
+          <a
+            href={supporter.website || '#'}
+            class:list={['supporter-card', { 'pointer-events-none': !supporter.website }]}
+            target={supporter.website ? '_blank' : undefined}
+            rel={supporter.website ? 'noopener noreferrer' : undefined}
+            data-supporter-card
+          >
+            <div class="supporter-media">
+              {supporter.image ? (
+                <img src={supporter.image} alt={supporter.name} loading="lazy" class="supporter-logo" />
+              ) : (
+                <div class="supporter-placeholder" aria-hidden="true">
+                  {supporter.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </div>
+            <div class="supporter-text">
+              <p class="supporter-name">{supporter.name}</p>
+              {supporter.website && (
+                <p class="supporter-url">
+                  {(() => {
+                    try {
+                      return new URL(supporter.website).hostname.replace(/^www\./, '');
+                    } catch {
+                      return supporter.website;
+                    }
+                  })()}
+                </p>
+              )}
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+<style>
+  .supporter-section {
+    background: linear-gradient(135deg, rgba(37, 83, 123, 0.04), rgba(252, 185, 0, 0.04));
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+  }
+
+  .supporter-heading {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #1f2937;
+  }
+
+  .supporter-grid {
+    margin-top: 1rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .supporter-card {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    background: white;
+    text-decoration: none;
+    transition:
+      transform 120ms ease,
+      box-shadow 120ms ease,
+      border-color 120ms ease;
+    color: inherit;
+  }
+
+  .supporter-card:hover {
+    transform: translateY(-1px);
+    border-color: var(--color-galaxy-gold, #fcb900);
+    box-shadow: 0 8px 20px rgba(31, 41, 55, 0.08);
+  }
+
+  .supporter-media {
+    width: 56px;
+    height: 56px;
+    display: grid;
+    place-items: center;
+    background: #f9fafb;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    border: 1px solid #eef2f7;
+  }
+
+  .supporter-logo {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  .supporter-placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    color: #6b7280;
+    font-weight: 700;
+    font-size: 1rem;
+    background: linear-gradient(135deg, #f8fafc, #e5e7eb);
+  }
+
+  .supporter-text {
+    min-width: 0;
+  }
+
+  .supporter-name {
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0;
+  }
+
+  .supporter-url {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #6b7280;
+  }
+</style>

--- a/astro/src/layouts/ArticleLayout.astro
+++ b/astro/src/layouts/ArticleLayout.astro
@@ -1,6 +1,8 @@
 ---
 import BaseLayout from './BaseLayout.astro';
 import PageHeader from '../components/layout/PageHeader.astro';
+import SupporterGrid from '../components/content/SupporterGrid.astro';
+import type { SupporterProfile } from '../utils/supporters';
 
 interface Props {
   title: string;
@@ -14,13 +16,24 @@ interface Props {
     href: string;
     label: string;
   };
+  supporters?: SupporterProfile[];
 }
 
-const { title, description, date, authors: authorsRaw = [], tags: tagsRaw = [], image, backLink } = Astro.props;
+const {
+  title,
+  description,
+  date,
+  authors: authorsRaw = [],
+  tags: tagsRaw = [],
+  image,
+  backLink,
+  supporters: supportersRaw = [],
+} = Astro.props;
 
 // Ensure arrays are never null
 const authors = authorsRaw || [];
 const tags = tagsRaw || [];
+const supporters = supportersRaw || [];
 
 // Check if we have meaningful metadata to show in header
 const hasMetadata = (title && title !== 'Galaxy Hub') || date || authors.length > 0 || tags.length > 0 || description;
@@ -45,6 +58,13 @@ const hasMetadata = (title && title !== 'Galaxy Hub') || date || authors.length 
 
     <!-- Footer -->
     <footer class="px-6 sm:px-8 pb-6 sm:pb-8 mt-8">
+      {
+        supporters.length > 0 && (
+          <div class="mb-6">
+            <SupporterGrid supporters={supporters} />
+          </div>
+        )
+      }
       {
         backLink && (
           <div class="pt-4 border-t border-gray-200">

--- a/astro/src/pages/events/[...slug].astro
+++ b/astro/src/pages/events/[...slug].astro
@@ -15,6 +15,8 @@ import Flickr from '../../components/mdx/Flickr.astro';
 import Supporters from '../../components/mdx/Supporters.astro';
 import Contacts from '../../components/mdx/Contacts.astro';
 import Insert from '../../components/mdx/Insert.astro';
+import SupporterGrid from '../../components/content/SupporterGrid.astro';
+import { resolveSupporters } from '../../utils/supporters';
 
 export async function getStaticPaths() {
   const events = await getCollection('events');
@@ -36,6 +38,7 @@ const { title, date, end, location, tags = [], tease, external_url, contacts = [
 if (external_url) {
   return Astro.redirect(external_url);
 }
+const supporters = await resolveSupporters((event as any).data.supporters);
 
 // MDX components map
 const components = {
@@ -222,6 +225,13 @@ function getLocationText(loc: typeof location): string {
 
     <!-- Event Footer -->
     <footer class="px-6 sm:px-8 pb-6 sm:pb-8 mt-8">
+      {
+        supporters.length > 0 && (
+          <div class="mb-6">
+            <SupporterGrid supporters={supporters} title="Supporters" />
+          </div>
+        )
+      }
       <div class="flex justify-between items-center pt-4 border-t border-gray-200">
         <a
           href="/events/"

--- a/astro/src/pages/news/[...slug].astro
+++ b/astro/src/pages/news/[...slug].astro
@@ -15,6 +15,7 @@ import Flickr from '../../components/mdx/Flickr.astro';
 import Supporters from '../../components/mdx/Supporters.astro';
 import Contacts from '../../components/mdx/Contacts.astro';
 import Insert from '../../components/mdx/Insert.astro';
+import { resolveSupporters } from '../../utils/supporters';
 
 export async function getStaticPaths() {
   // Get only published news articles (excludes future-dated articles)
@@ -37,6 +38,7 @@ const { title, date, authors = [], tags = [], tease, image, external_url } = art
 if (external_url) {
   return Astro.redirect(external_url);
 }
+const supporters = await resolveSupporters((article as any).data.supporters);
 
 // MDX components map
 const components = {
@@ -61,6 +63,7 @@ const components = {
   authors={authors}
   tags={tags}
   image={image}
+  supporters={supporters}
   backLink={{ href: '/news/', label: 'Back to News' }}
 >
   <Content components={components} />

--- a/astro/src/utils/supporters.ts
+++ b/astro/src/utils/supporters.ts
@@ -1,0 +1,78 @@
+export type SupporterProfile = {
+  slug: string;
+  name: string;
+  image?: string;
+  website?: string;
+};
+
+function slugify(value: string): string {
+  const normalized = String(value).trim().replace(/^@/, '');
+  return normalized
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function toArray(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => toArray(v));
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, any>;
+    if (obj.name) return [String(obj.name)];
+    if (obj.github) return [String(obj.github)];
+    if (obj.twitter) return [String(obj.twitter)];
+    return [];
+  }
+  return [String(value)];
+}
+
+let supporterMap: Map<string, SupporterProfile> | null = null;
+
+async function loadSupporterMap(): Promise<Map<string, SupporterProfile>> {
+  if (supporterMap) return supporterMap;
+
+  const { getEntry } = await import('astro:content');
+  const entry = await getEntry('datasets', 'supporters');
+  const map = new Map<string, SupporterProfile>();
+
+  const list = Array.isArray(entry?.data?.supporters) ? (entry.data.supporters as Array<Record<string, unknown>>) : [];
+
+  for (const item of list) {
+    const name = String(item.name || '').trim();
+    if (!name) continue;
+    const slug = slugify(name);
+    map.set(slug, {
+      slug,
+      name,
+      image: typeof item.image === 'string' ? item.image : undefined,
+      website: typeof item.website === 'string' ? item.website : undefined,
+    });
+  }
+
+  supporterMap = map;
+  return map;
+}
+
+export async function resolveSupporters(value: unknown): Promise<SupporterProfile[]> {
+  const map = await loadSupporterMap();
+  const names = toArray(value).filter(Boolean);
+  const seen = new Set<string>();
+  const resolved: SupporterProfile[] = [];
+
+  for (const name of names) {
+    const slug = slugify(name);
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    const mapped = map.get(slug);
+    resolved.push(
+      mapped || {
+        slug,
+        name,
+      }
+    );
+  }
+
+  return resolved;
+}

--- a/astro/tests/supporters.spec.ts
+++ b/astro/tests/supporters.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Supporters rendering', () => {
+  test('news article shows supporters', async ({ page }) => {
+    const response = await page.goto('/news/2025-10-15-egd2025/');
+    expect(response?.status()).toBe(200);
+
+    await expect(page.getByRole('heading', { name: /supporters/i })).toBeVisible();
+
+    const cards = page.locator('[data-supporter-card]');
+    await expect(cards.first()).toBeVisible();
+    expect(await cards.count()).toBeGreaterThan(0);
+    await expect(cards.filter({ hasText: /elixir/i }).first()).toBeVisible();
+  });
+
+  test('event page shows supporters', async ({ page }) => {
+    const response = await page.goto('/events/2025-admin-training-brno/');
+    expect(response?.status()).toBe(200);
+
+    await expect(page.getByRole('heading', { name: /supporters/i })).toBeVisible();
+
+    const cards = page.locator('[data-supporter-card]');
+    await expect(cards.first()).toBeVisible();
+    expect(await cards.count()).toBeGreaterThan(0);
+    await expect(cards.filter({ hasText: /cesnet/i }).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
part of https://github.com/galaxyproject/galaxy-hub/issues/3564

This PR renders supporters under news/events.

<img width="1152" height="276" alt="grafik" src="https://github.com/user-attachments/assets/372cd1b0-c702-4230-8660-9aed5703998a" />

Funders are not yet supported (in the metadata) and the GTN annotation is not yet used. I guess we can/should do this after the migration to astro is done.