### PR TITLE
extend search for Tags, Contributors, Organisations and Funders

### DIFF
--- a/astro/src/build/generate-search-index.test.mjs
+++ b/astro/src/build/generate-search-index.test.mjs
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildHallOfFameEntries,
+  classifyFunding,
+  extractCommunityMetadata,
+  communitySlug,
+} from './generate-search-index.mjs';
+
+describe('generate-search-index metadata helpers', () => {
+  const communityData = {
+    contributors: {},
+    organisations: {
+      deNBI: { name: 'de.NBI' },
+    },
+    grants: {
+      eurosciencegateway: { name: 'EuroScienceGateway' },
+    },
+    lookups: {
+      contributors: new Set(),
+      organisations: new Set(['denbi', 'de-nbi']),
+      grants: new Set(['eurosciencegateway']),
+    },
+    tagLookup: {
+      exact: new Map([
+        ['cofest', new Set(['CoFest'])],
+        ['esg-wp1', new Set(['esg-wp1'])],
+      ]),
+      compact: new Map([
+        ['cofest', new Set(['CoFest'])],
+        ['esgwp1', new Set(['esg-wp1'])],
+      ]),
+    },
+  };
+
+  it('classifies funding references into organisations and grants', () => {
+    const result = classifyFunding(['deNBI', 'eurosciencegateway', 'UnknownSponsor'], communityData);
+    expect(result.organisations).toContain('deNBI');
+    expect(result.organisations).toContain('UnknownSponsor');
+    expect(result.grants).toContain('eurosciencegateway');
+  });
+
+  it('extracts tags and community metadata from frontmatter', () => {
+    const metadata = extractCommunityMetadata(
+      {
+        slug: 'news/example',
+        CONTRIBUTORS: ['afgane'],
+        ORGANISATIONS: ['deNBI'],
+        GRANTS: ['eurosciencegateway'],
+        tags: ['community', 'cofest', 'esg wp1'],
+        contributions: {
+          authorship: ['afgane'],
+          funding: ['deNBI', 'eurosciencegateway'],
+        },
+      },
+      communityData
+    );
+
+    expect(metadata.tags).toContain('community');
+    expect(metadata.tags).toContain('CoFest');
+    expect(metadata.tags).toContain('esg-wp1');
+    expect(metadata.contributors).toContain('afgane');
+    expect(metadata.organisations).toContain('deNBI');
+    expect(metadata.grants).toContain('eurosciencegateway');
+    expect(metadata.search_terms).toContain('news/example');
+  });
+});
+
+describe('generate-search-index hall-of-fame entries', () => {
+  it('creates hall-of-fame entries with searchable ids and slugs', () => {
+    const communityData = {
+      contributors: {
+        alice: {
+          name: 'Alice Example',
+          joined: '2024-02',
+          affiliations: ['deNBI'],
+        },
+      },
+      organisations: {
+        deNBI: {
+          name: 'de.NBI',
+        },
+      },
+      grants: {},
+      lookups: {
+        contributors: new Set(['alice']),
+        organisations: new Set(['denbi', 'de-nbi']),
+        grants: new Set(),
+      },
+    };
+
+    const entries = buildHallOfFameEntries(communityData);
+
+    const orgEntry = entries.find((entry) => entry.slug === `hall-of-fame/${communitySlug('deNBI')}`);
+    expect(orgEntry).toBeDefined();
+    expect(orgEntry.path).toBe('/hall-of-fame/denbi/');
+    expect(orgEntry.search_terms).toContain('denbi');
+
+    const contributorEntry = entries.find((entry) => entry.slug === 'hall-of-fame/alice');
+    expect(contributorEntry).toBeDefined();
+    expect(contributorEntry.organisations).toContain('deNBI');
+  });
+});

--- a/astro/src/build/preprocess.mjs
+++ b/astro/src/build/preprocess.mjs
@@ -28,7 +28,7 @@ const PUBLIC_MEDIA_DIR = path.join(ASTRO_ROOT, 'public/media');
 // Post-normalization fixups for edge cases where the algorithm produces bad output.
 // Keys are the bad normalized form; values are the corrected form.
 // Applied after all regex rules + lowercasing, so keys should be lowercase-hyphenated.
-import slugOverrides from './slug-overrides.json' with { type: 'json' };
+const slugOverrides = JSON.parse(fs.readFileSync(new URL('./slug-overrides.json', import.meta.url), 'utf-8'));
 
 /**
  * Normalize a single path segment into a lowercase-hyphenated slug.

--- a/astro/src/build/search-index/community-metadata.mjs
+++ b/astro/src/build/search-index/community-metadata.mjs
@@ -1,0 +1,313 @@
+import fs from 'fs';
+import path from 'path';
+import { parse } from 'yaml';
+import { communitySlug, toArray } from '../../utils/community-base.mjs';
+export { communitySlug } from '../../utils/community-base.mjs';
+
+function uniqueStrings(values) {
+  return Array.from(
+    new Set(
+      values
+        .filter((v) => v !== undefined && v !== null)
+        .map((v) => String(v).trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+function lookupTokens(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return [];
+  const lower = raw.toLowerCase();
+  const slug = communitySlug(raw);
+  const compact = lower.replace(/[^a-z0-9]+/g, '');
+  return uniqueStrings([lower, slug, compact]);
+}
+
+function matchesLookup(value, lookupSet) {
+  const tokens = lookupTokens(value);
+  return tokens.some((token) => lookupSet.has(token));
+}
+
+function loadYamlMap(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return {};
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function loadYamlList(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((v) => typeof v === 'string')
+      .map((v) => v.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function normalizeTagToken(value) {
+  return String(value || '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function addSetMap(map, key, value) {
+  if (!key) return;
+  if (!map.has(key)) {
+    map.set(key, new Set());
+  }
+  map.get(key).add(value);
+}
+
+function buildTagLookup(tags) {
+  const exact = new Map();
+  const compact = new Map();
+  for (const tag of tags) {
+    const raw = String(tag || '').trim();
+    if (!raw) continue;
+    addSetMap(exact, raw.toLowerCase(), raw);
+    addSetMap(compact, normalizeTagToken(raw), raw);
+  }
+  return { exact, compact };
+}
+
+function expandTagVariants(tag, tagLookup) {
+  const raw = String(tag || '').trim();
+  if (!raw) return [];
+
+  const variants = new Set([raw]);
+  const exactMatches = tagLookup?.exact?.get(raw.toLowerCase());
+  const compactMatches = tagLookup?.compact?.get(normalizeTagToken(raw));
+
+  exactMatches?.forEach((v) => variants.add(v));
+  compactMatches?.forEach((v) => variants.add(v));
+
+  return Array.from(variants);
+}
+
+function buildLookupSet(map) {
+  const lookup = new Set();
+  for (const [id, value] of Object.entries(map || {})) {
+    const record = value && typeof value === 'object' ? value : {};
+    [id, record.name, record.short_name].forEach((candidate) => {
+      lookupTokens(candidate).forEach((token) => lookup.add(token));
+    });
+  }
+  return lookup;
+}
+
+const communityDataCache = new Map();
+
+export function loadCommunityData(sourceContentDir) {
+  if (communityDataCache.has(sourceContentDir)) {
+    return communityDataCache.get(sourceContentDir);
+  }
+
+  const contributors = loadYamlMap(path.join(sourceContentDir, 'CONTRIBUTORS.yaml'));
+  const organisations = loadYamlMap(path.join(sourceContentDir, 'ORGANISATIONS.yaml'));
+  const grants = loadYamlMap(path.join(sourceContentDir, 'GRANTS.yaml'));
+  const tags = loadYamlList(path.join(sourceContentDir, 'TAGS.yaml'));
+
+  const data = {
+    contributors,
+    organisations,
+    grants,
+    tags,
+    tagLookup: buildTagLookup(tags),
+    lookups: {
+      contributors: buildLookupSet(contributors),
+      organisations: buildLookupSet(organisations),
+      grants: buildLookupSet(grants),
+    },
+  };
+
+  communityDataCache.set(sourceContentDir, data);
+  return data;
+}
+
+function normalizeDate(value) {
+  if (!value) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  let candidate = raw;
+  if (/^\d{4}-\d{2}$/.test(raw)) {
+    candidate = `${raw}-01`;
+  } else if (/^\d{4}$/.test(raw)) {
+    candidate = `${raw}-01-01`;
+  }
+
+  const date = new Date(candidate);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export function classifyFunding(values, communityData) {
+  const organisations = [];
+  const grants = [];
+
+  for (const value of uniqueStrings(values)) {
+    if (matchesLookup(value, communityData.lookups.grants)) {
+      grants.push(value);
+      continue;
+    }
+    if (matchesLookup(value, communityData.lookups.organisations)) {
+      organisations.push(value);
+      continue;
+    }
+    // Unknown funding references are treated as organisation-style supporters.
+    organisations.push(value);
+  }
+
+  return {
+    organisations: uniqueStrings(organisations),
+    grants: uniqueStrings(grants),
+  };
+}
+
+export function extractCommunityMetadata(frontmatter, communityData) {
+  const contributions = frontmatter.contributions || {};
+
+  const contributors = uniqueStrings([
+    ...toArray(frontmatter.CONTRIBUTORS),
+    ...toArray(frontmatter.contributors),
+    ...toArray(contributions.authorship),
+    ...toArray(contributions.author),
+    ...toArray(contributions.contributors),
+  ]);
+
+  const directOrganisations = uniqueStrings([
+    ...toArray(frontmatter.ORGANISATIONS),
+    ...toArray(frontmatter.organisations),
+    ...toArray(frontmatter.organizations),
+  ]);
+
+  const directGrants = uniqueStrings([...toArray(frontmatter.GRANTS), ...toArray(frontmatter.grants)]);
+
+  const fundingCandidates = uniqueStrings([
+    ...toArray(contributions.funding),
+    ...toArray(frontmatter.funding),
+    ...toArray(frontmatter.infrastructure),
+    ...toArray(frontmatter.data),
+  ]);
+  const funding = classifyFunding(fundingCandidates, communityData);
+
+  const organisations = uniqueStrings([...directOrganisations, ...funding.organisations]);
+  const grants = uniqueStrings([...directGrants, ...funding.grants]);
+  const rawTags = uniqueStrings(toArray(frontmatter.tags));
+  const tags = uniqueStrings(rawTags.flatMap((tag) => expandTagVariants(tag, communityData.tagLookup)));
+
+  return {
+    tags,
+    contributors,
+    organisations,
+    grants,
+    search_terms: uniqueStrings([
+      frontmatter.slug,
+      frontmatter.naturalSlug,
+      ...tags,
+      ...contributors,
+      ...organisations,
+      ...grants,
+    ]),
+  };
+}
+
+function buildHallOfFameEntry(type, id, record, extractText, truncate, communityData) {
+  const slug = communitySlug(id);
+  if (!slug) return null;
+
+  const displayName = record.name || record.short_name || id;
+  const profileText = extractText(
+    [record.bio, record.description, record.funding_statement].filter((v) => typeof v === 'string').join('\n\n')
+  );
+
+  const entry = {
+    title: displayName,
+    slug: `hall-of-fame/${slug}`,
+    path: `/hall-of-fame/${slug}/`,
+    external_url: null,
+    excerpt: truncate(profileText),
+    tease: '',
+    tags: uniqueStrings(['hall-of-fame', type]),
+    date: normalizeDate(record.joined),
+    collection: 'hall-of-fame',
+    contributors: [],
+    organisations: [],
+    grants: [],
+    search_terms: uniqueStrings([id, record.name, record.short_name, slug, slug.replace(/-/g, '')]),
+  };
+
+  if (type === 'contributor') {
+    const affiliations = uniqueStrings([...toArray(record.affiliations), ...toArray(record.former_affiliations)]);
+    const classifiedAffiliations = classifyFunding(affiliations, communityData);
+    entry.contributors = uniqueStrings([id, record.name]);
+    entry.organisations = classifiedAffiliations.organisations;
+    entry.grants = classifiedAffiliations.grants;
+    entry.search_terms = uniqueStrings([
+      ...entry.search_terms,
+      ...entry.contributors,
+      ...entry.organisations,
+      ...entry.grants,
+    ]);
+    return entry;
+  }
+
+  if (type === 'organisation') {
+    entry.organisations = uniqueStrings([id, record.name, record.short_name]);
+    entry.search_terms = uniqueStrings([...entry.search_terms, ...entry.organisations]);
+    return entry;
+  }
+
+  entry.grants = uniqueStrings([id, record.name, record.short_name, record.funding_id, record.funder_name]);
+  entry.search_terms = uniqueStrings([...entry.search_terms, ...entry.grants]);
+  return entry;
+}
+
+function mergeHallOfFameEntries(existing, incoming) {
+  return {
+    ...existing,
+    title: existing.title || incoming.title,
+    excerpt: existing.excerpt.length >= incoming.excerpt.length ? existing.excerpt : incoming.excerpt,
+    date: existing.date || incoming.date,
+    tags: uniqueStrings([...existing.tags, ...incoming.tags]),
+    contributors: uniqueStrings([...existing.contributors, ...incoming.contributors]),
+    organisations: uniqueStrings([...existing.organisations, ...incoming.organisations]),
+    grants: uniqueStrings([...existing.grants, ...incoming.grants]),
+    search_terms: uniqueStrings([...existing.search_terms, ...incoming.search_terms]),
+  };
+}
+
+export function buildHallOfFameEntries(communityData, extractText, truncate) {
+  const bySlug = new Map();
+
+  const addEntry = (type, id, record) => {
+    const entry = buildHallOfFameEntry(type, id, record, extractText, truncate, communityData);
+    if (!entry) return;
+    const existing = bySlug.get(entry.slug);
+    bySlug.set(entry.slug, existing ? mergeHallOfFameEntries(existing, entry) : entry);
+  };
+
+  for (const [id, record] of Object.entries(communityData.contributors || {})) {
+    addEntry('contributor', id, record && typeof record === 'object' ? record : {});
+  }
+  for (const [id, record] of Object.entries(communityData.organisations || {})) {
+    addEntry('organisation', id, record && typeof record === 'object' ? record : {});
+  }
+  for (const [id, record] of Object.entries(communityData.grants || {})) {
+    addEntry('grant', id, record && typeof record === 'object' ? record : {});
+  }
+
+  return Array.from(bySlug.values());
+}

--- a/astro/src/build/search-index/text-utils.mjs
+++ b/astro/src/build/search-index/text-utils.mjs
@@ -1,0 +1,39 @@
+/**
+ * Extract plain text from markdown content.
+ */
+export function extractText(markdown) {
+  return (
+    markdown
+      // Remove frontmatter
+      .replace(/^---[\s\S]*?---\n?/, '')
+      // Remove HTML tags
+      .replace(/<[^>]+>/g, '')
+      // Remove markdown links, keep text
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      // Remove markdown images
+      .replace(/!\[([^\]]*)\]\([^)]+\)/g, '')
+      // Remove bold/italic
+      .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+      // Remove code blocks
+      .replace(/```[\s\S]*?```/g, '')
+      // Remove inline code
+      .replace(/`[^`]+`/g, '')
+      // Remove headers
+      .replace(/#{1,6}\s+/g, '')
+      // Remove blockquotes
+      .replace(/^>\s+/gm, '')
+      // Remove horizontal rules
+      .replace(/^[-*_]{3,}\s*$/gm, '')
+      // Normalize whitespace
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+/**
+ * Truncate text to a maximum length.
+ */
+export function truncate(text, maxLength = 300) {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength).replace(/\s+\S*$/, '') + '...';
+}

--- a/astro/src/utils/community-base.mjs
+++ b/astro/src/utils/community-base.mjs
@@ -1,0 +1,32 @@
+/**
+ * Shared normalization helpers for community identifiers and frontmatter values.
+ */
+export function communitySlug(value) {
+  const normalized = String(value || '')
+    .trim()
+    .replace(/^@/, '');
+  return normalized
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Convert unknown values to a flat array of strings.
+ * Handles arrays, objects with id/name/github/twitter fields, and primitives.
+ */
+export function toArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => toArray(v));
+  }
+  if (typeof value === 'object') {
+    const obj = value;
+    if (obj.id) return [String(obj.id)];
+    if (obj.name) return [String(obj.name)];
+    if (obj.github) return [String(obj.github)];
+    if (obj.twitter) return [String(obj.twitter)];
+    return [];
+  }
+  return [String(value)];
+}

--- a/astro/src/utils/contributors.ts
+++ b/astro/src/utils/contributors.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { parse } from 'yaml';
+import { communitySlug as baseCommunitySlug, toArray as baseToArray } from './community-base.mjs';
 
 const AVATAR_BASE = 'https://training.galaxyproject.org';
 
@@ -43,11 +44,7 @@ let organisationCache: OrganisationMap | null = null;
 let grantCache: GrantMap | null = null;
 
 export function communitySlug(value: string): string {
-  const normalized = String(value).trim().replace(/^@/, '');
-  return normalized
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  return baseCommunitySlug(value);
 }
 
 function normalizeAvatar(avatar?: string): string | undefined {
@@ -247,21 +244,10 @@ export function findCommunityBySlug(
 
 /**
  * Convert unknown values to a flat array of strings.
- * Handles arrays, objects with id/name/github fields, and primitives.
+ * Handles arrays, objects with id/name/github/twitter fields, and primitives.
  */
 export function toArray(value: unknown): string[] {
-  if (!value) return [];
-  if (Array.isArray(value)) {
-    return value.flatMap((v) => toArray(v));
-  }
-  if (typeof value === 'object') {
-    const obj = value as Record<string, unknown>;
-    if (obj.id) return [String(obj.id)];
-    if (obj.name) return [String(obj.name)];
-    if (obj.github) return [String(obj.github)];
-    return [];
-  }
-  return [String(value)];
+  return baseToArray(value);
 }
 
 /**

--- a/astro/src/utils/supporters.ts
+++ b/astro/src/utils/supporters.ts
@@ -1,4 +1,5 @@
 import { getGrant, getOrganisation } from './contributors';
+import { communitySlug as baseCommunitySlug, toArray as baseToArray } from './community-base.mjs';
 
 export type SupporterProfile = {
   slug: string;
@@ -8,27 +9,11 @@ export type SupporterProfile = {
 };
 
 function slugify(value: string): string {
-  const normalized = String(value).trim().replace(/^@/, '');
-  return normalized
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  return baseCommunitySlug(value);
 }
 
 function toArray(value: unknown): string[] {
-  if (!value) return [];
-  if (Array.isArray(value)) {
-    return value.flatMap((v) => toArray(v));
-  }
-  if (typeof value === 'object') {
-    const obj = value as Record<string, any>;
-    if (obj.id) return [String(obj.id)];
-    if (obj.name) return [String(obj.name)];
-    if (obj.github) return [String(obj.github)];
-    if (obj.twitter) return [String(obj.twitter)];
-    return [];
-  }
-  return [String(value)];
+  return baseToArray(value);
 }
 
 let supporterMap: Map<string, SupporterProfile> | null = null;

--- a/astro/tests/search-external.spec.ts
+++ b/astro/tests/search-external.spec.ts
@@ -9,4 +9,12 @@ test.describe('Search external event indicator', () => {
     await expect(result).toBeVisible();
     await expect(result.locator('[data-external-icon]')).toBeVisible();
   });
+
+  test('search finds hall-of-fame result by organisation id', async ({ page }) => {
+    const response = await page.goto('/search/?q=denbi');
+    expect(response?.status()).toBe(200);
+
+    const hallOfFameResult = page.locator('article a[href="/hall-of-fame/denbi/"]').first();
+    await expect(hallOfFameResult).toBeVisible();
+  });
 });


### PR DESCRIPTION
This PR will read the TAGS.yaml, ORGANISATIONS.yaml etc and makes them part of the search results.

It contains a some restructuring to share code, which might make your life harder to review @dannon ... let me know if you want to do those restructuring or if it is ok. Any advice welcome.