### PR TITLE
Fix events page links pointing to wrong detail pages

### DIFF
--- a/astro/src/pages/[subsite]/events/archive/index.astro
+++ b/astro/src/pages/[subsite]/events/archive/index.astro
@@ -46,7 +46,7 @@ const eventData = events.map((e) => ({
 
     <div class="px-6 sm:px-8 py-6">
       <EventsList
-        client:load
+        client:only="vue"
         events={eventData}
         initialSubsite={subsiteId}
         showUpcoming={false}

--- a/astro/src/pages/[subsite]/events/index.astro
+++ b/astro/src/pages/[subsite]/events/index.astro
@@ -40,7 +40,7 @@ const eventData = events.map((e) => ({
     </header>
 
     <div class="px-6 sm:px-8 py-6">
-      <EventsList client:load events={eventData} initialSubsite={subsiteId} />
+      <EventsList client:only="vue" events={eventData} initialSubsite={subsiteId} />
     </div>
   </div>
 </BaseLayout>

--- a/astro/src/pages/events/index.astro
+++ b/astro/src/pages/events/index.astro
@@ -25,7 +25,7 @@ const eventData = events.map((e) => ({
     <PageHeader title="Events" description="Workshops, conferences, and community gatherings" />
 
     <div class="bg-white px-6 sm:px-8 py-6 rounded-b-lg shadow-sm">
-      <EventsList client:load events={eventData} />
+      <EventsList client:only="vue" events={eventData} />
     </div>
   </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Same Vue hydration mismatch that was fixed for the platforms page in #3821 -- SSR and client-side rendering produce different orderings, scrambling which href goes with which event card. Switches `EventsList` from `client:load` to `client:only="vue"` on all three events pages to bypass SSR entirely.

The tradeoff is that the event list renders client-side only instead of being in the initial HTML, but since it's an interactive/filterable component that requires JS anyway the practical difference is minimal. We can still follow up to identify the root cause of the hydration mismatch and restore SSR if we want, but this is a safe fix for now.

Fixes #3915

## Test plan

- [x] `npm run lint && npm run format:check` passes
- [x] `npm run build` succeeds
- [x] Playwright tests pass (139/141, 1 pre-existing failure unrelated to this change)
- [ ] Open `/events/` and verify event links point to correct detail pages
- [ ] Check subsite events pages (`/eu/events/`, `/freiburg/events/`)