### PR TITLE
Fix UTC date handling for hydration mismatches and feeds

### DIFF
--- a/astro/src/components/events/EventsList.vue
+++ b/astro/src/components/events/EventsList.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { useStore } from '@nanostores/vue';
 import { currentSubsite, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { renderMarkdownInline } from '@/utils/markdown';
-import { formatDateRange } from '@/utils/dateUtils';
+import { formatDateRange, getUTCYear } from '@/utils/dateUtils';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface EventData {
@@ -66,7 +66,7 @@ function loadMorePast() {
 function getYear(event: EventData): number | null {
   if (!event.date) return null;
   const date = new Date(event.date);
-  return isNaN(date.getTime()) ? null : date.getFullYear();
+  return isNaN(date.getTime()) ? null : getUTCYear(date);
 }
 
 // Helper to normalize subsites to array

--- a/astro/src/components/news/NewsList.vue
+++ b/astro/src/components/news/NewsList.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { useStore } from '@nanostores/vue';
 import { currentSubsite, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { renderMarkdownInline } from '@/utils/markdown';
-import { formatDate } from '@/utils/dateUtils';
+import { formatDate, getUTCYear } from '@/utils/dateUtils';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface NewsArticle {
@@ -72,7 +72,7 @@ const filteredBySubsite = computed(() => {
 function getYear(article: NewsArticle): number | null {
   if (!article.date) return null;
   const date = new Date(article.date);
-  return isNaN(date.getTime()) ? null : date.getFullYear();
+  return isNaN(date.getTime()) ? null : getUTCYear(date);
 }
 
 // Available years (sorted descending)

--- a/astro/src/pages/events/feed.json.ts
+++ b/astro/src/pages/events/feed.json.ts
@@ -10,9 +10,9 @@ const JSONFEED_DAYS_AGO_LIMIT = 30;
 
 function formatDate(date: Date): string {
   // Match Gridsome format: "4 November 2026"
-  const day = date.getDate();
-  const month = date.toLocaleDateString('en-US', { month: 'long' });
-  const year = date.getFullYear();
+  const day = date.getUTCDate();
+  const month = date.toLocaleDateString('en-US', { timeZone: 'UTC', month: 'long' });
+  const year = date.getUTCFullYear();
   return `${day} ${month} ${year}`;
 }
 

--- a/astro/src/pages/news/feed.json.ts
+++ b/astro/src/pages/news/feed.json.ts
@@ -11,9 +11,9 @@ const JSONFEED_DAYS_AGO_LIMIT = 30;
 
 function formatDate(date: Date): string {
   // Match Gridsome format: "22 December 2025"
-  const day = date.getDate();
-  const month = date.toLocaleDateString('en-US', { month: 'long' });
-  const year = date.getFullYear();
+  const day = date.getUTCDate();
+  const month = date.toLocaleDateString('en-US', { timeZone: 'UTC', month: 'long' });
+  const year = date.getUTCFullYear();
   return `${day} ${month} ${year}`;
 }
 

--- a/astro/src/utils/dateUtils.ts
+++ b/astro/src/utils/dateUtils.ts
@@ -22,6 +22,23 @@ function toDate(d: Date | string | undefined): Date | null {
 }
 
 /**
+ * UTC date component helpers — use these instead of getFullYear()/getMonth()/getDate()
+ * to avoid hydration mismatches between server (UTC) and client (local timezone).
+ */
+export function getUTCYear(date: Date | string): number {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.getUTCFullYear();
+}
+export function getUTCMonth(date: Date | string): number {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.getUTCMonth();
+}
+export function getUTCDate(date: Date | string): number {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.getUTCDate();
+}
+
+/**
  * Format a date for display
  * @param date - Date to format
  * @param short - If true, use short month names (Jan, Feb). Default true for lists.
@@ -63,13 +80,13 @@ export function formatDateRange(
   }
 
   // Same month and year - show "Jan 15 - 17, 2024"
-  if (startDate.getMonth() === endDate.getMonth() && startDate.getFullYear() === endDate.getFullYear()) {
+  if (startDate.getUTCMonth() === endDate.getUTCMonth() && startDate.getUTCFullYear() === endDate.getUTCFullYear()) {
     const monthDay = startDate.toLocaleDateString('en-US', {
       timeZone: 'UTC',
       month: short ? 'short' : 'long',
       day: 'numeric',
     });
-    return `${monthDay} - ${endDate.getDate()}, ${endDate.getFullYear()}`;
+    return `${monthDay} - ${endDate.getUTCDate()}, ${endDate.getUTCFullYear()}`;
   }
 
   // Different months - show full dates


### PR DESCRIPTION
## Summary

- Use UTC methods consistently across all date handling so server-rendered output (built in UTC) matches client hydration in any local timezone
- Adds `getUTCYear`, `getUTCMonth`, `getUTCDate` helpers to `dateUtils.ts` and uses them in `NewsList.vue` and `EventsList.vue` year extraction
- Fixes `formatDateRange()` to use UTC month/day/year comparisons instead of local-timezone methods
- Fixes `formatDate()` in both `news/feed.json.ts` and `events/feed.json.ts` to use `getUTCDate()`, `getUTCFullYear()`, and `toLocaleDateString` with `timeZone: 'UTC'`

## Test plan

- [x] `npm run test:unit` — all 162 tests pass
- [x] `npm run lint && npm run format:check` — clean
- [x] Dev server `/news/feed.json` returns 8 recent articles with correct UTC dates
- [x] Dev server `/events/feed.json` returns 16 events with correct UTC dates
- [ ] Verify no "Hydration completed but contains mismatches" console errors on `/news/` and `/events/`