### PR TITLE
Render subsite main.md content on subsite homepages

### DIFF
--- a/astro/src/components/SubsiteOverview.astro
+++ b/astro/src/components/SubsiteOverview.astro
@@ -20,11 +20,13 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
     {!hasMainContent && <p class="text-gray-600">{description}</p>}
   </div>
 
-  {hasMainContent && (
-    <div class="mb-10 prose prose-galaxy max-w-none">
-      <slot name="main-content" />
-    </div>
-  )}
+  {
+    hasMainContent && (
+      <div class="mb-10 prose prose-galaxy max-w-none">
+        <slot name="main-content" />
+      </div>
+    )
+  }
 
   <div class="grid gap-8 lg:grid-cols-2">
     <section>

--- a/astro/src/pages/[subsite]/index.astro
+++ b/astro/src/pages/[subsite]/index.astro
@@ -23,20 +23,35 @@ const { title, description } = subsiteLabels[subsite] || {
 // Conventional insert filenames used across subsite homepages, in display order.
 // Each subsite uses a subset; missing ones are silently skipped.
 const INSERT_ORDER = [
-  'jumbotron', 'lead', 'lead1', 'lead2',
-  'main', 'main1', 'main2', 'main3', 'main4', 'main5',
-  'cards', 'lower', 'site-footer',
+  'jumbotron',
+  'lead',
+  'lead1',
+  'lead2',
+  'main',
+  'main1',
+  'main2',
+  'main3',
+  'main4',
+  'main5',
+  'cards',
+  'lower',
+  'site-footer',
 ];
 
-const subsiteInserts = (
-  await Promise.all(INSERT_ORDER.map((name) => getInsert(`${subsite}/${name}`)))
-).filter(Boolean);
+const subsiteInserts = (await Promise.all(INSERT_ORDER.map((name) => getInsert(`${subsite}/${name}`)))).filter(Boolean);
 
 const renderedInserts = await Promise.all(subsiteInserts.map((ins) => render(ins)));
 ---
 
 <BaseLayout title={title} description={description}>
-  <SubsiteOverview {subsite} {title} {description} {upcomingEvents} {subsiteNews} hasMainContent={renderedInserts.length > 0}>
+  <SubsiteOverview
+    {subsite}
+    {title}
+    {description}
+    {upcomingEvents}
+    {subsiteNews}
+    hasMainContent={renderedInserts.length > 0}
+  >
     {renderedInserts.map(({ Content }) => <Content slot="main-content" />)}
   </SubsiteOverview>
 </BaseLayout>


### PR DESCRIPTION
Fixes #3797

Subsite homepages (Belgium, EU, ELIXIR-IT, IFB, Pasteur, etc.) each have content files with their actual homepage material — logos, instance descriptions, what they offer, contact info, acknowledgements. During the Astro migration this content was dropped; `[subsite]/index.astro` rendered only a generic events/news overview.

## Fix

`[subsite]/index.astro` now discovers and renders all conventional subsite insert files in display order:

```
jumbotron → lead / lead1 / lead2 → main / main1–5 → cards → lower → site-footer
```

Missing files are silently skipped. The content is rendered above the events/news grid via a named slot in `SubsiteOverview`. The generic fallback description is suppressed when real content is present. Subsites with no content files (fall-back behavior) are unaffected.

## Results

| Subsite | Content now rendered |
|---------|---------------------|
| Belgium | main.md (logo, description, what we offer, acknowledgements) |
| Pasteur | main.md (how to use, how to cite, links) |
| EU | lead.md, main1.md, main2.md |
| ELIXIR-IT | lead1.md, main1–5.md, cards.md, lower.md |
| IFB | lead1.md, lead2.md, main1–3.md, cards.md, lower.md |
| Freiburg, Erasmus MC, US | stub main.md only — no visible change |