### PR TITLE
Add source blog annotations to former blog posts

### DIFF
--- a/content/news/2015-07-mysql-2-postgresql/index.md
+++ b/content/news/2015-07-mysql-2-postgresql/index.md
@@ -6,6 +6,8 @@ authors: "Hans-Rudolf Hotz"
 contributions:
   authorship:
     - hrhotz
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2015-07-mysql-2-postgresql/"
 ---
 After running our Galaxy servers successfully with MySQL as the backend database server for several years, we decided to switch to the recommended PostgreSQL server.
 

--- a/content/news/2015-12-galaxy-irods-connection/index.md
+++ b/content/news/2015-12-galaxy-irods-connection/index.md
@@ -8,4 +8,6 @@ contributions:
   authorship:
     - mikaelloaec
     - olivierinizan
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2015-12-galaxy-irods-connection/"
 ---

--- a/content/news/2017-10-05-elixir-galaxy-community/index.md
+++ b/content/news/2017-10-05-elixir-galaxy-community/index.md
@@ -9,6 +9,8 @@ contributions:
     - frederikcoppens
     - lecorguille
     - bgruening
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2017-10-05-elixir-galaxy-community/"
 ---
 
 ELIXIR is an intergovernmental organisation that brings together life science resources from across Europe.

--- a/content/news/2017-10-10-scipy-galaxy/index.md
+++ b/content/news/2017-10-10-scipy-galaxy/index.md
@@ -8,6 +8,8 @@ tags: [tools]
 contributions:
   authorship:
     - bgruening
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2017-10-10-scipy-galaxy/"
 ---
 
 [Numpy](http://www.numpy.org), [SciPy](https://www.scipy.org), [scikit-learn](http://scikit-learn.org),

--- a/content/news/2017-10-16-unicycler-tutorial/index.md
+++ b/content/news/2017-10-16-unicycler-tutorial/index.md
@@ -7,6 +7,8 @@ image: unicycler.png
 contributions:
   authorship:
     - nekrut
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2017-10-16-unicycler-tutorial/"
 ---
 
 <div class="alert alert-info trim-p inline-p" role="alert"><i class="fa fa-fighter-jet" aria-hidden="true"></i>

--- a/content/news/2017-10-5000-pubs/index.md
+++ b/content/news/2017-10-5000-pubs/index.md
@@ -7,6 +7,8 @@ authors: "Dave Clements"
 contributions:
   authorship:
     - tnabtaf
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2017-10-5000-pubs/"
 ---
 
 We reached 5,000 publications in the [Galaxy Publication Library](https://www.zotero.org/groups/1732893/galaxy) last week.  The library tracks publications that use, extend, implement or reference Galaxy or a Galaxy server.  It includes journal articles, theses, and a couple of odds and ends.  This milestone is a good opportunity to look at what the library tells us about where the Galaxy project has been, and maybe where it's going too.

--- a/content/news/2017-10-a-blog-is-born/index.md
+++ b/content/news/2017-10-a-blog-is-born/index.md
@@ -7,6 +7,8 @@ authors: "Dave Clements"
 contributions:
   authorship:
     - tnabtaf
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2017-10-a-blog-is-born/"
 ---
 
 Today we launch the new *[Galactic Blog](/news/)*.

--- a/content/news/2017-10-public-galaxy-dashboard/index.md
+++ b/content/news/2017-10-public-galaxy-dashboard/index.md
@@ -6,6 +6,8 @@ authors: "Helena Rasche"
 contributions:
   authorship:
     - hexylena
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2017-10-public-galaxy-dashboard/"
 ---
 
 [<img class="img-fluid mx-auto" src="/news/2017-10-public-galaxy-dashboard/dashboard-landing.png" alt="Public Galaxy Server Dashboard" />](https://stats.galaxyproject.eu/dashboard/db/public-galaxy-servers)

--- a/content/news/2018-06-training-material/index.md
+++ b/content/news/2018-06-training-material/index.md
@@ -6,6 +6,8 @@ image: "/news/2018-06-training-material/cover_art.png"
 contributions:
   authorship:
     - bebatut
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-06-training-material/"
 ---
 
 The Galaxy Training Network has developed an infrastructure to deliver interactive training based on Galaxy: one central place ([https://training.galaxyproject.org](https://training.galaxyproject.org)) to aggregate training materials covering many current research topics.

--- a/content/news/2018-08-cotm-pablo-moreno/index.md
+++ b/content/news/2018-08-cotm-pablo-moreno/index.md
@@ -6,6 +6,8 @@ image: "/news/2018-08-cotm-pablo-moreno/pablo-moreno.jpg"
 contributions:
   authorship:
     - bgruening
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-08-cotm-pablo-moreno/"
 ---
 
 **Welcome to the first ever Galaxy Contributor of the Month posting!**

--- a/content/news/2018-09-cotm-carrie-ganote/index.md
+++ b/content/news/2018-09-cotm-carrie-ganote/index.md
@@ -6,6 +6,8 @@ image: "/news/2018-09-cotm-carrie-ganote/carrie-ganote.png"
 contributions:
   authorship:
     - bgruening
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-09-cotm-carrie-ganote/"
 ---
 
 The Galaxy ecosystem is a direct result of the Galaxy community and the contributions and involvement of community members.  The community makes it all work in innumerable ways, including support, training and tutorial development, talks, posters, documentation, issue reporting, feature requests, tool publishing, coding, and Galaxy server, cloud, and appliance support.

--- a/content/news/2018-09-totm/index.md
+++ b/content/news/2018-09-totm/index.md
@@ -5,6 +5,8 @@ authors: "Bérénice Batut"
 contributions:
   authorship:
     - bebatut
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-09-totm/"
 ---
 
 The Galaxy community is developing and maintaining a collection of tutorials that are designed to be interactive and are built around Galaxy: [https://training.galaxyproject.org](https://training.galaxyproject.org). These tutorials can be used for learning and teaching how to use Galaxy for general data analysis, and for learning/teaching specific domains such as assembly and differential gene expression analysis with RNA-Seq data. These materials are targetting both self-paced individual learners and instructors.

--- a/content/news/2018-10-cotm-yvan-le-bras/index.md
+++ b/content/news/2018-10-cotm-yvan-le-bras/index.md
@@ -7,6 +7,8 @@ image: "/images/photos/yvanlebras.png"
 contributions:
   authorship:
     - bgruening
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-10-cotm-yvan-le-bras/"
 ---
 
 This month we welcome Yvan Le Bras, also called the magic Yvan ([@yvanlebras](https://github.com/yvanlebras)) as our *Galaxy contributor of the Month!* Yvan is a long time community member and PI of the GalaxyE project for Ecology data science. Yvan thanks for doing this interview with us, we are looking forward to learn more about you and your work!

--- a/content/news/2018-10-totm/index.md
+++ b/content/news/2018-10-totm/index.md
@@ -6,6 +6,8 @@ subsites: [global, eu, freiburg]
 contributions:
   authorship:
     - bebatut
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-10-totm/"
 ---
 
 The Galaxy community is developing and maintaining a collection of tutorials that are designed to be interactive and are built around Galaxy: [https://training.galaxyproject.org](https://training.galaxyproject.org). These tutorials can be used for learning and teaching how to use Galaxy for general data analysis, and for learning/teaching specific domains such as assembly and differential gene expression analysis with RNA-Seq data. These materials are targetting both self-paced individual learners and instructors.

--- a/content/news/2018-11-cotm-saskia-hiltemann/index.md
+++ b/content/news/2018-11-cotm-saskia-hiltemann/index.md
@@ -6,6 +6,8 @@ image: "/news/2018-11-cotm-saskia-hiltemann/saskia-hiltemann.png"
 contributions:
   authorship:
     - martenson
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-11-cotm-saskia-hiltemann/"
 ---
 
 This month we welcome Saskia Hiltemann (Twitter: [@shiltemann](https://twitter.com/shiltemann), GitHub: [@shiltemann](https://github.com/shiltemann)) as our Galaxy contributor of the Month! Saskia is a bioinformatician and a PhD student working in metagenomics at Rotterdam’s Erasmus Medical Center in the Netherlands, a core member of the [Intergalactic Utilities Commission](https://galaxyproject.org/iuc/), and one of the two primary creators of the [Galaxy Training Framework](https://training.galaxyproject.org/) ([published](https://doi.org/10.1016/j.cels.2018.05.012) in *Cell Systems*).

--- a/content/news/2018-11-totm/index.md
+++ b/content/news/2018-11-totm/index.md
@@ -7,6 +7,8 @@ main_subsite: freiburg
 contributions:
   authorship:
     - bebatut
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-11-totm/"
 ---
 
 The Galaxy community is developing and maintaining a collection of tutorials that are designed to be interactive and are built around Galaxy: [https://training.galaxyproject.org](https://training.galaxyproject.org). These tutorials can be used for learning and teaching how to use Galaxy for general data analysis, and for learning/teaching specific domains such as assembly and differential gene expression analysis with RNA-Seq data. These materials are targetting both self-paced individual learners and instructors.

--- a/content/news/2018-12-cotm-simon-gladman/index.md
+++ b/content/news/2018-12-cotm-simon-gladman/index.md
@@ -6,6 +6,8 @@ image: "/news/2018-12-cotm-simon-gladman/simon_small.jpg"
 contributions:
   authorship:
     - martenson
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2018-12-cotm-simon-gladman/"
 ---
 
 This month we welcome Simon Gladman (Twitter: [@SimonGladman1](https://twitter.com/SimonGladman1), GitHub: [@slugger70](https://github.com/slugger70)) as our Galaxy contributor of the Month! Simon works at the [University of Melbourne](https://www.unimelb.edu.au/) and is one of the developers of the [Genomics Virtual Laboratory](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4621043/) cloud image. Simon is a firefighter, cheesemaker, pillar of the [Galaxy Australia](https://usegalaxy.org.au/), and an overall jolly good fellow.

--- a/content/news/2019-01-totm/index.md
+++ b/content/news/2019-01-totm/index.md
@@ -5,6 +5,8 @@ authors: "Bérénice Batut"
 contributions:
   authorship:
     - bebatut
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2019-01-totm/"
 ---
 
 The Galaxy community is developing and maintaining a collection of tutorials that are designed to be interactive and are built around Galaxy: [https://training.galaxyproject.org](https://training.galaxyproject.org). These tutorials can be used for learning and teaching how to use Galaxy for general data analysis, and for learning/teaching specific domains such as assembly and differential gene expression analysis with RNA-Seq data. These materials are targetting both self-paced individual learners and instructors.

--- a/content/news/2019-02-cvmfs/index.md
+++ b/content/news/2019-02-cvmfs/index.md
@@ -7,6 +7,8 @@ image: "/news/2019-02-cvmfs/Nate_face.jpeg"
 contributions:
   authorship:
     - moheydarian
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2019-02-cvmfs/"
 ---
 
 This month we interviewed [Nate Coraor](https://github.com/natefoo) of the Galaxy Team to learn about what CVMFS is and how it is being used for Galaxy.

--- a/content/news/2019-04-gcc2019/index.md
+++ b/content/news/2019-04-gcc2019/index.md
@@ -8,6 +8,8 @@ tags: [gcc, conference]
 contributions:
   authorship:
     - bgruening
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2019-04-gcc2019/"
 ---
 
 As you probably know GCC2019 will be held in Freiburg, Germany, from 1-6 July. Like [previous Galaxy Community Conferences](https://galaxyproject.org/gcc/), GCC2019 will [feature](https://gcc2019.sched.com) keynotes, accepted talks, posters, and demos, birds-of-a-feather gatherings, multiple days of collaborative work, and plenty of opportunities to network with your fellow data-intensive researchers and practitioners. If you are working in data-intensive life science, there is no better place to be.

--- a/content/news/2019-04-gcp/index.md
+++ b/content/news/2019-04-gcp/index.md
@@ -9,6 +9,8 @@ contributions:
   authorship:
     - afgane
     - vahidjalili
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2019-04-gcp/"
 ---
 
 The Galaxy project has long embraced support and integration with cloud

--- a/content/news/2019-05-gcr/index.md
+++ b/content/news/2019-05-gcr/index.md
@@ -9,6 +9,8 @@ contributions:
   authorship:
     - afgane
     - nuwang
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2019-05-gcr/"
 ---
 
 Did you ever feel the need for speed, as in more compute capacity on your Galaxy

--- a/content/news/2019-07-galaxy-twitter/index.md
+++ b/content/news/2019-07-galaxy-twitter/index.md
@@ -11,6 +11,8 @@ contributions:
     - moheydarian
     - hrhotz
     - nsoranzo
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2019-07-galaxy-twitter/"
 ---
 
 [<img class="float-right" style="max-width: 100px" src="/images/logos/TwitterBird300.png" alt="Galaxy on Twitter" />](https://twitter.com/hashtag/UseGalaxy)

--- a/content/news/2019-07-looking-for-galaxy/index.md
+++ b/content/news/2019-07-looking-for-galaxy/index.md
@@ -6,6 +6,8 @@ tease: "Which are dangerously close to the wrong places..."
 contributions:
   authorship:
     - tnabtaf
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2019-07-looking-for-galaxy/"
 ---
 
 Ever search for "Galaxy" on [Google](https://www.google.com/search?q=galaxy), or [Bing](https://www.bing.com/search?q=galaxy), or [DuckDuckGo](https://duckduckgo.com/?q=galaxy), or [Yahoo!](https://search.yahoo.com/search?q=galaxy)?  Well, if you are interested in [phones](https://www.samsung.com/global/galaxy/), [astronomy](https://davecl.wordpress.com/), [soccer](https://www.lagalaxy.com/), [cars](https://www.ford.co.uk/cars/galaxy)<sup>&#42;</sup>, [chocolate](https://www.galaxychocolate.co.uk/), or [Ansible](https://galaxy.ansible.com/) (ok, that last one is close), then you are in luck.  But, if you are interested in *the one true Galaxy* then the pickings are pretty thin.

--- a/content/news/2020-01-galaxy-ecology-citizen-science/index.md
+++ b/content/news/2020-01-galaxy-ecology-citizen-science/index.md
@@ -10,6 +10,8 @@ contributions:
   authorship:
     - yvanlebras
     - sbenateau
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2020-01-galaxy-ecology-citizen-science/"
 ---
 
 One year after the *[Galaxy contributor of the Month!](https://galaxyproject.org/blog/2018-10-cotm-yvan-le-bras/)* (originally I was supposed to post this blog post in october 2019... but starting 2020 appears to be better no ? ;) ) it's a pleasure for me to come back with some crispy news about the Galaxy for Ecology project!

--- a/content/news/2020-02-gvl5-beta/index.md
+++ b/content/news/2020-02-gvl5-beta/index.md
@@ -12,6 +12,8 @@ contributions:
     - almahmoud
     - astrovsky01
     - gvlteam
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2020-02-gvl5-beta/"
 ---
 
 ## tl; dr

--- a/content/news/2020-04-gvl5-beta2/index.md
+++ b/content/news/2020-04-gvl5-beta2/index.md
@@ -15,6 +15,8 @@ contributions:
     - nuwang
     - lukesargent
     - afgane
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2020-04-gvl5-beta2/"
 ---
 
 Mid-February, we announced [the first beta release](https://galaxyproject.org/blog/2020-02-gvl5-beta/) of the all-new Genomics Virtual Lab v5.0 (GVL 5). Today, beta2 release has become available. This latest version comes packed with several new features and enhancements as well as general improvements regarding the stability and robustness of the platform. We’d like to highlight the following three features, with more detailed blog posts about each of the features coming in the following weeks:

--- a/content/news/2020-06-gvl5-beta3/index.md
+++ b/content/news/2020-06-gvl5-beta3/index.md
@@ -13,6 +13,8 @@ contributions:
     - almahmoud
     - nuwang
     - afgane
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2020-06-gvl5-beta3/"
 ---
 
 We are happy to announce the latest release of the Genomics Virtual Lab (GVL),

--- a/content/news/2020-07-gvl5-beta4/index.md
+++ b/content/news/2020-07-gvl5-beta4/index.md
@@ -11,6 +11,8 @@ contributions:
     - almahmoud
     - mohamadsafadieh
     - afgane
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2020-07-gvl5-beta4/"
 ---
 
 Less than a month ago we shared the news about the [beta3 release of GVL

--- a/content/news/2020-08-10k-pubs/index.md
+++ b/content/news/2020-08-10k-pubs/index.md
@@ -7,6 +7,8 @@ authors: "Dave Clements"
 contributions:
   authorship:
     - tnabtaf
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2020-08-10k-pubs/"
 ---
 
 We reached 10,000 publications in the [Galaxy Publication Library](https://www.zotero.org/groups/1732893/galaxy) this month.  This library tracks publications that use, extend, implement or reference Galaxy or Galaxy-based platforms.  It includes journal articles, theses, book chapters, preprints, and a couple more odds and ends.  This milestone is a good opportunity to look at what the library tells us about where the Galaxy project has been, and maybe where it's going as well.

--- a/content/news/2021-05-galaxy-helm-chart-v4/index.md
+++ b/content/news/2021-05-galaxy-helm-chart-v4/index.md
@@ -13,6 +13,8 @@ contributions:
     - nuwang
     - ksuderman
     - afgane
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2021-05-galaxy-helm-chart-v4/"
 ---
 
 We are happy to announce general availability of a new major version of the

--- a/content/news/2021-09-cancer-informatics-wg-update/index.md
+++ b/content/news/2021-09-cancer-informatics-wg-update/index.md
@@ -6,6 +6,8 @@ date: "2021-09-02"
 contributions:
   authorship:
     - lukesargent
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2021-09-cancer-informatics-wg-update/"
 ---
 
 # Cancer Informatics + Galaxy

--- a/content/news/2021-09-hub2/index.md
+++ b/content/news/2021-09-hub2/index.md
@@ -7,6 +7,8 @@ contributions:
   authorship:
     - NickSto
     - dannon
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2021-09-hub2/"
 ---
 
 You may not have noticed, but things have changed a lot around here! Today we are happy to unveil the new Galaxy Community Hub. This is a ground-up rewrite of the back-end for the site you're reading right now.

--- a/content/news/2021-09-human-genetics-wg-update/index.md
+++ b/content/news/2021-09-human-genetics-wg-update/index.md
@@ -6,6 +6,8 @@ date: "2021-09-21"
 contributions:
   authorship:
     - afgane
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2021-09-human-genetics-wg-update/"
 ---
 
 <div class="card float-right" style="min-width: 12rem; max-width: 20rem">

--- a/content/news/2021-10-sunsetting-cloudlaunch/index.md
+++ b/content/news/2021-10-sunsetting-cloudlaunch/index.md
@@ -6,6 +6,8 @@ date: "2021-10-15"
 contributions:
   authorship:
     - afgane
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2021-10-sunsetting-cloudlaunch/"
 ---
 
 Sunsets are generally considered pretty events so we’ll paint a positive picture

--- a/content/news/2022-01-18-reproducibility-and-support-bjoern/index.md
+++ b/content/news/2022-01-18-reproducibility-and-support-bjoern/index.md
@@ -10,6 +10,8 @@ contributions:
     - gallardoalba
     - jennaj
     - fubar2
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2022-01-18-reproducibility-and-support-bjoern/"
 ---
 
 `tl;dr` We take a closer look at Galaxy as a sharing infrastructure and framework. How this enables best practices in science and helps the European Galaxy team to

--- a/content/news/2022-01-27-disbanding-roundtables/index.md
+++ b/content/news/2022-01-27-disbanding-roundtables/index.md
@@ -9,6 +9,8 @@ contributions:
     - beatrizserrano
     - jmchilton
     - dannon
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2022-01-27-disbanding-roundtables/"
 ---
 
 ## Why are we disbanding roundtables?

--- a/content/news/2022-01-27-introduce-assunta-desanto/index.md
+++ b/content/news/2022-01-27-introduce-assunta-desanto/index.md
@@ -5,6 +5,8 @@ date: "2022-01-27"
 contributions:
   authorship:
     - assuntad23
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2022-01-27-introduce-assunta-desanto/"
 ---
 
 ![Assunta DeSanto](adesanto_book_resize.png)

--- a/content/news/2022-04-06-launching-community-calls/index.md
+++ b/content/news/2022-04-06-launching-community-calls/index.md
@@ -7,6 +7,8 @@ tags: [community]
 contributions:
   authorship:
     - beatrizserrano
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2022-04-06-launching-community-calls/"
 ---
 
 We are happy to announce that we are launching the new Galaxy Community Calls!

--- a/content/news/2022-06-22-outreachy-intro/index.md
+++ b/content/news/2022-06-22-outreachy-intro/index.md
@@ -10,6 +10,8 @@ contributions:
     - Quickbeasts51429
     - annefou
     - beatrizserrano
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2022-06-22-outreachy-intro/"
 ---
 
 

--- a/content/news/2022-06-guide-to-gcc2022/index.md
+++ b/content/news/2022-06-guide-to-gcc2022/index.md
@@ -7,6 +7,8 @@ contributions:
   authorship:
     - afgane
     - subinamehta
+source_blog: "Galaxy Project Blog"
+source_blog_url: "https://galaxyproject.org/blog/2022-06-guide-to-gcc2022/"
 ---
 
 The [Galaxy Community Conference](https://galaxyproject.org/events/gcc2022/)


### PR DESCRIPTION
## Summary

Adds `source_blog` and `source_blog_url` frontmatter fields to 41 news posts that were originally published on the Galaxy Project Blog before it was merged into the news section. Useful provenance metadata.

Cherry-picked and adapted from @bgruening's work in #3618.

## Test plan

- [ ] Pure content metadata change, no functional impact
- [ ] Spot-check a few files have correct `source_blog_url` values