### PR TITLE
Add EMBL-EBI training course to Events

### DIFF
--- a/content/events/2026-06-15-EMBL-EBI/index.md
+++ b/content/events/2026-06-15-EMBL-EBI/index.md
@@ -1,0 +1,17 @@
+---
+title: Data science for life scientists - hands-on machine learning for biological data
+date: '2026-06-15'
+days: 5
+continent: EU
+location:
+  name: European Bioinformatics Institute, United Kingdom
+gtn: false
+contact:  EMBL-EBI Training (courses@ebi.ac.uk)
+tags: [training]
+---
+
+We are happy to share the following training course on behalf of the European Bioinformatics Institute:
+
+"We are thrilled to announce ‘Data science for life scientists: hands-on machine learning for biological data’, will run from 15 – 19 June 2026 at EMBL's European Bioinformatics Institute (EMBL-EBI), United Kingdom. This course will introduce life scientists to practical data science methods increasingly used in research, with a particular focus on statistics and machine learning, using Python as the language of choice. Participants will learn how to prepare, process, and visualise some key biological datatypes, and gain hands-on experience in training and evaluating machine learning models using publicly available data."
+
+For more information on the course and to apply, [please visit the EMBL-EBI website](https://www.ebi.ac.uk/training/events/data-science-for-life-scientists-2026/?utm_source=Galaxy+Event+Horizon&utm_medium=calendar_listing&utm_campaign=DAT26#vf-tabs__section--tab1).


### PR DESCRIPTION
Adding an EMBL-EBI training course to the Events page. The event was submitted to our events form, and I am adding it on their behalf.