### PR TITLE
add new metadata to already existing post

### DIFF
--- a/content/news/2026-01-07-hf-integration/index.md
+++ b/content/news/2026-01-07-hf-integration/index.md
@@ -2,6 +2,12 @@
 title: "Integration of the Hugging Face Hub with Galaxy"
 date: "2026-01-07"
 authors: Anup Kumar
+contributions:
+  authorship:
+    - anuprulez
+  funding:
+    - uni-freiburg
+    - nfdi4bioimage
 tease: "Galaxy users can now browse the Hugging Face Hub as a repository source, import models straight into their histories, and feed them into tools. A step-by-step example shows how to pull models from the Hugging Face Hub into Galaxy and then using the existing DocLayout-YOLO tool for document layout segmentation."
 subsites: [global,eu,us]
 main_subsite: freiburg


### PR DESCRIPTION
This PR will check if anything breaks if we add additional metadata.

Assuming this has no bad effect to the old website. I would like to propose that we add this new metadata **in attrition** to the old style to our content. The astro site will take the new metadata and once we switched we simply remove the old metadata.