### PR TITLE
Fix image path for Galaxy Community Conference 2026 carousel

### DIFF
--- a/astro/src/components/mdx/Carousel.astro
+++ b/astro/src/components/mdx/Carousel.astro
@@ -18,7 +18,7 @@ const props = Astro.props;
   interval={props.interval ?? 5000}
   images={props.images ?? [
     {
-      src: '/images/events/gcc2026/gcc2026-carousel.png',
+      src: '/images/events/gcc-2026/gcc2026-carousel.png',
       alt: 'Galaxy Community Conference 2026 - Announcement',
       link: 'https://galaxyproject.org/events/gcc2026/',
     },


### PR DESCRIPTION
Update the image path for the GCC2026 carousel to ensure it displays correctly. 

The previous link pointed to: 
https://archive.galaxyproject.org/images/events/gcc2026/gcc2026-carousel.png

It should now point to: 
https://galaxyproject.org/images/events/gcc-2026/gcc2026-carousel.png