### PR TITLE
Fix authors display in ArticleHeader component

### DIFF
--- a/src/components/ArticleHeader.vue
+++ b/src/components/ArticleHeader.vue
@@ -34,7 +34,7 @@
                 <p class="contact" v-if="hasContacts">
                     Contact: <Contacts :contact="article.contact" :contacts="article.contacts" />
                 </p>
-                <p class="authors" v-if="article.authors">By {{ article.authors }}</p>
+                <p class="authors" v-if="authorsDisplay">By {{ authorsDisplay }}</p>
                 <p class="date" v-if="article.date">
                     {{ articleDateStr }}
                 </p>
@@ -142,6 +142,16 @@ export default {
         },
         image() {
             return getImage(this.article.image, this.article.images);
+        },
+        authorsDisplay() {
+            const authors = this.article.authors;
+            if (!authors) {
+                return null;
+            }
+            if (Array.isArray(authors)) {
+                return authors.join(", ");
+            }
+            return authors;
         },
     },
     mounted() {


### PR DESCRIPTION
## Summary
- Fixed the authors field showing "By []" on news articles and "By [ ]" on SIG pages
- Added `authorsDisplay` computed property that properly handles both string and array author formats
- Empty or undefined authors now hide the "By" line entirely

## Test plan
- [ ] Verify news articles with string authors display correctly (e.g., `/news/2026-01-15-dataverse/`)
- [ ] Verify news articles with array authors display correctly (e.g., `/news/2025-07-10-tool-dev-workshop/`)
- [ ] Verify SIG pages no longer show "By [ ]" (e.g., `/community/sig/microbial/`)

Fixes #3650, fixes #3657