### PR TITLE
Add additional NFDI4BioImage annotation to news and events pages

### DIFF
--- a/content/events/2025-04-22-galaxy-imaging-hackathon/index.md
+++ b/content/events/2025-04-22-galaxy-imaging-hackathon/index.md
@@ -17,6 +17,7 @@ contributions:
   funding:
     - nfdi
     - oscars
+    - nfdi4bioimage
 
 ---
 

--- a/content/events/2025-08-26-cordi/index.md
+++ b/content/events/2025-08-26-cordi/index.md
@@ -14,6 +14,8 @@ subsites: [all]
 contributions:
   authorship:
     - Sch-Da
+  funding:
+    - nfdi4bioimage
 
 ---
 

--- a/content/news/2025-10-21-BiaPy-available-in-Galaxy/index.md
+++ b/content/news/2025-10-21-BiaPy-available-in-Galaxy/index.md
@@ -3,6 +3,8 @@ title: "New Galaxy Tool: BiaPy – Deep Learning for Bioimage Analysis in Galaxy
 contributions:
   authorship:
     - danifranco
+  funding:
+    - nfdi4bioimage
 tags: [imaging, workflow, microscopy]
 layout: news
 date: "2025-10-21"


### PR DESCRIPTION
Following https://github.com/galaxyproject/galaxy-hub/pull/3744 this PR adds the NFDI4BioImage annotation to relevant news and event pages across the website

Changes included

- Added NFDI4BioImage annotation to multiple news posts
- Added NFDI4BioImage annotation to relevant event pages

ping @dianichj @bgruening 