### PR TITLE
Hide inactive force-mounted search tabs

### DIFF
--- a/astro/src/components/search/SearchPage.vue
+++ b/astro/src/components/search/SearchPage.vue
@@ -82,11 +82,11 @@ watch(activeTab, (tab) => {
         <HubSearch :query="searchQuery" />
       </TabsContent>
 
-      <TabsContent value="google" force-mount>
+      <TabsContent value="google" force-mount class="data-[state=inactive]:hidden">
         <PanGalacticSearch :query="searchQuery" />
       </TabsContent>
 
-      <TabsContent value="publications" force-mount>
+      <TabsContent value="publications" force-mount class="data-[state=inactive]:hidden">
         <PublicationSearch :query="searchQuery" />
       </TabsContent>
     </Tabs>


### PR DESCRIPTION
## Summary
- Fixes inactive force-mounted `TabsContent` panels being visible simultaneously on the search page
- Reka UI's `force-mount` keeps components alive across tab switches but intentionally doesn't hide inactive content — the consumer is expected to handle visibility
- Adds `data-[state=inactive]:hidden` to the Google and Publications tab panels so they get `display: none` when not selected

Closes #3700