### PR TITLE
Fix GCC registration VAT, is included in price, rate is 10%

### DIFF
--- a/content/events/gcc2026/register/index.md
+++ b/content/events/gcc2026/register/index.md
@@ -25,8 +25,8 @@ purchased along with the registration. If you'd like to purchase additional
 dinner tickets for your travel companion(s) you can do so at the time of
 registration.
 
-**Please note that all prices are listed in Euros (EUR) and exclude the mandatory
-VAT (21%).** When paying for the registration, you can use a credit card or do a bank
+**Please note that all prices are listed in Euros (EUR) and include the mandatory
+VAT (10%).** When paying for the registration, you can use a credit card or do a bank
 transfer. You can also register and request the payment be processed afterwards
 by someone else, such as your department administrator. If you prefer to
 reason in a different currency, here is a convenient [currency
@@ -53,9 +53,6 @@ provided.
 | Academic / Non-Profit / Government | EUR350 | EUR400 | EUR480   |
 | Industry                           | EUR450 | EUR675 | EUR1,000 |
 | Conference dinner                  |        |        | EUR70    |
-
-\* Please note that the above prices do not include the mandatory 21% VAT, which
-will be added during registration.
 
 <div class="text-center my-5">
     <a href="https://v4.event-vert.org/en/gcc2026" type="button" class="btn btn-primary">


### PR DESCRIPTION
Confirmed by Jenn Vessio and aligns with the invoice I received. ping @bebatut 