### PR TITLE
Refactor: extract shared metadata helpers to contributors.ts

### DIFF
--- a/astro/src/assets/gtn_icon.svg
+++ b/astro/src/assets/gtn_icon.svg
@@ -1,1 +1,0 @@
-../../../content/images/logos/gtn_icon.svg

--- a/astro/src/pages/events/[...slug].astro
+++ b/astro/src/pages/events/[...slug].astro
@@ -18,6 +18,7 @@ import Contacts from '../../components/mdx/Contacts.astro';
 import Insert from '../../components/mdx/Insert.astro';
 import SupporterGrid from '../../components/content/SupporterGrid.astro';
 import { resolveSupporters } from '../../utils/supporters';
+import { extractFunding } from '../../utils/contributors';
 import Icon from '../../components/ui/Icon.astro';
 
 export async function getStaticPaths() {
@@ -36,32 +37,14 @@ export async function getStaticPaths() {
 const { event } = Astro.props;
 const { Content, headings } = await render(event);
 
-const toArray = (value: unknown): string[] => {
-  if (!value) return [];
-  if (Array.isArray(value)) return value.flatMap((v) => toArray(v));
-  if (typeof value === 'object') {
-    const obj = value as Record<string, any>;
-    if (obj.id) return [String(obj.id)];
-    if (obj.name) return [String(obj.name)];
-    return [];
-  }
-  return [String(value)];
-};
-
 const { title, date, end, location, tags = [], tease, external_url, contacts = [], autotoc } = event.data;
 
 if (external_url) {
   return Astro.redirect(external_url);
 }
-const contributions = (event as any).data.contributions || {};
-const contributionFunding = [
-  ...toArray(contributions.funding),
-  ...toArray((event as any).data.funding),
-  ...toArray((event as any).data.infrastructure),
-  ...toArray((event as any).data.data),
-].filter(Boolean);
-const supporterSource = contributionFunding.length > 0 ? contributionFunding : (event as any).data.supporters;
-const supporters = await resolveSupporters(supporterSource);
+const eventData = event.data as Record<string, unknown>;
+const fundingIds = extractFunding(eventData);
+const supporters = await resolveSupporters(fundingIds.length > 0 ? fundingIds : eventData.supporters);
 
 // MDX components map
 const components = {

--- a/astro/src/pages/hall-of-fame/[slug].astro
+++ b/astro/src/pages/hall-of-fame/[slug].astro
@@ -3,6 +3,8 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import {
   communitySlug,
+  extractAuthors,
+  extractFunding,
   findCommunityBySlug,
   getCommunityDisplay,
   getGrantDisplay,
@@ -10,59 +12,21 @@ import {
   listContributors,
   listGrants,
   listOrganisations,
+  toArray,
 } from '../../utils/contributors';
-import gtnIcon from '../../assets/gtn_icon.svg?url';
+const gtnIcon = '/images/logos/gtn_icon.svg';
 
 type ArticleEntry = CollectionEntry<'articles'>;
 type EventEntry = CollectionEntry<'events'>;
 
 const slugify = communitySlug;
 
-function toArray(value: unknown): string[] {
-  if (!value) return [];
-  if (Array.isArray(value)) {
-    return value.flatMap((v) => toArray(v));
-  }
-  if (typeof value === 'object') {
-    const obj = value as Record<string, any>;
-    if (obj.id) return [String(obj.id)];
-    if (obj.name) return [String(obj.name)];
-    if (obj.github) return [String(obj.github)];
-    return [];
-  }
-  return [String(value)];
-}
-
-function extractAuthors(entry: ArticleEntry | EventEntry): string[] {
-  const contrib = (entry as any).data.contributions || {};
-  const contributionAuthors = [
-    ...toArray(contrib.authorship),
-    ...toArray(contrib.authors),
-    ...toArray(contrib.author),
-    ...toArray(contrib.contributors),
-  ].filter(Boolean);
-
-  if (contributionAuthors.length > 0) {
-    return contributionAuthors;
-  }
-
-  return [...toArray(entry.data.authors), ...toArray((entry as any).data.authors_structured)].filter(Boolean);
-}
-
 function normalizeCandidates(entry: ArticleEntry | EventEntry): { authors: string[]; supporters: string[] } {
-  const authors = extractAuthors(entry);
-  const contrib = (entry as any).data.contributions || {};
-  const funding = [
-    ...toArray(contrib.funding),
-    ...toArray((entry as any).data.funding),
-    ...toArray((entry as any).data.infrastructure),
-    ...toArray((entry as any).data.data),
-  ].filter(Boolean);
-  const supporters =
-    funding.length > 0
-      ? funding
-      : [...toArray(entry.data.supporters), ...toArray((entry as any).data.supporters)].filter(Boolean);
-  return { authors, supporters };
+  const data = entry.data as Record<string, unknown>;
+  return {
+    authors: extractAuthors(data),
+    supporters: extractFunding(data),
+  };
 }
 
 function matchesTarget(values: string[], targetSlug: string): { matched: boolean; display?: string } {
@@ -85,73 +49,19 @@ export async function getStaticPaths() {
   const events = await getCollection('events');
   const slugs = new Map<string, string>();
 
-  const localSlugify = (value: string): string => {
-    const normalized = String(value).trim().replace(/^@/, '');
-    return normalized
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-  };
-
-  const localToArray = (value: unknown): string[] => {
-    if (!value) return [];
-    if (Array.isArray(value)) {
-      return value.flatMap((v) => localToArray(v));
-    }
-    if (typeof value === 'object') {
-      const obj = value as Record<string, any>;
-      if (obj.name) return [String(obj.name)];
-      if (obj.github) return [String(obj.github)];
-      return [];
-    }
-    return [String(value)];
-  };
-
-  const localExtractAuthors = (entry: ArticleEntry | EventEntry) => {
-    const contrib = (entry as any).data.contributions || {};
-    const contributionAuthors = [
-      ...localToArray(contrib.authorship),
-      ...localToArray(contrib.authors),
-      ...localToArray(contrib.author),
-      ...localToArray(contrib.contributors),
-    ].filter(Boolean);
-
-    if (contributionAuthors.length > 0) {
-      return contributionAuthors;
-    }
-
-    return [...localToArray(entry.data.authors), ...localToArray((entry as any).data.authors_structured)].filter(
-      Boolean
-    );
-  };
-
-  const localNormalize = (entry: ArticleEntry | EventEntry) => {
-    const authors = localExtractAuthors(entry);
-    const contrib = (entry as any).data.contributions || {};
-    const funding = [
-      ...localToArray(contrib.funding),
-      ...localToArray((entry as any).data.funding),
-      ...localToArray((entry as any).data.infrastructure),
-      ...localToArray((entry as any).data.data),
-    ].filter(Boolean);
-    const supporters =
-      funding.length > 0
-        ? funding
-        : [...localToArray(entry.data.supporters), ...localToArray((entry as any).data.supporters)].filter(Boolean);
-    return { authors, supporters };
-  };
-
   const addSlug = (value: string, displayOverride?: string) => {
-    const s = localSlugify(value);
+    const s = communitySlug(value);
     if (s && !slugs.has(s)) {
       slugs.set(s, displayOverride || getCommunityDisplay(value) || value);
     }
   };
 
   const collect = (entry: ArticleEntry | EventEntry) => {
-    const { authors, supporters } = localNormalize(entry);
-    authors.forEach(addSlug);
-    supporters.forEach(addSlug);
+    const data = entry.data as Record<string, unknown>;
+    const authors = extractAuthors(data);
+    const supporters = extractFunding(data);
+    authors.forEach((a) => addSlug(a));
+    supporters.forEach((s) => addSlug(s));
   };
 
   articles.forEach(collect);

--- a/astro/src/pages/news/[...slug].astro
+++ b/astro/src/pages/news/[...slug].astro
@@ -16,7 +16,7 @@ import Supporters from '../../components/mdx/Supporters.astro';
 import Contacts from '../../components/mdx/Contacts.astro';
 import Insert from '../../components/mdx/Insert.astro';
 import { resolveSupporters } from '../../utils/supporters';
-import { getContributor } from '../../utils/contributors';
+import { extractAuthors, extractFunding, resolveAuthor } from '../../utils/contributors';
 
 export async function getStaticPaths() {
   // Get only published news articles (excludes future-dated articles)
@@ -35,55 +35,16 @@ export async function getStaticPaths() {
 const { article } = Astro.props;
 const { Content, headings } = await render(article);
 
-const toArray = (value: unknown): string[] => {
-  if (!value) return [];
-  if (Array.isArray(value)) return value.flatMap((v) => toArray(v));
-  if (typeof value === 'object') {
-    const obj = value as Record<string, any>;
-    if (obj.name) return [String(obj.name)];
-    return [];
-  }
-  return [String(value)];
-};
-
-const contributions = (article as any).data.contributions || {};
-const contributionAuthors = [
-  ...toArray(contributions.authorship),
-  ...toArray(contributions.authors),
-  ...toArray(contributions.author),
-  ...toArray(contributions.contributors),
-].filter(Boolean);
-
-const contributionFunding = [
-  ...toArray(contributions.funding),
-  ...toArray((article as any).data.infrastructure),
-  ...toArray((article as any).data.data),
-].filter(Boolean);
-
-const rawAuthors = toArray((article as any).data.authors);
-
-const resolveAuthor = (value: string) => {
-  const contributor = getContributor(value);
-  if (contributor) {
-    return { id: contributor.id, name: contributor.name || contributor.id };
-  }
-  return { name: value };
-};
-
-const displayAuthorsDetailed =
-  contributionAuthors.length > 0
-    ? contributionAuthors.map((id: string) => resolveAuthor(id))
-    : rawAuthors.map((name: string) => resolveAuthor(name));
+const articleData = article.data as Record<string, unknown>;
+const authorIds = extractAuthors(articleData);
+const fundingIds = extractFunding(articleData);
+const displayAuthorsDetailed = authorIds.map(resolveAuthor);
 
 const { title, date, tags = [], tease, image, external_url, autotoc } = article.data;
 if (external_url) {
   return Astro.redirect(external_url);
 }
-const supporterSource =
-  contributionFunding.length > 0
-    ? contributionFunding
-    : (article as any).data.supporters || (article as any).data.funding;
-const supporters = await resolveSupporters(supporterSource);
+const supporters = await resolveSupporters(fundingIds.length > 0 ? fundingIds : articleData.supporters);
 
 // MDX components map
 const components = {


### PR DESCRIPTION
Follow-up to #3614 - the new contributions metadata system had similar helper functions scattered across a few page files. This pulls them into `contributors.ts` so there's one place to maintain them.

Adds `toArray`, `extractAuthors`, `extractFunding`, and `resolveAuthor` as shared exports. The page files now just import and use these instead of defining their own versions.

Also removes the `gtn_icon.svg` symlink in `src/assets/` - the icon is already copied to `public/images/logos/` by preprocess, so we just reference it directly from there.

No functional changes, just cleanup.