### PR TITLE
Pre-bake all redirects as S3 object metadata for native 301s

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,5 +30,7 @@ jobs:
           aws-region: us-east-2
       - name: Sync to preview S3
         run: aws s3 sync astro/dist/ s3://astro-hub/ --delete
+      - name: Set S3 redirect metadata
+        run: S3_BUCKET=astro-hub node deploy/set-s3-redirects.mjs
       - name: Invalidate CloudFront cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.ASTRO_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/deploy/set-s3-redirects.mjs
+++ b/deploy/set-s3-redirects.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * After `aws s3 sync`, overwrite every Astro-generated meta-refresh redirect page
+ * in S3 with an empty object that has `x-amz-website-redirect-location` set.
+ * S3's website endpoint then returns a native 301 for those paths instead of
+ * serving HTML.
+ *
+ * Reads the pre-computed redirect map from astro/src/build/generated-redirects.json
+ * (populated from slug normalization, YAML redirects, and frontmatter redirects).
+ *
+ * Usage:
+ *   S3_BUCKET=astro-hub node deploy/set-s3-redirects.mjs
+ */
+
+import { readFileSync } from 'fs';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+
+const execFileAsync = promisify(execFile);
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { redirects } = JSON.parse(
+  readFileSync(join(root, 'astro/src/build/generated-redirects.json'), 'utf8')
+);
+
+const bucket = process.env.S3_BUCKET;
+if (!bucket) {
+  console.error('S3_BUCKET environment variable is required');
+  process.exit(1);
+}
+
+const CONCURRENCY = 20;
+
+async function setRedirect(fromPath, toPath) {
+  // /events/gcc2026/ → events/gcc2026/index.html
+  const key = fromPath.replace(/^\//, '').replace(/\/$/, '') + '/index.html';
+  try {
+    await execFileAsync('aws', [
+      's3api', 'put-object',
+      '--bucket', bucket,
+      '--key', key,
+      '--website-redirect-location', toPath,
+      '--content-length', '0',
+    ]);
+  } catch (err) {
+    console.error(`\nFailed to set redirect ${fromPath} → ${toPath}: ${err.stderr || err.message}`);
+    throw err;
+  }
+}
+
+const entries = Object.entries(redirects);
+console.log(`Setting ${entries.length} S3 redirect objects in bucket "${bucket}"...`);
+
+let done = 0;
+for (let i = 0; i < entries.length; i += CONCURRENCY) {
+  const batch = entries.slice(i, i + CONCURRENCY);
+  await Promise.all(batch.map(([from, to]) => setRedirect(from, to)));
+  done += batch.length;
+  process.stdout.write(`\r  ${done}/${entries.length}`);
+}
+
+console.log('\nDone.');


### PR DESCRIPTION
## Summary

Astro in static mode generates `<meta http-equiv="refresh">` HTML pages for redirects. This means every redirect requires a full page load before the browser navigates to the canonical URL.

This PR pre-bakes all known redirects (from slug normalization, `redirects.yaml`, and frontmatter) as S3 object metadata (`x-amz-website-redirect-location`). The S3 website endpoint returns native 301 responses for these objects — no HTML page is loaded, no meta-refresh is parsed.

## Changes

- **`deploy/set-s3-redirects.mjs`**: New script that reads `generated-redirects.json` (built during the Astro build) and calls `aws s3api put-object` with `--website-redirect-location` for each redirect. Runs 20 concurrent requests. The key for each redirect is `{fromPath}/index.html` — matching where Astro puts the meta-refresh HTML.

- **`.github/workflows/publish.yml`**: Added a step after `aws s3 sync` that runs `set-s3-redirects.mjs`. Requires the existing `S3_BUCKET` env var to be set.

## Notes

- `generated-redirects.json` is produced by the build pipeline and contains ~1040 entries from all redirect sources.
- The script overwrites existing redirect objects on each deploy, so stale entries from removed redirects will persist until manually cleaned up (acceptable tradeoff).
- Pairs with a separate PR that adds real-time slug normalization to the CloudFront function for any URLs not covered by the pre-baked list.