### PR TITLE
Add labels for current affiliations and former affiliations

### DIFF
--- a/astro/src/pages/hall-of-fame/[slug].astro
+++ b/astro/src/pages/hall-of-fame/[slug].astro
@@ -170,24 +170,30 @@ function formatDate(date: Date | string | undefined): string {
                   <span class="profile-avatar-fallback">{(displayName || slug || '?').charAt(0).toUpperCase()}</span>
                 )}
               </a>
-              <div class="flex-1 space-y-2 min-w-0">
+              <div class="flex-1 space-y-3 min-w-0">
                 {affiliationTags.length > 0 && (
-                  <div class="flex flex-wrap gap-2" aria-label="Affiliations">
-                    {affiliationTags.map((aff) => (
-                      <a href={aff.slug} class="chip chip-light">
-                        {aff.label}
-                      </a>
-                    ))}
+                  <div class="affiliation-group">
+                    <p class="affiliation-label">Affiliations</p>
+                    <div class="flex flex-wrap gap-2" aria-label="Affiliations">
+                      {affiliationTags.map((aff) => (
+                        <a href={aff.slug} class="chip chip-light">
+                          {aff.label}
+                        </a>
+                      ))}
+                    </div>
                   </div>
                 )}
 
                 {formerAffiliationTags.length > 0 && (
-                  <div class="flex flex-wrap gap-2" aria-label="Former affiliations">
-                    {formerAffiliationTags.map((aff) => (
-                      <a href={aff.slug} class="chip chip-muted chip-light">
-                        {aff.label}
-                      </a>
-                    ))}
+                  <div class="affiliation-group">
+                    <p class="affiliation-label affiliation-label-muted">Former Affiliations</p>
+                    <div class="flex flex-wrap gap-2" aria-label="Former affiliations">
+                      {formerAffiliationTags.map((aff) => (
+                        <a href={aff.slug} class="chip chip-muted chip-light">
+                          {aff.label}
+                        </a>
+                      ))}
+                    </div>
                   </div>
                 )}
 
@@ -562,6 +568,25 @@ function formatDate(date: Date | string | undefined): string {
 
   .chip-light.chip-muted {
     color: rgba(255, 255, 255, 0.78);
+  }
+
+  .affiliation-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .affiliation-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.55);
+    margin: 0;
+  }
+
+  .affiliation-label-muted {
+    color: rgba(255, 255, 255, 0.38);
   }
 
   .chip-light.chip-link {


### PR DESCRIPTION
Trying to separate current affiliation from former affiliations, similar to GTN HOF pages. I know that there is a subtle change in the color of the former affiliations, but it is hard to notice. Adding a label will make it evident. 

ATM, all the affiliations are grouped together:
<img width="973" height="297" alt="image" src="https://github.com/user-attachments/assets/4662edb9-c6be-4cb8-bd77-48dce1fe5d42" />

Here is how it will display with this PR:
<img width="973" height="297" alt="image" src="https://github.com/user-attachments/assets/1ef4299b-1e70-4f05-87a2-9b1df7fb30e7" />
