### PR TITLE
Fix sidebar search not passing query to search page

### DIFF
--- a/astro/src/components/layout/Sidebar.astro
+++ b/astro/src/components/layout/Sidebar.astro
@@ -15,7 +15,7 @@ import SidebarNav from './SidebarNav.vue';
 
   <!-- Search -->
   <div class="p-4 border-b border-medium-bg">
-    <form action="/search" method="get">
+    <form action="/search/" method="get">
       <div class="relative">
         <input
           type="search"


### PR DESCRIPTION
The sidebar form action was missing a trailing slash, so submitting a search from interior pages would redirect /search?q=term to /search/ and drop the query parameter in the process.