### PR TITLE
[astro] Render tease/summary as markdown and deduplicate utilities

### DIFF
--- a/astro/src/components/events/EventsList.vue
+++ b/astro/src/components/events/EventsList.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import { useStore } from '@nanostores/vue';
-import { marked } from 'marked';
 import { currentSubsite, type SubsiteId } from '@/stores/subsiteStore';
+import { renderMarkdownInline } from '@/utils/markdown';
+import { formatDateRange } from '@/utils/dateUtils';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface EventData {
@@ -186,24 +187,6 @@ watch(selectedPastYear, (year) => {
   updateUrl(year);
 });
 
-function formatDate(date: string | undefined): string {
-  if (!date) return '';
-  return new Date(date).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
-function formatDateRange(start: string | undefined, end?: string): string {
-  if (!start) return '';
-  const startDate = new Date(start);
-  if (!end) return formatDate(start);
-  const endDate = new Date(end);
-  if (startDate.getTime() === endDate.getTime()) return formatDate(start);
-  return `${formatDate(start)} - ${formatDate(end)}`;
-}
-
 function getLocationText(location: EventData['location']): string {
   if (!location) return '';
   if (typeof location === 'string') return location;
@@ -212,10 +195,6 @@ function getLocationText(location: EventData['location']): string {
 
 function buildUrl(slug: string): string {
   return `/${slug}/`;
-}
-
-function renderTease(tease?: string): string {
-  return tease ? marked.parseInline(tease) : '';
 }
 </script>
 
@@ -251,7 +230,7 @@ function renderTease(tease?: string): string {
                   {{ event.title || 'Untitled Event' }}
                   <ExternalIcon v-if="event.externalUrl" :href="event.externalUrl" />
                 </h3>
-                <p v-if="event.tease" class="text-gray-600 mt-1" v-html="renderTease(event.tease)"></p>
+                <p v-if="event.tease" class="text-gray-600 mt-1" v-html="renderMarkdownInline(event.tease)"></p>
                 <p v-if="event.location" class="text-sm text-gray-500 mt-2 flex items-center gap-1">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/astro/src/components/layout/PageHeader.astro
+++ b/astro/src/components/layout/PageHeader.astro
@@ -5,6 +5,8 @@
  * Supports optional article metadata (date, authors, tags)
  */
 
+import { formatDate } from '../../utils/dateUtils';
+
 interface Props {
   title: string;
   description?: string;
@@ -46,21 +48,13 @@ function toDate(d: Date | string | undefined): Date | null {
   return d instanceof Date ? d : new Date(d);
 }
 
-// Format date for display
-function formatDate(d: Date | string | undefined): string {
-  const dateObj = toDate(d);
-  if (!dateObj) return '';
-  return dateObj.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-}
-
 function toISOString(d: Date | string | undefined): string {
   const dateObj = toDate(d);
   return dateObj ? dateObj.toISOString() : '';
 }
+
+// Use long format (full month names) for standalone page headers
+const formattedDate = formatDate(date, false);
 ---
 
 <header class="page-header">
@@ -77,7 +71,7 @@ function toISOString(d: Date | string | undefined): string {
         <div class="flex flex-wrap items-center gap-4 text-sm text-white/70 mt-4">
           {date && (
             <time datetime={toISOString(date)} class="font-medium">
-              {formatDate(date)}
+              {formattedDate}
             </time>
           )}
           {normalizedAuthors.length > 0 && (

--- a/astro/src/components/news/NewsList.vue
+++ b/astro/src/components/news/NewsList.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import { useStore } from '@nanostores/vue';
-import { marked } from 'marked';
 import { currentSubsite, type SubsiteId } from '@/stores/subsiteStore';
+import { renderMarkdownInline } from '@/utils/markdown';
+import { formatDate } from '@/utils/dateUtils';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface NewsArticle {
@@ -141,23 +142,8 @@ function loadMore() {
   displayCount.value += pageSize;
 }
 
-function formatDate(dateStr: string | undefined): string {
-  if (!dateStr) return '';
-  const date = new Date(dateStr);
-  if (isNaN(date.getTime())) return '';
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
 function buildUrl(slug: string): string {
   return `/${slug}/`;
-}
-
-function renderTease(tease?: string): string {
-  return tease ? marked.parseInline(tease) : '';
 }
 </script>
 
@@ -238,7 +224,7 @@ function renderTease(tease?: string): string {
           <time v-if="article.date" class="text-sm text-gray-500 mb-2 block">
             {{ formatDate(article.date) }}
           </time>
-          <p v-if="article.tease" class="text-gray-600" v-html="renderTease(article.tease)"></p>
+          <p v-if="article.tease" class="text-gray-600" v-html="renderMarkdownInline(article.tease)"></p>
           <div v-if="article.tags?.length" class="flex flex-wrap gap-2 mt-3">
             <span
               v-for="tag in article.tags.slice(0, 5)"

--- a/astro/src/components/platforms/PlatformDirectory.vue
+++ b/astro/src/components/platforms/PlatformDirectory.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { marked } from 'marked';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { renderMarkdownInline } from '@/utils/markdown';
 
 interface Platform {
   slug: string;
@@ -102,8 +102,6 @@ function getHostname(url: string): string {
     return url;
   }
 }
-
-const renderSummary = (summary?: string): string => (summary ? marked.parseInline(summary) : '');
 </script>
 
 <template>
@@ -176,7 +174,7 @@ const renderSummary = (summary?: string): string => (summary ? marked.parseInlin
             <p
               v-if="platform.summary"
               class="text-sm text-gray-600 line-clamp-3 mb-3 prose prose-sm max-w-none"
-              v-html="renderSummary(platform.summary)"
+              v-html="renderMarkdownInline(platform.summary)"
             ></p>
             <div class="flex items-center justify-between text-xs text-gray-500">
               <span v-if="platform.url" class="truncate max-w-[60%]">

--- a/astro/src/components/search/SearchPage.vue
+++ b/astro/src/components/search/SearchPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import { Input } from '@/components/ui/input';
+import { formatDate } from '@/utils/dateUtils';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface SearchEntry {
@@ -86,17 +87,6 @@ const results = computed(() => {
     })
     .slice(0, 100);
 });
-
-function formatDate(dateStr: string): string {
-  if (!dateStr) return '';
-  const date = new Date(dateStr);
-  if (isNaN(date.getTime())) return '';
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
 
 function getCollectionLabel(collection: string): string {
   const labels: Record<string, string> = {

--- a/astro/src/layouts/PlatformLayout.astro
+++ b/astro/src/layouts/PlatformLayout.astro
@@ -5,8 +5,8 @@
  * Displays platform info, instances table, and various metadata sections
  */
 import BaseLayout from './BaseLayout.astro';
-import { marked } from 'marked';
 import Icon from '../components/ui/Icon.astro';
+import { renderMarkdownInline } from '../utils/markdown';
 
 interface PlatformInstance {
   platform_group?: string;
@@ -70,8 +70,6 @@ const scopeNames: Record<string, string> = {
   domain: 'Domain Specific',
   'tool-publishing': 'Tool Publishing',
 };
-
-const renderMarkdown = (value?: string): string => (value ? marked.parseInline(value) : '');
 
 // Sections to render
 const sections = [
@@ -201,7 +199,7 @@ const sections = [
                   <th class="px-4 py-3 text-left text-sm font-medium text-gray-900 w-40 align-top">Summary:</th>
                   <td
                     class="px-4 py-3 text-sm text-gray-700 prose prose-sm max-w-none"
-                    set:html={renderMarkdown(summary)}
+                    set:html={renderMarkdownInline(summary)}
                   />
                 </tr>
               )}
@@ -223,7 +221,7 @@ const sections = [
           <h2 class="text-xl font-semibold text-gray-900 mb-3 capitalize">{section.name}</h2>
           <ul class="list-disc list-inside space-y-1 text-gray-700">
             {section.items.map((item: string) => (
-              <li class="prose prose-sm max-w-none" set:html={renderMarkdown(item)} />
+              <li class="prose prose-sm max-w-none" set:html={renderMarkdownInline(item)} />
             ))}
             {section.key === 'citations' && pub_libraries && pub_libraries.length > 0 && (
               <>

--- a/astro/src/pages/bare/fr/latest/events.astro
+++ b/astro/src/pages/bare/fr/latest/events.astro
@@ -34,20 +34,21 @@ const upcomingEvents = allEvents
   })
   .slice(0, 5);
 
-function formatDate(date: Date | string | undefined): string {
+// Compact date format without year for embedded feed display
+function formatCompactDate(date: Date | string | undefined): string {
   if (!date) return '';
   const d = typeof date === 'string' ? new Date(date) : date;
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
-function formatDateRange(start: Date | string | undefined, end: Date | string | undefined): string {
+function formatCompactDateRange(start: Date | string | undefined, end: Date | string | undefined): string {
   if (!start) return '';
-  const startStr = formatDate(start);
+  const startStr = formatCompactDate(start);
   if (!end) return startStr;
   const startD = typeof start === 'string' ? new Date(start) : start;
   const endD = typeof end === 'string' ? new Date(end) : end;
   if (startD.toDateString() === endD.toDateString()) return startStr;
-  return `${startStr} - ${formatDate(end)}`;
+  return `${startStr} - ${formatCompactDate(end)}`;
 }
 ---
 
@@ -136,7 +137,7 @@ function formatDateRange(start: Date | string | undefined, end: Date | string | 
                 <a href={`https://galaxyproject.org/events/${slug}/`} target="_blank">
                   {event.data.title}
                 </a>
-                <span class="event-date">{formatDateRange(event.data.date, event.data.date_end)}</span>
+                <span class="event-date">{formatCompactDateRange(event.data.date, event.data.date_end)}</span>
                 {locationStr && <span class="event-location"> · {locationStr}</span>}
               </div>
             );

--- a/astro/src/pages/bare/fr/latest/news.astro
+++ b/astro/src/pages/bare/fr/latest/news.astro
@@ -27,7 +27,8 @@ const newsArticles = allArticles
   })
   .slice(0, 5);
 
-function formatDate(date: Date | string | undefined): string {
+// Format date without year for compact display
+function formatCompactDate(date: Date | string | undefined): string {
   if (!date) return '';
   const d = typeof date === 'string' ? new Date(date) : date;
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
@@ -111,7 +112,7 @@ function formatDate(date: Date | string | undefined): string {
               <a href={`https://galaxyproject.org/news/${slug}/`} target="_blank">
                 {article.data.title}
               </a>
-              <span class="news-date">{formatDate(article.data.date)}</span>
+              <span class="news-date">{formatCompactDate(article.data.date)}</span>
             </div>
           );
         })

--- a/astro/src/utils/content.ts
+++ b/astro/src/utils/content.ts
@@ -4,7 +4,7 @@
  */
 
 import { getCollection, type CollectionEntry } from 'astro:content';
-import { isPublishedDate } from './dateUtils';
+import { isPublishedDate, formatDate as formatDateUtil, formatDateRange as formatDateRangeUtil } from './dateUtils';
 
 type ArticleEntry = CollectionEntry<'articles'>;
 type EventEntry = CollectionEntry<'events'>;
@@ -253,35 +253,18 @@ export async function getEventBySlug(slug: string): Promise<EventEntry | undefin
 
 /**
  * Format a date for display
+ * Re-exported from dateUtils for backward compatibility
+ * Uses long format (full month names) by default for content pages
  */
 export function formatDate(date: Date | string | undefined): string {
-  if (!date) return '';
-  const d = typeof date === 'string' ? new Date(date) : date;
-  return d.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  return formatDateUtil(date, false);
 }
 
 /**
  * Format a date range for events
+ * Re-exported from dateUtils for backward compatibility
+ * Uses long format (full month names) by default for content pages
  */
 export function formatDateRange(start: Date | string | undefined, end: Date | string | undefined): string {
-  if (!start) return '';
-
-  const startDate = typeof start === 'string' ? new Date(start) : start;
-  const endDate = end ? (typeof end === 'string' ? new Date(end) : end) : null;
-
-  if (!endDate || startDate.getTime() === endDate.getTime()) {
-    return formatDate(startDate);
-  }
-
-  // Same month
-  if (startDate.getMonth() === endDate.getMonth() && startDate.getFullYear() === endDate.getFullYear()) {
-    return `${startDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })} - ${endDate.getDate()}, ${endDate.getFullYear()}`;
-  }
-
-  // Different months
-  return `${formatDate(startDate)} - ${formatDate(endDate)}`;
+  return formatDateRangeUtil(start, end, false);
 }

--- a/astro/src/utils/dateUtils.ts
+++ b/astro/src/utils/dateUtils.ts
@@ -12,3 +12,64 @@ export function isPublishedDate(date: Date | string | undefined, now: Date = new
   const d = date instanceof Date ? date : new Date(date);
   return d <= now;
 }
+
+/**
+ * Convert a date value to a Date object
+ */
+function toDate(d: Date | string | undefined): Date | null {
+  if (!d) return null;
+  return d instanceof Date ? d : new Date(d);
+}
+
+/**
+ * Format a date for display
+ * @param date - Date to format
+ * @param short - If true, use short month names (Jan, Feb). Default true for lists.
+ * @returns Formatted date string like "Jan 15, 2024" or "January 15, 2024"
+ */
+export function formatDate(date: Date | string | undefined, short: boolean = true): string {
+  const d = toDate(date);
+  if (!d || isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: short ? 'short' : 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Format a date range for events
+ * @param start - Start date
+ * @param end - End date (optional)
+ * @param short - If true, use short month names. Default true for lists.
+ * @returns Formatted date range like "Jan 15 - 17, 2024" or "Jan 15 - Feb 2, 2024"
+ */
+export function formatDateRange(
+  start: Date | string | undefined,
+  end?: Date | string | undefined,
+  short: boolean = true
+): string {
+  if (!start) return '';
+
+  const startDate = toDate(start);
+  const endDate = toDate(end);
+
+  if (!startDate || isNaN(startDate.getTime())) return '';
+
+  // No end date or same as start
+  if (!endDate || startDate.getTime() === endDate.getTime()) {
+    return formatDate(startDate, short);
+  }
+
+  // Same month and year - show "Jan 15 - 17, 2024"
+  if (startDate.getMonth() === endDate.getMonth() && startDate.getFullYear() === endDate.getFullYear()) {
+    const monthDay = startDate.toLocaleDateString('en-US', {
+      month: short ? 'short' : 'long',
+      day: 'numeric',
+    });
+    return `${monthDay} - ${endDate.getDate()}, ${endDate.getFullYear()}`;
+  }
+
+  // Different months - show full dates
+  return `${formatDate(startDate, short)} - ${formatDate(endDate, short)}`;
+}

--- a/astro/src/utils/markdown.ts
+++ b/astro/src/utils/markdown.ts
@@ -1,0 +1,14 @@
+/**
+ * Markdown utility functions for Galaxy Hub
+ * Provides consistent markdown rendering across Vue and Astro components
+ */
+
+import { marked } from 'marked';
+
+/**
+ * Render markdown inline (no wrapping <p> tags)
+ * Use for short text like tease/summary fields that shouldn't be block elements
+ */
+export function renderMarkdownInline(text?: string): string {
+  return text ? (marked.parseInline(text) as string) : '';
+}


### PR DESCRIPTION
## Summary
- Render tease field as markdown in news/events lists so inline formatting (links, bold, etc.) displays correctly
- Consolidate duplicated date formatting and markdown rendering functions into shared utility modules (`utils/dateUtils.ts`, `utils/markdown.ts`)

Should close https://github.com/galaxyproject/galaxy-hub/issues/3648
## Test plan
- [ ] Verify news list items with markdown in tease field render correctly
- [ ] Verify events list items with markdown in tease field render correctly
- [ ] Check date formatting displays correctly in lists (short month) and page headers (long month)