### PR TITLE
Adding second hotel option to the GCC2026 website

### DIFF
--- a/content/events/gcc2026/travel/index.md
+++ b/content/events/gcc2026/travel/index.md
@@ -41,15 +41,21 @@ Clermont-Ferrand is **perfectly positioned** for those traveling by car, with **
 
 # Lodging
 
-Attendees looking for accommodations in Clermont-Ferrand may wish to consider **Oceania Clermont-Ferrand**. 
+Attendees looking for accommodations in Clermont-Ferrand may wish to consider the following options:
 
-To reserve a room, please email cleocf.recep.1@oceaniahotels.com and mention the group code **Group CSAM AAFNO GCC2026**.
+**Oceania Clermont-Ferrand**
 
-Rates range from €111.20 to €131.20 per night, depending on the night of your stay.
+To reserve a room, please email cleocf.recep.1@oceaniahotels.com
+ and mention the group code **Group CSAM AAFNO GCC2026**. Rates range from €111.20 to €131.20 per night, depending on the night of your stay.
 
-**As availability may be limited, we encourage attendees to book early**.
+**Holiday Inn Clermont Ferrand Centre**
 
-If you are searching for accommodations independently, you may wish to look near the conference venue at **5 Av. Blaise Pascal, 63170 Aubière, France**.
+To reserve a room, please email clermont@hiclermont.com
+ and mention the booking code **HICF-GCC2026** in the subject line or body of the email. The rate is €110 per night.
+
+**As availability may be limited, we encourage attendees to book early.**
+
+If you are searching for accommodations independently, you may wish to look near the conference venue at **5 Av. Blaise Pascal, 63170 Aubière, France.**
 
 # Local Attractions
 


### PR DESCRIPTION
Adding a second hotel option to the GCC2026 website under the Travel page.