### PR TITLE
Fix citation table styling on statistics page

### DIFF
--- a/astro/src/build/preprocess.mjs
+++ b/astro/src/build/preprocess.mjs
@@ -283,6 +283,11 @@ function addBootstrapMarker(content) {
     'alert-dark',
     // Typography
     'lead',
+    // Tables
+    'table',
+    'table-striped',
+    'table-bordered',
+    'table-hover',
   ];
 
   let processed = content;

--- a/astro/src/build/preprocess.test.mjs
+++ b/astro/src/build/preprocess.test.mjs
@@ -226,4 +226,22 @@ describe('addBootstrapMarker', () => {
       '<a class="bs-compat btn btn-primary btn-lg">Big button</a>'
     );
   });
+
+  it('adds bs-compat marker to table elements', () => {
+    expect(addBootstrapMarker('<table class="table">Content</table>')).toBe(
+      '<table class="bs-compat table">Content</table>'
+    );
+  });
+
+  it('adds bs-compat marker to table-striped', () => {
+    expect(addBootstrapMarker('<table class="table table-striped">Content</table>')).toBe(
+      '<table class="bs-compat table table-striped">Content</table>'
+    );
+  });
+
+  it('adds bs-compat marker to table-bordered', () => {
+    expect(addBootstrapMarker('<table class="table-bordered">Content</table>')).toBe(
+      '<table class="bs-compat table-bordered">Content</table>'
+    );
+  });
 });

--- a/astro/src/styles/bootstrap-compat.css
+++ b/astro/src/styles/bootstrap-compat.css
@@ -302,6 +302,57 @@
     font-weight: 300;
     line-height: 1.6;
   }
+
+  /* Tables */
+
+  &.table {
+    width: 100%;
+    margin-bottom: 1rem;
+    color: #212529;
+    border-collapse: collapse;
+  }
+
+  &.table th,
+  &.table td {
+    padding: 0.75rem;
+    vertical-align: top;
+    border-top: 1px solid #dee2e6;
+  }
+
+  &.table thead th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #dee2e6;
+  }
+
+  &.table-striped tbody tr:nth-of-type(odd) {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  &.table-bordered {
+    border: 1px solid #dee2e6;
+  }
+
+  &.table-bordered th,
+  &.table-bordered td {
+    border: 1px solid #dee2e6;
+  }
+
+  &.table-hover tbody tr:hover {
+    background-color: rgba(0, 0, 0, 0.075);
+  }
+}
+
+/* Bootstrap .table within .prose should preserve inline styles (statistics/citations page) */
+.prose .bs-compat.table th,
+.prose .bs-compat.table td {
+  background-color: inherit;
+  color: inherit;
+}
+
+/* Restore styling for .table headers without inline background colors */
+.prose .bs-compat.table th:not([style*='background-color']) {
+  background-color: transparent;
+  color: #1f2937;
 }
 
 /* ==========================================================================
@@ -818,46 +869,6 @@
 }
 .align-items-center {
   align-items: center !important;
-}
-
-/* ==========================================================================
-   Table Utilities
-   ========================================================================== */
-
-.table {
-  width: 100%;
-  margin-bottom: 1rem;
-  color: #212529;
-  border-collapse: collapse;
-}
-
-.table th,
-.table td {
-  padding: 0.75rem;
-  vertical-align: top;
-  border-top: 1px solid #dee2e6;
-}
-
-.table thead th {
-  vertical-align: bottom;
-  border-bottom: 2px solid #dee2e6;
-}
-
-.table-striped tbody tr:nth-of-type(odd) {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-.table-bordered {
-  border: 1px solid #dee2e6;
-}
-
-.table-bordered th,
-.table-bordered td {
-  border: 1px solid #dee2e6;
-}
-
-.table-hover tbody tr:hover {
-  background-color: rgba(0, 0, 0, 0.075);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary

The citation tables on `/galaxy-project/statistics/` were broken - the inline styles for background colors and rotated headers weren't being applied because `.prose th` was overriding them.

This follows the pattern from #3611 by adding `table`/`table-striped`/`table-bordered`/`table-hover` to the Bootstrap patterns list so they get the `bs-compat` marker. The `.table` CSS is now scoped under `.bs-compat` instead of being global, which also means non-Bootstrap tables in Astro components won't accidentally pick up these styles.

Closes #3568