### PR TITLE
Add Pan-Galactic and publication search tabs to /search

### DIFF
--- a/astro/src/components/search/HubSearch.vue
+++ b/astro/src/components/search/HubSearch.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { formatDate } from '@/utils/dateUtils';
+import ExternalIcon from '../common/ExternalIcon.vue';
+
+interface SearchEntry {
+  title: string;
+  slug: string;
+  path: string;
+  external_url?: string | null;
+  excerpt: string;
+  tease: string;
+  tags: string[];
+  date: string;
+  collection: string;
+}
+
+const props = defineProps<{ query: string }>();
+
+const searchIndex = ref<SearchEntry[]>([]);
+const isLoading = ref(true);
+const selectedCollection = ref<string>('all');
+
+onMounted(async () => {
+  try {
+    const response = await fetch('/search-index.json');
+    searchIndex.value = await response.json();
+  } catch (error) {
+    console.error('Failed to load search index:', error);
+  } finally {
+    isLoading.value = false;
+  }
+});
+
+const collections = computed(() => {
+  const unique = new Set(searchIndex.value.map((e) => e.collection));
+  return ['all', ...Array.from(unique).sort()];
+});
+
+const results = computed(() => {
+  if (!props.query.trim()) {
+    return [];
+  }
+
+  const q = props.query.toLowerCase().trim();
+  const words = q.split(/\s+/);
+
+  let filtered = searchIndex.value.filter((entry) => {
+    const searchText = [entry.title, entry.excerpt, entry.tease, ...entry.tags].join(' ').toLowerCase();
+    return words.every((word) => searchText.includes(word));
+  });
+
+  if (selectedCollection.value !== 'all') {
+    filtered = filtered.filter((e) => e.collection === selectedCollection.value);
+  }
+
+  return filtered
+    .sort((a, b) => {
+      const dateA = new Date(a.date).getTime() || 0;
+      const dateB = new Date(b.date).getTime() || 0;
+      return dateB - dateA;
+    })
+    .slice(0, 100);
+});
+
+function getCollectionLabel(collection: string): string {
+  const labels: Record<string, string> = {
+    articles: 'Article',
+    events: 'Event',
+    platforms: 'Platform',
+  };
+  return labels[collection] || collection;
+}
+
+function getCollectionColor(collection: string): string {
+  const colors: Record<string, string> = {
+    articles: 'bg-blue-100 text-blue-800',
+    events: 'bg-green-100 text-green-800',
+    platforms: 'bg-purple-100 text-purple-800',
+  };
+  return colors[collection] || 'bg-gray-100 text-gray-800';
+}
+
+function highlightMatch(text: string, maxLength: number = 200): string {
+  if (!text) return '';
+
+  const words = props.query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 2);
+
+  let result = text.length > maxLength ? text.slice(0, maxLength) + '...' : text;
+
+  words.forEach((word) => {
+    const regex = new RegExp(`(${word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+    result = result.replace(regex, '<mark class="bg-yellow-200">$1</mark>');
+  });
+
+  return result;
+}
+</script>
+
+<template>
+  <div>
+    <!-- Collection filter -->
+    <div class="mb-4 flex items-center gap-4">
+      <div class="w-full md:w-48">
+        <select
+          v-model="selectedCollection"
+          class="w-full h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option v-for="col in collections" :key="col" :value="col">
+            {{ col === 'all' ? 'All content' : getCollectionLabel(col) + 's' }}
+          </option>
+        </select>
+      </div>
+      <div class="text-sm text-gray-600">
+        <span v-if="isLoading">Loading search index...</span>
+        <span v-else-if="!query.trim()"> {{ searchIndex.length.toLocaleString() }} pages indexed </span>
+        <span v-else>
+          {{ results.length }} result{{ results.length !== 1 ? 's' : '' }}
+          <span v-if="results.length >= 100">(showing first 100)</span>
+        </span>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div v-if="results.length > 0" class="space-y-4">
+      <article
+        v-for="result in results"
+        :key="result.slug"
+        class="bg-white rounded-lg border border-gray-200 p-5 hover:shadow-md transition-shadow"
+      >
+        <a :href="result.path" class="block">
+          <div class="flex items-start justify-between gap-4 mb-2">
+            <h2 class="text-lg font-semibold text-gray-900 hover:text-galaxy-primary transition-colors">
+              {{ result.title }}
+              <ExternalIcon v-if="result.collection === 'events' && result.external_url" />
+            </h2>
+            <span :class="['text-xs px-2 py-1 rounded-full whitespace-nowrap', getCollectionColor(result.collection)]">
+              {{ getCollectionLabel(result.collection) }}
+            </span>
+          </div>
+
+          <p
+            v-if="result.excerpt || result.tease"
+            class="text-gray-600 text-sm mb-3"
+            v-html="highlightMatch(result.tease || result.excerpt)"
+          ></p>
+
+          <div class="flex items-center gap-4 text-xs text-gray-500">
+            <time v-if="result.date">{{ formatDate(result.date) }}</time>
+            <div v-if="result.tags?.length" class="flex gap-1 flex-wrap">
+              <span v-for="tag in result.tags.slice(0, 3)" :key="tag" class="px-2 py-0.5 bg-gray-100 rounded">
+                {{ tag }}
+              </span>
+              <span v-if="result.tags.length > 3" class="text-gray-400"> +{{ result.tags.length - 3 }} more </span>
+            </div>
+          </div>
+        </a>
+      </article>
+    </div>
+
+    <!-- No results -->
+    <div v-else-if="query.trim() && !isLoading" class="text-center py-12">
+      <svg class="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        ></path>
+      </svg>
+      <p class="text-gray-500 mb-2">No results found for "{{ query }}"</p>
+      <p class="text-sm text-gray-400">Try different keywords or check your spelling</p>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!isLoading" class="text-center py-12">
+      <svg class="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        ></path>
+      </svg>
+      <p class="text-gray-500">Enter a search term to search the Galaxy Community Hub</p>
+    </div>
+  </div>
+</template>

--- a/astro/src/components/search/PanGalacticSearch.vue
+++ b/astro/src/components/search/PanGalacticSearch.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, nextTick } from 'vue';
+
+const props = defineProps<{ query: string }>();
+
+const cseLoaded = ref(false);
+const cseError = ref(false);
+const containerRef = ref<HTMLElement | null>(null);
+
+function loadCSEScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if ((window as any).__gcse_loaded) {
+      resolve();
+      return;
+    }
+
+    (window as any).__gcse = {
+      parsetags: 'explicit',
+      callback: () => {
+        (window as any).__gcse_loaded = true;
+        resolve();
+      },
+    };
+
+    const script = document.createElement('script');
+    script.src = 'https://cse.google.com/cse.js?cx=007594916903876912968:w0nrox8rzzy';
+    script.async = true;
+    script.onerror = () => reject(new Error('Failed to load Google CSE'));
+    document.head.appendChild(script);
+  });
+}
+
+function executeSearch(query: string) {
+  const google = (window as any).google;
+  if (!google?.search?.cse?.element) return;
+
+  const element = google.search.cse.element.getElement('galaxySearch');
+  if (element) {
+    if (query.trim()) {
+      element.execute(query);
+    } else {
+      element.clearAllResults();
+    }
+  }
+}
+
+function renderAndSearch() {
+  const google = (window as any).google;
+  if (!google?.search?.cse?.element || !containerRef.value) return;
+
+  const existing = google.search.cse.element.getElement('galaxySearch');
+  if (!existing) {
+    google.search.cse.element.render({
+      div: containerRef.value,
+      tag: 'searchresults-only',
+      gname: 'galaxySearch',
+    });
+  }
+
+  if (props.query.trim()) {
+    // Small delay to let the element initialize
+    setTimeout(() => executeSearch(props.query), 100);
+  }
+}
+
+onMounted(async () => {
+  try {
+    await loadCSEScript();
+    cseLoaded.value = true;
+    await nextTick();
+    renderAndSearch();
+  } catch {
+    cseError.value = true;
+  }
+});
+
+watch(
+  () => props.query,
+  (newQuery) => {
+    if (cseLoaded.value) {
+      executeSearch(newQuery);
+    }
+  }
+);
+</script>
+
+<template>
+  <div>
+    <p class="text-sm text-gray-600 mb-4">
+      Search across the Galaxy ecosystem: Hub pages, codebase, mailing lists, help forum, and more.
+    </p>
+
+    <div v-if="cseError" class="text-center py-12">
+      <p class="text-gray-500 mb-2">Could not load Google Search.</p>
+      <p class="text-sm text-gray-400">
+        This may be due to an ad blocker or network issue. Try the Hub Search tab instead.
+      </p>
+    </div>
+
+    <div v-else-if="!cseLoaded" class="text-center py-12">
+      <p class="text-gray-500">Loading Google Search...</p>
+    </div>
+
+    <div v-else-if="!query.trim()" class="text-center py-12">
+      <svg class="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        ></path>
+      </svg>
+      <p class="text-gray-500">Enter a search term to search across the Galaxy ecosystem</p>
+    </div>
+
+    <div ref="containerRef" class="gcse-results"></div>
+  </div>
+</template>
+
+<style>
+/* Override Google CSE default styles to blend with the site */
+.gsc-control-cse {
+  padding: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  font-family: inherit !important;
+}
+.gsc-results-wrapper-overlay,
+.gsc-results-wrapper-visible {
+  box-shadow: none !important;
+  border: none !important;
+}
+.gsc-webResult.gsc-result {
+  border-bottom: 1px solid #e5e7eb !important;
+  padding: 12px 0 !important;
+}
+.gs-title a {
+  color: #25537b !important;
+}
+.gs-title a:hover {
+  color: #1a3a57 !important;
+}
+</style>

--- a/astro/src/components/search/PublicationSearch.vue
+++ b/astro/src/components/search/PublicationSearch.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+const props = defineProps<{ query: string }>();
+
+interface ZoteroItem {
+  data: {
+    title: string;
+    url: string;
+    abstractNote?: string;
+  };
+}
+
+const results = ref<ZoteroItem[] | null>(null);
+const isLoading = ref(false);
+const error = ref<string | null>(null);
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+async function search(query: string) {
+  if (!query.trim()) {
+    results.value = null;
+    return;
+  }
+
+  isLoading.value = true;
+  error.value = null;
+  results.value = null;
+
+  try {
+    const response = await fetch(
+      `https://api.zotero.org/groups/1732893/items/top?start=0&limit=25&q=${encodeURIComponent(query)}`
+    );
+    if (!response.ok) throw new Error(`Zotero API error: ${response.status}`);
+    results.value = await response.json();
+  } catch (e) {
+    error.value = 'Failed to search the Galaxy publication library. Please try again.';
+    console.error('Zotero search failed:', e);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+watch(
+  () => props.query,
+  (newQuery) => {
+    if (searchTimeout) clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(() => search(newQuery), 400);
+  },
+  { immediate: true }
+);
+</script>
+
+<template>
+  <div>
+    <p class="text-sm text-gray-600 mb-4">
+      Search the
+      <a href="https://www.zotero.org/groups/1732893/galaxy" target="_blank" class="text-galaxy-primary hover:underline"
+        >Galaxy publication library</a
+      >
+      on Zotero.
+    </p>
+
+    <div v-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+      {{ error }}
+    </div>
+
+    <div v-else-if="isLoading" class="text-center py-12">
+      <svg class="w-8 h-8 mx-auto text-gray-400 animate-spin mb-4" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+      </svg>
+      <p class="text-gray-500">Searching publications...</p>
+    </div>
+
+    <div v-else-if="results && results.length > 0" class="space-y-4">
+      <article
+        v-for="item in results"
+        :key="item.data.url || item.data.title"
+        class="bg-white rounded-lg border border-gray-200 p-5 hover:shadow-md transition-shadow"
+      >
+        <a v-if="item.data.url" :href="item.data.url" target="_blank" class="block">
+          <h2 class="text-lg font-semibold text-gray-900 hover:text-galaxy-primary transition-colors mb-1">
+            {{ item.data.title }}
+          </h2>
+          <p class="text-xs text-green-700 mb-2">{{ item.data.url }}</p>
+          <p v-if="item.data.abstractNote" class="text-gray-600 text-sm">
+            {{ item.data.abstractNote.slice(0, 450) }}{{ item.data.abstractNote.length > 450 ? '...' : '' }}
+          </p>
+        </a>
+        <div v-else>
+          <h2 class="text-lg font-semibold text-gray-900 mb-1">{{ item.data.title }}</h2>
+          <p v-if="item.data.abstractNote" class="text-gray-600 text-sm">
+            {{ item.data.abstractNote.slice(0, 450) }}{{ item.data.abstractNote.length > 450 ? '...' : '' }}
+          </p>
+        </div>
+      </article>
+    </div>
+
+    <div v-else-if="results && results.length === 0" class="text-center py-12">
+      <p class="text-gray-500 mb-2">No publications found for "{{ query }}"</p>
+      <p class="text-sm text-gray-400">Try different keywords or check your spelling</p>
+    </div>
+
+    <div v-else-if="!query.trim()" class="text-center py-12">
+      <svg class="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        ></path>
+      </svg>
+      <p class="text-gray-500">Enter a search term to search Galaxy publications</p>
+    </div>
+  </div>
+</template>

--- a/astro/src/components/search/SearchPage.vue
+++ b/astro/src/components/search/SearchPage.vue
@@ -1,46 +1,26 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { Input } from '@/components/ui/input';
-import { formatDate } from '@/utils/dateUtils';
-import ExternalIcon from '../common/ExternalIcon.vue';
-
-interface SearchEntry {
-  title: string;
-  slug: string;
-  path: string;
-  external_url?: string | null;
-  excerpt: string;
-  tease: string;
-  tags: string[];
-  date: string;
-  collection: string;
-}
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import HubSearch from './HubSearch.vue';
+import PanGalacticSearch from './PanGalacticSearch.vue';
+import PublicationSearch from './PublicationSearch.vue';
 
 const searchQuery = ref('');
-const searchIndex = ref<SearchEntry[]>([]);
-const isLoading = ref(true);
-const selectedCollection = ref<string>('all');
+const activeTab = ref('hub');
 
-// Load search index
-onMounted(async () => {
-  try {
-    const response = await fetch('/search-index.json');
-    searchIndex.value = await response.json();
-  } catch (error) {
-    console.error('Failed to load search index:', error);
-  } finally {
-    isLoading.value = false;
-  }
-
-  // Check URL for initial query
+onMounted(() => {
   const params = new URLSearchParams(window.location.search);
   const q = params.get('q');
   if (q) {
     searchQuery.value = q;
   }
+  const tab = params.get('tab');
+  if (tab && ['hub', 'google', 'publications'].includes(tab)) {
+    activeTab.value = tab;
+  }
 });
 
-// Update URL when search changes
 watch(searchQuery, (query) => {
   const url = new URL(window.location.href);
   if (query) {
@@ -51,179 +31,49 @@ watch(searchQuery, (query) => {
   window.history.replaceState({}, '', url.toString());
 });
 
-// Get unique collections
-const collections = computed(() => {
-  const unique = new Set(searchIndex.value.map((e) => e.collection));
-  return ['all', ...Array.from(unique).sort()];
-});
-
-// Search results
-const results = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return [];
+watch(activeTab, (tab) => {
+  const url = new URL(window.location.href);
+  if (tab !== 'hub') {
+    url.searchParams.set('tab', tab);
+  } else {
+    url.searchParams.delete('tab');
   }
-
-  const query = searchQuery.value.toLowerCase().trim();
-  const words = query.split(/\s+/);
-
-  let filtered = searchIndex.value.filter((entry) => {
-    const searchText = [entry.title, entry.excerpt, entry.tease, ...entry.tags].join(' ').toLowerCase();
-
-    // All words must match
-    return words.every((word) => searchText.includes(word));
-  });
-
-  // Filter by collection
-  if (selectedCollection.value !== 'all') {
-    filtered = filtered.filter((e) => e.collection === selectedCollection.value);
-  }
-
-  // Sort by date (most recent first)
-  return filtered
-    .sort((a, b) => {
-      const dateA = new Date(a.date).getTime() || 0;
-      const dateB = new Date(b.date).getTime() || 0;
-      return dateB - dateA;
-    })
-    .slice(0, 100);
+  window.history.replaceState({}, '', url.toString());
 });
-
-function getCollectionLabel(collection: string): string {
-  const labels: Record<string, string> = {
-    articles: 'Article',
-    events: 'Event',
-    platforms: 'Platform',
-  };
-  return labels[collection] || collection;
-}
-
-function getCollectionColor(collection: string): string {
-  const colors: Record<string, string> = {
-    articles: 'bg-blue-100 text-blue-800',
-    events: 'bg-green-100 text-green-800',
-    platforms: 'bg-purple-100 text-purple-800',
-  };
-  return colors[collection] || 'bg-gray-100 text-gray-800';
-}
-
-function highlightMatch(text: string, maxLength: number = 200): string {
-  if (!text) return '';
-
-  const query = searchQuery.value.toLowerCase();
-  const words = query.split(/\s+/).filter((w) => w.length > 2);
-
-  let result = text.length > maxLength ? text.slice(0, maxLength) + '...' : text;
-
-  // Simple highlighting (would need proper escaping for production)
-  words.forEach((word) => {
-    const regex = new RegExp(`(${word})`, 'gi');
-    result = result.replace(regex, '<mark class="bg-yellow-200">$1</mark>');
-  });
-
-  return result;
-}
 </script>
 
 <template>
   <div class="search-page">
-    <!-- Search Form -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-8">
-      <div class="flex flex-col md:flex-row gap-4">
-        <div class="flex-1">
-          <Input
-            v-model="searchQuery"
-            type="text"
-            placeholder="Search articles, events, platforms..."
-            class="w-full text-lg"
-            autofocus
-          />
-        </div>
-        <div class="w-full md:w-48">
-          <select
-            v-model="selectedCollection"
-            class="w-full h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
-          >
-            <option v-for="col in collections" :key="col" :value="col">
-              {{ col === 'all' ? 'All content' : getCollectionLabel(col) + 's' }}
-            </option>
-          </select>
-        </div>
-      </div>
-
-      <div class="mt-4 text-sm text-gray-600">
-        <span v-if="isLoading">Loading search index...</span>
-        <span v-else-if="!searchQuery.trim()">
-          Enter a search term to find content across {{ searchIndex.length.toLocaleString() }} pages
-        </span>
-        <span v-else>
-          Found {{ results.length }} result{{ results.length !== 1 ? 's' : '' }}
-          <span v-if="results.length >= 100">(showing first 100)</span>
-        </span>
-      </div>
+    <!-- Shared search input -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
+      <Input
+        v-model="searchQuery"
+        type="text"
+        placeholder="Search articles, events, platforms..."
+        class="w-full text-lg"
+        autofocus
+      />
     </div>
 
-    <!-- Results -->
-    <div v-if="results.length > 0" class="space-y-4">
-      <article
-        v-for="result in results"
-        :key="result.slug"
-        class="bg-white rounded-lg border border-gray-200 p-5 hover:shadow-md transition-shadow"
-      >
-        <a :href="result.path" class="block">
-          <div class="flex items-start justify-between gap-4 mb-2">
-            <h2 class="text-lg font-semibold text-gray-900 hover:text-galaxy-primary transition-colors">
-              {{ result.title }}
-              <ExternalIcon v-if="result.collection === 'events' && result.external_url" />
-            </h2>
-            <span :class="['text-xs px-2 py-1 rounded-full whitespace-nowrap', getCollectionColor(result.collection)]">
-              {{ getCollectionLabel(result.collection) }}
-            </span>
-          </div>
+    <!-- Tabs -->
+    <Tabs v-model="activeTab" default-value="hub">
+      <TabsList class="mb-6">
+        <TabsTrigger value="hub">Hub Search</TabsTrigger>
+        <TabsTrigger value="google">Pan-Galactic Search</TabsTrigger>
+        <TabsTrigger value="publications">Publication Search</TabsTrigger>
+      </TabsList>
 
-          <p
-            v-if="result.excerpt || result.tease"
-            class="text-gray-600 text-sm mb-3"
-            v-html="highlightMatch(result.tease || result.excerpt)"
-          ></p>
+      <TabsContent value="hub">
+        <HubSearch :query="searchQuery" />
+      </TabsContent>
 
-          <div class="flex items-center gap-4 text-xs text-gray-500">
-            <time v-if="result.date">{{ formatDate(result.date) }}</time>
-            <div v-if="result.tags?.length" class="flex gap-1 flex-wrap">
-              <span v-for="tag in result.tags.slice(0, 3)" :key="tag" class="px-2 py-0.5 bg-gray-100 rounded">
-                {{ tag }}
-              </span>
-              <span v-if="result.tags.length > 3" class="text-gray-400"> +{{ result.tags.length - 3 }} more </span>
-            </div>
-          </div>
-        </a>
-      </article>
-    </div>
+      <TabsContent value="google">
+        <PanGalacticSearch :query="searchQuery" />
+      </TabsContent>
 
-    <!-- No results -->
-    <div v-else-if="searchQuery.trim() && !isLoading" class="text-center py-12">
-      <svg class="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-        ></path>
-      </svg>
-      <p class="text-gray-500 mb-2">No results found for "{{ searchQuery }}"</p>
-      <p class="text-sm text-gray-400">Try different keywords or check your spelling</p>
-    </div>
-
-    <!-- Empty state -->
-    <div v-else-if="!isLoading" class="text-center py-12">
-      <svg class="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-        ></path>
-      </svg>
-      <p class="text-gray-500">Start typing to search the Galaxy Community Hub</p>
-    </div>
+      <TabsContent value="publications">
+        <PublicationSearch :query="searchQuery" />
+      </TabsContent>
+    </Tabs>
   </div>
 </template>

--- a/astro/src/pages/search.astro
+++ b/astro/src/pages/search.astro
@@ -7,7 +7,9 @@ import SearchPage from '../components/search/SearchPage.vue';
   <div class="max-w-4xl mx-auto">
     <header class="mb-8">
       <h1 class="text-3xl font-bold text-gray-900 mb-2">Search</h1>
-      <p class="text-lg text-gray-600">Find articles, events, and platforms across the Galaxy Community Hub</p>
+      <p class="text-lg text-gray-600">
+        Search the Galaxy Community Hub, the broader Galaxy ecosystem, or the Galaxy publication library.
+      </p>
     </header>
 
     <SearchPage client:load />


### PR DESCRIPTION
## Summary

Addresses #3531 — adds the legacy "Pan-Galactic Google Search" and "Galaxy Publication Search" back to the `/search` page alongside the existing hub search.

- Refactors `/search` into a three-tab interface using existing Reka UI tabs: **Hub Search** (local client-side, the default), **Pan-Galactic Search** (Google CSE covering the broader Galaxy ecosystem), and **Publication Search** (Zotero API for the Galaxy publication library)
- Extracts the existing local search into `HubSearch.vue`, adds `PanGalacticSearch.vue` and `PublicationSearch.vue` as new components
- Shared query input across all tabs, with `?q=` and `?tab=` URL parameters for shareable links
- Google CSE script loads on-demand with error handling for ad blockers
- Uses the same Google CSE engine ID and Zotero group ID as the legacy Gridsome site

## Test plan

- [x] Existing Playwright search test passes
- [x] All 93 unit tests pass
- [x] Lint and format clean
- [ ] Manually verify Hub Search tab works with query from sidebar
- [ ] Manually verify Pan-Galactic Search tab loads and returns Google results
- [ ] Manually verify Publication Search tab returns Zotero results
- [ ] Verify `?q=search+term&tab=google` URL sharing works