### PR TITLE
Fix YAML parse error in people.yaml

### DIFF
--- a/content/people/people.yaml
+++ b/content/people/people.yaml
@@ -201,7 +201,7 @@ freiburg:
         website: http://leendertse.eu
         linkedin: JanLeendertse
         researchgate: JanLeendertse
-        matrix: @janleendertse:matrix.org
+        matrix: "@janleendertse:matrix.org"
 
     beatrizserrano:
         name: Beatriz Serrano-Solano


### PR DESCRIPTION
The `matrix` value for `janleendertse` was unquoted (`@janleendertse:matrix.org`), which breaks js-yaml since `@` and `:` are special YAML characters. This was introduced in 2f56b7f80 and prevents the Astro site from building or starting the dev server.

All other `matrix` entries in the file are already quoted — this just adds the missing quotes.