### PR TITLE
Fix date hydration mismatch on news/events pages

### DIFF
--- a/astro/src/utils/dateUtils.ts
+++ b/astro/src/utils/dateUtils.ts
@@ -31,6 +31,7 @@ export function formatDate(date: Date | string | undefined, short: boolean = tru
   const d = toDate(date);
   if (!d || isNaN(d.getTime())) return '';
   return d.toLocaleDateString('en-US', {
+    timeZone: 'UTC',
     year: 'numeric',
     month: short ? 'short' : 'long',
     day: 'numeric',
@@ -64,6 +65,7 @@ export function formatDateRange(
   // Same month and year - show "Jan 15 - 17, 2024"
   if (startDate.getMonth() === endDate.getMonth() && startDate.getFullYear() === endDate.getFullYear()) {
     const monthDay = startDate.toLocaleDateString('en-US', {
+      timeZone: 'UTC',
       month: short ? 'short' : 'long',
       day: 'numeric',
     });


### PR DESCRIPTION
@afgane I think this was it.  Closes #3745 

## Summary

- Adds `timeZone: 'UTC'` to the two `toLocaleDateString()` calls in `dateUtils.ts`, fixing the "Hydration completed but contains mismatches" console error on `/news/` and `/events/`

The build server renders dates in UTC, but client browsers in other timezones (e.g. UTC-7) would re-render midnight-UTC dates as the previous day during hydration. Pinning to UTC ensures server and client always produce identical date strings.

## Test plan

- [ ] `npm run test:unit` passes
- [ ] Open `/news/` in a non-UTC timezone browser, confirm no hydration mismatch warning in console
- [ ] Dates display correctly (matching content frontmatter)