### PR TITLE
Remove stale Vue syntax from content files

### DIFF
--- a/content/bare/eu/usegalaxy/proteomics/index.md
+++ b/content/bare/eu/usegalaxy/proteomics/index.md
@@ -32,7 +32,7 @@ Welcome to **Galaxy Proteomics**
 
 </div>
 <div class="right" style="width: calc(50% - 12px); max-width: 400px">
-  <twitter user="usegalaxyp" :height="420"></twitter>
+  <twitter user="usegalaxyp" height="420"></twitter>
 </div>
 <div class="clearfix">
 </div>

--- a/content/news/2022-06-23-reached-50000-users/index.md
+++ b/content/news/2022-06-23-reached-50000-users/index.md
@@ -64,7 +64,6 @@ And we wanted to celebrate this important milestone with __all the people that h
 
 __Big thanks__ to everybody that has contributed to the success of UseGalaxy.eu and to each of the 50K users for using Galaxy! Next stop: 100K!
 
-import Flickr from '@/components/Flickr.vue';
 <div class="center">
   <Flickr title="50k user workshop" link="https://www.flickr.com/photos/134305289@N03/52168204601/in/shares-eLN9iG/" coverWidth="640" coverHeight="427" cover="https://live.staticflickr.com/65535/52168204601_12fc4c1f4a.jpg"></Flickr>
 </div>


### PR DESCRIPTION
Remove Gridsome-era Vue syntax from two content source files — a stale `import Flickr` and a Vue `:height` prop binding. The Astro preprocessor (`stripVueArtifacts`) handles these automatically, but cleaning the source is better long-term.

## Files
- `content/news/2022-06-23-reached-50000-users/index.md` — remove unused `import Flickr from '@/components/Flickr.vue'`
- `content/bare/eu/usegalaxy/proteomics/index.md` — `:height="420"` → `height="420"`