### PR TITLE
Add usegalaxy.fr to initial launcher

### DIFF
--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1048,6 +1048,10 @@ const pillars = [
                 >usegalaxy.eu</a
               >
               <span class="server-pill-sep">·</span>
+              <a href="https://usegalaxy.fr" target="_blank" rel="noopener noreferrer" class="server-pill"
+                >usegalaxy.fr</a
+              >
+              <span class="server-pill-sep">·</span>
               <a href="https://usegalaxy.org.au" target="_blank" rel="noopener noreferrer" class="server-pill"
                 >usegalaxy.org.au</a
               >


### PR DESCRIPTION
We've talked a bit about overhauling this launcher totally (the dropdown was awkward, it seems weird to immediately send someone to a different site with the primary CTA on the homepage, etc), but this includes all .* for now.