### PR TITLE
Add contributors extraction to GTN event import

### DIFF
--- a/utils/gtn-import.py
+++ b/utils/gtn-import.py
@@ -54,6 +54,11 @@ for entry in feed.get("entries", []):
         continue
 
     authors = ", ".join(tag.get("name", "") for tag in entry.get("authors", []))
+    contributors = []
+    for contributor in entry.get("contributors", []):
+        name = contributor.get("name", "")
+        if name and name not in contributors:
+            contributors.append(name)
     link = entry.get("link", "")
     summary = html.unescape(entry.get("summary", ""))
 
@@ -132,6 +137,7 @@ for entry in feed.get("entries", []):
             "days": duration,
             "title": str(title),
             "contact": authors,
+            "contributors": contributors,
             "location": {"name": location},
             "continent": continent,
             "external_url": link,


### PR DESCRIPTION
Extract contributors from the GTN event import data and include them in the event details.
Ref: https://github.com/galaxyproject/galaxy-hub/pull/3608#issuecomment-3785076946