### PR TITLE
Remove master branch triggers from workflows

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches:
       - main
-      - master
     paths:
       - "**.jpg"
       - "**.jpeg"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   schedule:
     - cron: "30 23 * * *"
 concurrency:

--- a/.github/workflows/rewrites.yml
+++ b/.github/workflows/rewrites.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - main
-      - master
     paths:
       - 'deploy/rewrites.js'
   pull_request:
     branches:
       - main
-      - master
     paths:
       - 'deploy/rewrites.js'
 
@@ -33,7 +31,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Now that `master` has been renamed to `main`, remove the transitional `master` triggers from the workflow files that were added in the preparation PR.

Affected workflows: publish.yml, rewrites.yml, optimize-images.yml