### PR TITLE
Improve coverage of sidebar search test

### DIFF
--- a/astro/tests/navigation.spec.ts
+++ b/astro/tests/navigation.spec.ts
@@ -319,8 +319,12 @@ test.describe('Navigation', () => {
       const searchButton = page.locator('aside button[type="submit"]');
       await searchButton.click();
 
-      // Should navigate to search page with query
-      await expect(page).toHaveURL(/\/search/);
+      // Should navigate to search page with query parameter preserved
+      await expect(page).toHaveURL(/\/search\/\?q=galaxy/);
+
+      // Wait for Vue hydration and search results to appear
+      const resultsText = page.getByText(/\d+ results?/);
+      await expect(resultsText).toBeVisible({ timeout: 10000 });
     });
   });
 


### PR DESCRIPTION
The existing test only checked that navigation landed on /search/, which didn't catch the trailing-slash bug that dropped query parameters. Now it asserts the full URL including ?q= and waits for search results to appear.

Followup to https://github.com/galaxyproject/galaxy-hub/pull/3807, we had tests for the navigation but not the actual execution of search