### PR TITLE
Search page styling and tab switch fix

### DIFF
--- a/astro/src/components/search/SearchPage.vue
+++ b/astro/src/components/search/SearchPage.vue
@@ -58,20 +58,35 @@ watch(activeTab, (tab) => {
     <!-- Tabs -->
     <Tabs v-model="activeTab" default-value="hub">
       <TabsList class="mb-6 bg-galaxy-dark/10 p-1">
-        <TabsTrigger value="hub" class="data-[state=active]:bg-galaxy-primary data-[state=active]:text-white data-[state=active]:shadow-md">Hub Search</TabsTrigger>
-        <TabsTrigger value="google" class="data-[state=active]:bg-galaxy-primary data-[state=active]:text-white data-[state=active]:shadow-md">Pan-Galactic Search</TabsTrigger>
-        <TabsTrigger value="publications" class="data-[state=active]:bg-galaxy-primary data-[state=active]:text-white data-[state=active]:shadow-md">Publication Search</TabsTrigger>
+        <TabsTrigger
+          value="hub"
+          class="data-[state=active]:bg-galaxy-primary data-[state=active]:text-white data-[state=active]:shadow-md"
+        >
+          Hub Search
+        </TabsTrigger>
+        <TabsTrigger
+          value="google"
+          class="data-[state=active]:bg-galaxy-primary data-[state=active]:text-white data-[state=active]:shadow-md"
+        >
+          Pan-Galactic Search
+        </TabsTrigger>
+        <TabsTrigger
+          value="publications"
+          class="data-[state=active]:bg-galaxy-primary data-[state=active]:text-white data-[state=active]:shadow-md"
+        >
+          Publication Search
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="hub">
         <HubSearch :query="searchQuery" />
       </TabsContent>
 
-      <TabsContent value="google">
+      <TabsContent value="google" force-mount>
         <PanGalacticSearch :query="searchQuery" />
       </TabsContent>
 
-      <TabsContent value="publications">
+      <TabsContent value="publications" force-mount>
         <PublicationSearch :query="searchQuery" />
       </TabsContent>
     </Tabs>

--- a/astro/src/pages/search.astro
+++ b/astro/src/pages/search.astro
@@ -6,7 +6,10 @@ import SearchPage from '../components/search/SearchPage.vue';
 
 <BaseLayout title="Search" description="Search the Galaxy Community Hub">
   <div class="max-w-6xl mx-auto">
-    <PageHeader title="Search" description="Search the Galaxy Community Hub, the broader Galaxy ecosystem, or the Galaxy publication library." />
+    <PageHeader
+      title="Search"
+      description="Search the Galaxy Community Hub, the broader Galaxy ecosystem, or the Galaxy publication library."
+    />
 
     <div class="bg-white px-6 sm:px-8 py-6 rounded-b-lg shadow-sm">
       <SearchPage client:load />


### PR DESCRIPTION
## Summary

- Use standard page container for search page (PageHeader + white card body), matching layout of news/events/etc
- Style search tabs with Galaxy-branded colors instead of default shadcn neutral
- Fix Pan-Galactic and Publication search not executing when switching tabs — `forceMount` keeps components alive so Google CSE's global state and Zotero results persist across tab switches

## Test plan

- [ ] Navigate to /search, type a query, confirm Hub Search works
- [ ] Click Pan-Galactic Search tab — Google results should appear
- [ ] Click Publication Search tab — Zotero results should appear
- [ ] Switch back to Hub, change query, switch to other tabs — results should update
- [ ] Load directly via URL: `/search?q=cloud&tab=google` — should show Google results
- [ ] Verify page layout matches other pages (news, events) with PageHeader and card body