### PR TITLE
Add edit on GitHub button to content pages

### DIFF
--- a/astro/src/components/ui/Icon.astro
+++ b/astro/src/components/ui/Icon.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * Simple Icon component for consistent icon usage in Astro components.
+ * Uses Heroicons-style SVG paths.
+ */
+interface Props {
+  name: 'edit' | 'external-link' | 'chevron-left' | 'calendar' | 'location' | 'link' | 'user';
+  class?: string;
+}
+
+const { name, class: className = 'h-4 w-4' } = Astro.props;
+
+const icons: Record<string, string> = {
+  edit: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z',
+  'external-link': 'M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14',
+  'chevron-left': 'M15 19l-7-7 7-7',
+  calendar: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
+  location:
+    'M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z',
+  link: 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1',
+  user: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
+};
+
+const path = icons[name];
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={path}></path>
+</svg>

--- a/astro/src/layouts/ArticleLayout.astro
+++ b/astro/src/layouts/ArticleLayout.astro
@@ -4,6 +4,7 @@ import PageHeader from '../components/layout/PageHeader.astro';
 import SupporterGrid from '../components/content/SupporterGrid.astro';
 import type { SupporterProfile } from '../utils/supporters';
 import ContentWithToc from '../components/layout/ContentWithToc.astro';
+import Icon from '../components/ui/Icon.astro';
 
 interface Heading {
   depth: number;
@@ -25,6 +26,7 @@ interface Props {
     label: string;
   };
   supporters?: SupporterProfile[];
+  sourceFile?: string;
 }
 
 const {
@@ -38,7 +40,12 @@ const {
   autotoc = false,
   headings = [],
   supporters: supportersRaw = [],
+  sourceFile,
 } = Astro.props;
+
+const editUrl = sourceFile
+  ? `https://github.com/galaxyproject/galaxy-hub/edit/master/content/${sourceFile}/index.md`
+  : undefined;
 
 // Ensure arrays are never null
 const authors = authorsRaw || [];
@@ -50,7 +57,7 @@ const hasMetadata = (title && title !== 'Galaxy Hub') || date || authors.length 
 ---
 
 <BaseLayout title={title} description={description}>
-  <article class="max-w-6xl mx-auto bg-white relative article-with-corner">
+  <article class="max-w-6xl mx-auto bg-white relative">
     {hasMetadata && <PageHeader title={title} description={description} date={date} authors={authors} tags={tags} />}
 
     {
@@ -75,23 +82,30 @@ const hasMetadata = (title && title !== 'Galaxy Hub') || date || authors.length 
         )
       }
       {
-        backLink && (
-          <div class="pt-4 border-t border-gray-200">
-            <a
-              href={backLink.href}
-              class="text-galaxy-primary hover:text-galaxy-gold flex items-center gap-1.5 font-medium transition-colors"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+        (backLink || editUrl) && (
+          <div class="flex justify-between items-center pt-4 border-t border-gray-200">
+            {backLink ? (
+              <a
+                href={backLink.href}
+                class="text-galaxy-primary hover:text-galaxy-gold flex items-center gap-1.5 font-medium transition-colors"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-              </svg>
-              {backLink.label}
-            </a>
+                <Icon name="chevron-left" />
+                {backLink.label}
+              </a>
+            ) : (
+              <span />
+            )}
+            {editUrl && (
+              <a
+                href={editUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-gray-500 hover:text-galaxy-primary flex items-center gap-1.5 transition-colors"
+              >
+                <Icon name="edit" />
+                Edit on GitHub
+              </a>
+            )}
           </div>
         )
       }
@@ -125,17 +139,5 @@ const hasMetadata = (title && title !== 'Galaxy Hub') || date || authors.length 
   .prose-galaxy :where(pre):not(:where([class~='not-prose'] *)) {
     background-color: #1f2937;
     border-radius: 0.5rem;
-  }
-
-  /* Folded corner accent - three diagonal lines */
-  .article-with-corner::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: 40px;
-    height: 40px;
-    background: repeating-linear-gradient(-45deg, transparent, transparent 6px, #ffd700 6px, #ffd700 8px);
-    clip-path: polygon(100% 0, 100% 100%, 0 100%);
   }
 </style>

--- a/astro/src/layouts/PlatformLayout.astro
+++ b/astro/src/layouts/PlatformLayout.astro
@@ -6,6 +6,7 @@
  */
 import BaseLayout from './BaseLayout.astro';
 import { marked } from 'marked';
+import Icon from '../components/ui/Icon.astro';
 
 interface PlatformInstance {
   platform_group?: string;
@@ -29,6 +30,7 @@ interface Props {
   pub_libraries?: string[];
   sponsors?: string[];
   tags?: string[];
+  sourceFile?: string;
 }
 
 const {
@@ -45,7 +47,12 @@ const {
   pub_libraries = [],
   sponsors = [],
   tags = [],
+  sourceFile,
 } = Astro.props;
+
+const editUrl = sourceFile
+  ? `https://github.com/galaxyproject/galaxy-hub/edit/master/content/${sourceFile}/index.md`
+  : undefined;
 
 // Platform group display names
 const groupNames: Record<string, string> = {
@@ -247,37 +254,37 @@ const sections = [
     <footer class="mt-12 pt-8 border-t border-gray-200">
       <div class="flex justify-between items-center">
         <a href="/use/" class="text-galaxy-primary hover:underline flex items-center gap-1">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
-          </svg>
+          <Icon name="chevron-left" />
           Back to Galaxy Servers
         </a>
-        {
-          url && (
-            <a
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-2 px-4 py-2 bg-galaxy-primary text-white rounded-md hover:bg-galaxy-primary/90 transition-colors"
-            >
-              Launch Galaxy
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+        <div class="flex items-center gap-4">
+          {
+            editUrl && (
+              <a
+                href={editUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-gray-500 hover:text-galaxy-primary flex items-center gap-1.5 transition-colors"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                />
-              </svg>
-            </a>
-          )
-        }
+                <Icon name="edit" />
+                Edit on GitHub
+              </a>
+            )
+          }
+          {
+            url && (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-2 px-4 py-2 bg-galaxy-primary text-white rounded-md hover:bg-galaxy-primary/90 transition-colors"
+              >
+                Launch Galaxy
+                <Icon name="external-link" />
+              </a>
+            )
+          }
+        </div>
       </div>
     </footer>
   </article>

--- a/astro/src/pages/[...slug].astro
+++ b/astro/src/pages/[...slug].astro
@@ -61,6 +61,7 @@ const components = {
   image={image}
   headings={headings}
   autotoc={autotoc}
+  sourceFile={article.data.slug}
 >
   <Content components={components} />
 </ArticleLayout>

--- a/astro/src/pages/events/[...slug].astro
+++ b/astro/src/pages/events/[...slug].astro
@@ -18,6 +18,7 @@ import Contacts from '../../components/mdx/Contacts.astro';
 import Insert from '../../components/mdx/Insert.astro';
 import SupporterGrid from '../../components/content/SupporterGrid.astro';
 import { resolveSupporters } from '../../utils/supporters';
+import Icon from '../../components/ui/Icon.astro';
 
 export async function getStaticPaths() {
   const events = await getCollection('events');
@@ -148,10 +149,12 @@ const schemaEvent = {
     },
   },
 };
+
+const editUrl = `https://github.com/galaxyproject/galaxy-hub/edit/master/content/${event.data.slug}/index.md`;
 ---
 
 <BaseLayout title={title || 'Event'} description={tease}>
-  <article class="max-w-6xl mx-auto bg-white relative article-with-corner">
+  <article class="max-w-6xl mx-auto bg-white relative">
     <PageHeader title={title || 'Event'} description={tease} tags={tags}>
       {/* Event-specific metadata */}
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm mt-4">
@@ -293,37 +296,33 @@ const schemaEvent = {
           href="/events/"
           class="text-galaxy-primary hover:text-galaxy-gold flex items-center gap-1.5 font-medium transition-colors"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
-          </svg>
+          <Icon name="chevron-left" />
           Back to Events
         </a>
-        {
-          external_url && (
-            <a
-              href={external_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-2 px-4 py-2 bg-galaxy-primary text-white rounded-md hover:bg-galaxy-primary/90 transition-colors"
-            >
-              Visit Event Website
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+        <div class="flex items-center gap-4">
+          <a
+            href={editUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-gray-500 hover:text-galaxy-primary flex items-center gap-1.5 transition-colors"
+          >
+            <Icon name="edit" />
+            Edit on GitHub
+          </a>
+          {
+            external_url && (
+              <a
+                href={external_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-2 px-4 py-2 bg-galaxy-primary text-white rounded-md hover:bg-galaxy-primary/90 transition-colors"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                />
-              </svg>
-            </a>
-          )
-        }
+                Visit Event Website
+                <Icon name="external-link" />
+              </a>
+            )
+          }
+        </div>
       </div>
     </footer>
 
@@ -344,17 +343,5 @@ const schemaEvent = {
 
   .prose-galaxy :where(a):not(:where([class~='not-prose'] *)):hover {
     text-decoration: underline;
-  }
-
-  /* Folded corner accent */
-  .article-with-corner::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: 40px;
-    height: 40px;
-    background: repeating-linear-gradient(-45deg, transparent, transparent 6px, #ffd700 6px, #ffd700 8px);
-    clip-path: polygon(100% 0, 100% 100%, 0 100%);
   }
 </style>

--- a/astro/src/pages/news/[...slug].astro
+++ b/astro/src/pages/news/[...slug].astro
@@ -96,6 +96,7 @@ const schemaNews = {
   autotoc={autotoc}
   supporters={supporters}
   backLink={{ href: '/news/', label: 'Back to News' }}
+  sourceFile={article.data.slug}
 >
   <Content components={components} />
   <script type="application/ld+json" is:inline set:html={JSON.stringify(schemaNews)} />

--- a/astro/src/pages/use/[...slug].astro
+++ b/astro/src/pages/use/[...slug].astro
@@ -83,6 +83,7 @@ const components = {
   pub_libraries={pub_libraries}
   sponsors={sponsors}
   tags={tagList}
+  sourceFile={platform.data.slug}
 >
   <Content components={components} />
 </PlatformLayout>


### PR DESCRIPTION
Adds an "Edit on GitHub" link to the footer of article, news, event, and platform pages. The link goes directly to the source markdown file in the content/ directory so folks can quickly propose edits.

Also cleans up the inline SVGs by adding a small Icon component, and removes those decorative corner triangles that were a bit distracting.

Closes #3588