### PR TITLE
Invalidate CloudFront cache after S3 deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Sync to preview S3
         run: aws s3 sync astro/dist/ s3://astro-hub/ --delete
       - name: Invalidate CloudFront cache
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.ASTRO_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
## Summary

- Adds a CloudFront cache invalidation step after the S3 sync in the publish workflow
- Uses the new `ASTRO_CLOUDFRONT_DISTRIBUTION_ID` secret (already added)

Without this, CloudFront serves stale HTML referencing old content-hashed asset filenames that no longer exist on S3 after `sync --delete`. Browsers get 404 HTML responses for JS/CSS requests, which breaks hydration and styles sitewide. This was happening today on preview — confirmed that a manual invalidation fixed it.