### PR TITLE
Restrict certain GitHub workflow jobs to galaxyproject owner

### DIFF
--- a/.github/workflows/links-external.yml
+++ b/.github/workflows/links-external.yml
@@ -9,6 +9,7 @@ jobs:
   check_links:
     name: Check External Links
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
     steps:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/rewrites.yml
+++ b/.github/workflows/rewrites.yml
@@ -31,7 +31,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'galaxyproject' && github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sync-training-material-metadata.yml
+++ b/.github/workflows/sync-training-material-metadata.yml
@@ -10,6 +10,7 @@ jobs:
   sync-files:
     name: Sync files from training-material
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
They just fail on forks, wasting compute resources.