### PR TITLE
Add huggingface Galaxy data table schema reference

### DIFF
--- a/content/news/2026/2026-04-13-huggingface-data-table/index.md
+++ b/content/news/2026/2026-04-13-huggingface-data-table/index.md
@@ -1,0 +1,199 @@
+---
+title: "The huggingface Galaxy data table: schema and ontology"
+date: "2026-04-13"
+tease: "Galaxy is standardizing a shared data table for pre-downloaded HuggingFace models. This post is the canonical reference for the 7-column schema, controlled vocabularies, and conventions."
+tags: [tools, admin, ai]
+subsites: [all]
+autotoc: true
+contributions:
+  authorship:
+    - arash77
+---
+
+A growing number of Galaxy tools need to present pre-downloaded
+HuggingFace-compatible models to users at job submission time.
+[Flux](https://github.com/bgruening/galaxytools/tree/master/tools/flux)
+already uses this pattern, and future HuggingFace-backed tools can adopt the
+same convention.  To avoid schema drift and duplicated administrator effort,
+the Galaxy community is standardizing a **shared Galaxy data table** named
+`huggingface`.  This post is the **canonical reference** for that schema.
+
+**Key points:**
+
+- The table has **7 columns**: `value`, `name`, `pipeline_tag`, `domain`, `free_tag`, `version`, `path`
+- Every tool must **filter by `free_tag` + `version`** so different tools' rows never interfere
+- `path` is **always a directory** — a tool derives full file paths inside its command block
+- New tools choose a **unique lowercase `free_tag`** as their namespace in the shared file
+
+## The data table
+
+The table is declared with this block in `tool_data_table_conf.xml`:
+
+```xml
+<!-- huggingface models -->
+<table name="huggingface" comment_char="#" allow_duplicate_entries="False">
+    <columns>value, name, pipeline_tag, domain, free_tag, version, path</columns>
+    <file path="/opt/galaxy/tool-data/huggingface.loc" />
+</table>
+```
+
+The sample file shipped with each tool (`tool-data/huggingface.loc.sample`)
+uses the same 7-column layout.
+
+## Column reference
+
+| # | Column | Purpose |
+|---|--------|---------|
+| 0 | `value` | Unique row ID across the **whole table** |
+| 1 | `name` | Human-readable label shown in the Galaxy select widget |
+| 2 | `pipeline_tag` | Model role — see controlled vocabulary below |
+| 3 | `domain` | Coarse data domain — see controlled vocabulary below |
+| 4 | `free_tag` | Per-tool-family tag; used as the primary XML filter |
+| 5 | `version` | Tool version the row belongs to |
+| 6 | `path` | Root directory of the model data (never a file path) |
+
+### `value` (column 0)
+
+Must be **globally unique** across every row in `huggingface.loc`,
+regardless of which tool added it.  Recommended pattern:
+
+```
+<free_tag>_<version>_<slug>
+```
+
+Examples: `flux_1_dev`, `embedding_1.0_bge-small-en`,
+`mytool_2.1_base-model`.
+
+### `pipeline_tag` (column 2)
+
+Use the **official HuggingFace pipeline tag** whenever one exists — browse
+the full list at https://huggingface.co/models?pipeline_tag=…
+
+Recommended values for this table include:
+
+| Value | When to use |
+|-------|-------------|
+| `text-to-image` | Image generation models (Flux) |
+| `automatic-speech-recognition` | ASR / transcription models |
+| `feature-extraction` | Sentence / document embedding models |
+| `tabular-classification` | Tabular ML classifiers |
+| `tabular-regression` | Tabular ML regressors |
+| `text-generation` | Causal / instruction-tuned LLMs |
+
+Do **not** invent synonyms for existing HF tags (e.g. write
+`automatic-speech-recognition`, not `asr`).  If you genuinely need a custom
+tag because no official HuggingFace pipeline tag exists, document it here
+before using it.
+
+### `domain` (column 3)
+
+Coarse data-domain vocabulary defined by the Galaxy community.  Use one of:
+
+`image` · `text` · `audio` · `tabular` · `sequence` · `video` · `multimodal`
+
+If a tool needs a narrower or tool-specific value, document that exception
+here before adding rows.  The default expectation is that `domain` uses the
+closed vocabulary above.
+
+### `free_tag` (column 4)
+
+A short, tool-family-specific identifier used as the primary filter in the
+tool XML.  Currently registered public values:
+
+| Value | Tool |
+|-------|------|
+| `flux` | Flux image-generation tool |
+
+When adding a new HF-backed tool, choose a unique lowercase `free_tag` and
+add it to this table when the tool is ready to be documented publicly.
+
+### `version` (column 5)
+
+The tool version the row is valid for.  Should match the `@TOOL_VERSION@`
+macro in the consuming tool XML so that the version filter works
+automatically.
+
+### `path` (column 6)
+
+**Always a directory — never a file.**  It points at the root folder that
+contains the HuggingFace cache layout understood by the tool, for example:
+
+```
+/data/hf_models/
+└── hub/
+    ├── models--black-forest-labs--FLUX.1-dev/
+    └── models--sentence-transformers--all-MiniLM-L6-v2/
+```
+
+If a tool needs a specific file (e.g. a `.ckpt` checkpoint), it derives the
+path from `$row.path` inside the command block — the `.loc` entry itself
+never points directly at a file.
+
+## XML filter convention
+
+Every tool XML that reads from this table **must** filter by at least
+`free_tag` (column 4) and `version` (column 5), so rows belonging to other
+tools do not appear in the select:
+
+```xml
+<param name="model" type="select" label="Model">
+    <options from_data_table="huggingface">
+        <filter type="static_value" column="4" value="<free_tag>"/>
+        <filter type="static_value" column="5" value="@TOOL_VERSION@"/>
+        <!-- optional: also filter by pipeline_tag or domain -->
+    </options>
+</param>
+```
+
+Canonical example from the Flux tool:
+
+```xml
+<options from_data_table="huggingface">
+    <filter type="static_value" column="4" value="flux"/>
+    <filter type="static_value" column="5" value="1"/>
+</options>
+```
+
+## Complete example rows
+
+Each row in the `.loc` file is **TAB-separated** (7 fields). The comments show
+the column order.  The concrete example below reflects a published Flux entry;
+future adopters should follow the same 7-column pattern.
+
+```
+# Columns: value <TAB> name <TAB> pipeline_tag <TAB> domain <TAB> free_tag <TAB> version <TAB> path
+#
+# Flux
+black-forest-labs/FLUX.1-dev	FLUX.1 [dev]	text-to-image	image	flux	1	/data/hf_models
+```
+
+## Checklist for tool authors adding HF-backed models
+
+1. **Choose a `free_tag`** — unique lowercase slug. Add it to the table above (via a PR to this post or to the sample file).
+2. **Pick `pipeline_tag`** — use an official HF tag if one exists; document any custom tag.
+3. **Pick `domain`** — use the closed vocabulary above; document deviations.
+4. **Write `tool-data/huggingface.loc.sample`** — include commented example rows with a header linking to this post.
+5. **Write `tool_data_table_conf.xml.sample`** — copy the standard block verbatim.
+6. **Add XML filters** — filter by `free_tag` + `version` at minimum.
+7. **`path` is always a directory** — never point at a file; derive file paths in the command block.
+8. **Test cross-tool isolation** — concatenate your sample with another tool's sample into one `.loc` file and confirm your select shows only your rows.
+
+## For Galaxy administrators
+
+The production `.loc` file (at `/opt/galaxy/tool-data/huggingface.loc` on
+UseGalaxy.eu) is a single flat file that may contain rows from many tools.
+When adding entries:
+
+- Copy the relevant rows from the tool's `huggingface.loc.sample` file.
+- Replace the example `path` values with the actual directories on your server.
+- Rows from different tools coexist safely because every tool XML filters by `free_tag`.
+- You do **not** need to restart Galaxy after editing the `.loc` file — Galaxy
+  reloads data tables on the next job submission.
+
+## Contributing
+
+If you are adding a new HuggingFace-backed tool, open a pull request that includes:
+
+- `tool-data/huggingface.loc.sample` with correctly formatted example rows
+- `tool_data_table_conf.xml.sample` using the standard `huggingface` table block
+- An update to the `free_tag` table in this post when the tool is ready to be documented publicly

--- a/content/news/2026/2026-04-13-huggingface-data-table/index.md
+++ b/content/news/2026/2026-04-13-huggingface-data-table/index.md
@@ -1,165 +1,24 @@
 ---
-title: "The Hugging Face Galaxy data table: schema and ontology"
+title: "Announcing a shared Hugging Face data table for Galaxy"
 date: "2026-04-13"
-tease: "Galaxy is standardizing a shared data table for pre-downloaded Hugging Face models. This post is the reference for the 7-column schema, controlled vocabularies, and conventions."
+tease: "Galaxy is standardising a shared data table for pre-downloaded Hugging Face models so tool authors and admins can coordinate without duplicated effort."
 tags: [tools, admin, ai]
 subsites: [all]
-autotoc: true
 contributions:
   authorship:
     - arash77
 ---
 
-A growing number of Galaxy tools need to present pre-downloaded
-HuggingFace-compatible models to users at job submission time.
-[Flux](https://github.com/bgruening/galaxytools/tree/master/tools/flux)
-already uses this pattern, and future HuggingFace-backed tools can adopt the
-same convention.  To avoid schema drift and duplicated administrator effort,
-the Galaxy community is standardizing a [**shared Galaxy data table**](/admin/tools/data-tables/) named
-`huggingface`.  This post is the **reference** for that schema.
+A growing number of Galaxy tools need to present pre-downloaded Hugging Face-compatible models to users at job submission time.  To avoid schema drift and duplicated administrator effort, the Galaxy community is standardising a **shared Galaxy data table** named `huggingface` that all such tools can consume from a single admin-managed `.loc` file.
+
+[Flux](https://github.com/bgruening/galaxytools/tree/master/tools/flux) is the first tool to adopt this pattern, filtering models by type so users only see entries relevant to their task.
 
 **Key points:**
 
-- The table has **7 columns**: `value`, `name`, `pipeline_tag`, `domain`, `free_tag`, `version`, `path`
-- It is recommended to **filter primarily by `pipeline_tag` and/or `domain`**; use `free_tag` only as a fallback when those are not specific enough
+- The table is named `huggingface` and lives in the standard Galaxy tool data directory
+- It has **7 columns**: `value`, `name`, `pipeline_tag`, `domain`, `free_tag`, `version`, `path`
+- Tool authors filter primarily by `pipeline_tag` and/or `domain`; `free_tag` is a fallback for finer-grained selection
+- Rows are only added, never removed, so existing tool configurations stay stable as new models are registered
+- A single `huggingface.loc` file is shared across all tools and maintained by admins
 
-## The data table
-
-The table is declared with this block in `tool_data_table_conf.xml`:
-
-```xml
-<!-- huggingface models -->
-<table name="huggingface" comment_char="#" allow_duplicate_entries="False">
-    <columns>value, name, pipeline_tag, domain, free_tag, version, path</columns>
-    <file path="/opt/galaxy/tool-data/huggingface.loc" />
-</table>
-```
-
-The sample file shipped with each tool (`tool-data/huggingface.loc.sample`)
-uses the same 7-column layout.
-
-## Column reference
-
-| # | Column | Purpose |
-|---|--------|---------|
-| 0 | `value` | Unique row ID across the **whole table** |
-| 1 | `name` | Human-readable label shown in the Galaxy select widget |
-| 2 | `pipeline_tag` | Model role — see controlled vocabulary below |
-| 3 | `domain` | Coarse data domain — see controlled vocabulary below |
-| 4 | `free_tag` | Optional narrowing tag; fallback filter when `pipeline_tag`/`domain` alone are not specific enough |
-| 5 | `version` | Model version |
-| 6 | `path` | Path to the model data, a directory or a specific file, depending on the model structure |
-
-### `value` (column 0)
-
-Must be **globally unique** across every row in `huggingface.loc`,
-regardless of which tool added it.  Hugging Face already assigns unique model
-IDs (in the form `<owner>/<model-name>`) — use those directly as the value
-wherever possible, since they are stable and unambiguous.  If the same
-underlying model is registered at more than one version, append the version:
-
-```
-<hf-model-id>
-<hf-model-id>_<version>
-```
-
-Examples: `black-forest-labs/FLUX.1-dev`,
-`sentence-transformers/all-MiniLM-L6-v2`,
-`openai/whisper-large-v3_3.0`.
-
-### `pipeline_tag` (column 2)
-
-Use the **official Hugging Face pipeline tag** whenever one exists — browse
-the full list at https://huggingface.co/models?pipeline_tag=…
-
-Recommended values for this table include:
-
-| Value | When to use |
-|-------|-------------|
-| `text-to-image` | Image generation models (Flux) |
-| `automatic-speech-recognition` | ASR / transcription models |
-| `feature-extraction` | Sentence / document embedding models |
-| `tabular-classification` | Tabular ML classifiers |
-| `tabular-regression` | Tabular ML regressors |
-| `text-generation` | Causal / instruction-tuned LLMs |
-
-Do **not** invent synonyms for existing HF tags (e.g. write
-`automatic-speech-recognition`, not `asr`).
-
-### `domain` (column 3)
-
-A broad category for the type of data the model works with. For example:
-
-`image` · `text` · `audio` · `tabular` · `sequence` · `video` · `multimodal`
-
-
-### `free_tag` (column 4)
-
-An optional short identifier used as a **fallback narrowing filter** in the
-tool XML, for cases where `pipeline_tag` and `domain` alone are not specific
-enough.  Because a model can be consumed by multiple tools, the `free_tag`
-should not encode a specific tool name.  Currently registered public values:
-
-| Value | Scope |
-|-------|-------|
-| `flux` | Flux image-generation models |
-
-Only add a `free_tag` when you genuinely need to narrow the selection beyond
-what `pipeline_tag`/`domain` provide.  Choose a short, lowercase, descriptive
-identifier and register it here when the tool is ready to be documented
-publicly.
-
-### `version` (column 5)
-
-The **model version** string.  A tool declares in its XML which model version(s)
-it can consume, allowing multiple versions of the same model to coexist in the
-table.  Where possible, rows are only added, never removed or edited; when a new model version
-is deployed it gets a new row while existing rows stay in place.
-
-### `path` (column 6)
-
-The path to the model data either on a local machine during tool development or on the Galaxy production server (maintained by admins). It can be a directory (when the
-tool reads the whole HuggingFace cache layout) or a specific file (e.g. a
-`.ckpt` checkpoint when the tool only needs that one file).
-
-## XML filter convention
-
-It is recommended that tool XML filters **primarily by `pipeline_tag` (column 2)
-and/or `domain` (column 3)**, so only relevant model types are presented to the
-user.  Add a `free_tag` or `version` filter only when you need to narrow the
-selection further:
-
-```xml
-<param name="model" type="select" label="Model">
-    <options from_data_table="huggingface">
-        <filter type="static_value" column="2" value="<pipeline_tag>"/>
-        <filter type="static_value" column="3" value="<domain>"/>
-        <!-- optional: narrow further by version or free_tag -->
-        <!-- <filter type="static_value" column="5" value="<version>"/> -->
-        <!-- <filter type="static_value" column="4" value="<free_tag>"/> -->
-    </options>
-</param>
-```
-
-Example from the Flux tool (filters by `free_tag` to restrict to
-Flux-specific model variants):
-
-```xml
-<options from_data_table="huggingface">
-    <filter type="static_value" column="4" value="flux"/>
-    <filter type="static_value" column="5" value="1"/>
-</options>
-```
-
-## Complete example rows
-
-Each row in the `.loc` file is **TAB-separated** (7 columns). The comments show
-the column order.  The concrete example below reflects a published Flux entry;
-future adopters should follow the same 7-column pattern.
-
-```
-# Columns: value <TAB> name <TAB> pipeline_tag <TAB> domain <TAB> free_tag <TAB> version <TAB> path
-#
-# Flux
-black-forest-labs/FLUX.1-dev	FLUX.1 [dev]	text-to-image	image	flux	1	/data/hf_models
-```
+The full schema reference, column conventions, and XML filter examples are being added to the [Galaxy admin documentation](https://docs.galaxyproject.org/en/master/admin/data_tables.html).

--- a/content/news/2026/2026-04-13-huggingface-data-table/index.md
+++ b/content/news/2026/2026-04-13-huggingface-data-table/index.md
@@ -1,7 +1,7 @@
 ---
-title: "The huggingface Galaxy data table: schema and ontology"
+title: "The Hugging Face Galaxy data table: schema and ontology"
 date: "2026-04-13"
-tease: "Galaxy is standardizing a shared data table for pre-downloaded HuggingFace models. This post is the reference for the 7-column schema, controlled vocabularies, and conventions."
+tease: "Galaxy is standardizing a shared data table for pre-downloaded Hugging Face models. This post is the reference for the 7-column schema, controlled vocabularies, and conventions."
 tags: [tools, admin, ai]
 subsites: [all]
 autotoc: true
@@ -53,7 +53,7 @@ uses the same 7-column layout.
 ### `value` (column 0)
 
 Must be **globally unique** across every row in `huggingface.loc`,
-regardless of which tool added it.  HuggingFace already assigns unique model
+regardless of which tool added it.  Hugging Face already assigns unique model
 IDs (in the form `<owner>/<model-name>`) — use those directly as the value
 wherever possible, since they are stable and unambiguous.  If the same
 underlying model is registered at more than one version, append the version:
@@ -69,7 +69,7 @@ Examples: `black-forest-labs/FLUX.1-dev`,
 
 ### `pipeline_tag` (column 2)
 
-Use the **official HuggingFace pipeline tag** whenever one exists — browse
+Use the **official Hugging Face pipeline tag** whenever one exists — browse
 the full list at https://huggingface.co/models?pipeline_tag=…
 
 Recommended values for this table include:
@@ -114,11 +114,11 @@ publicly.
 The **model version** string.  A tool declares in its XML which model version(s)
 it can consume, allowing multiple versions of the same model to coexist in the
 table.  Where possible, rows are only added, never removed or edited; when a new model version
-is deployed it gets a new row while old rows stay in place.
+is deployed it gets a new row while existing rows stay in place.
 
 ### `path` (column 6)
 
-The path to the model data on the server. It can be a directory (when the
+The path to the model data either on a local machine during tool development or on the Galaxy production server (maintained by admins). It can be a directory (when the
 tool reads the whole HuggingFace cache layout) or a specific file (e.g. a
 `.ckpt` checkpoint when the tool only needs that one file).
 
@@ -153,7 +153,7 @@ Flux-specific model variants):
 
 ## Complete example rows
 
-Each row in the `.loc` file is **TAB-separated** (7 fields). The comments show
+Each row in the `.loc` file is **TAB-separated** (7 columns). The comments show
 the column order.  The concrete example below reflects a published Flux entry;
 future adopters should follow the same 7-column pattern.
 

--- a/content/news/2026/2026-04-13-huggingface-data-table/index.md
+++ b/content/news/2026/2026-04-13-huggingface-data-table/index.md
@@ -1,7 +1,7 @@
 ---
 title: "The huggingface Galaxy data table: schema and ontology"
 date: "2026-04-13"
-tease: "Galaxy is standardizing a shared data table for pre-downloaded HuggingFace models. This post is the canonical reference for the 7-column schema, controlled vocabularies, and conventions."
+tease: "Galaxy is standardizing a shared data table for pre-downloaded HuggingFace models. This post is the reference for the 7-column schema, controlled vocabularies, and conventions."
 tags: [tools, admin, ai]
 subsites: [all]
 autotoc: true
@@ -15,14 +15,13 @@ HuggingFace-compatible models to users at job submission time.
 [Flux](https://github.com/bgruening/galaxytools/tree/master/tools/flux)
 already uses this pattern, and future HuggingFace-backed tools can adopt the
 same convention.  To avoid schema drift and duplicated administrator effort,
-the Galaxy community is standardizing a **shared Galaxy data table** named
-`huggingface`.  This post is the **canonical reference** for that schema.
+the Galaxy community is standardizing a [**shared Galaxy data table**](/admin/tools/data-tables/) named
+`huggingface`.  This post is the **reference** for that schema.
 
 **Key points:**
 
 - The table has **7 columns**: `value`, `name`, `pipeline_tag`, `domain`, `free_tag`, `version`, `path`
-- Every tool must **filter by `free_tag` + `version`** so different tools' rows never interfere
-- `path` is **always a directory** — a tool derives full file paths inside its command block
+- It is recommended to **filter by `free_tag` + `version`** so different tools' rows never interfere
 - New tools choose a **unique lowercase `free_tag`** as their namespace in the shared file
 
 ## The data table
@@ -50,7 +49,7 @@ uses the same 7-column layout.
 | 3 | `domain` | Coarse data domain — see controlled vocabulary below |
 | 4 | `free_tag` | Per-tool-family tag; used as the primary XML filter |
 | 5 | `version` | Tool version the row belongs to |
-| 6 | `path` | Root directory of the model data (never a file path) |
+| 6 | `path` | Path to the model data, a directory or a specific file |
 
 ### `value` (column 0)
 
@@ -81,19 +80,14 @@ Recommended values for this table include:
 | `text-generation` | Causal / instruction-tuned LLMs |
 
 Do **not** invent synonyms for existing HF tags (e.g. write
-`automatic-speech-recognition`, not `asr`).  If you genuinely need a custom
-tag because no official HuggingFace pipeline tag exists, document it here
-before using it.
+`automatic-speech-recognition`, not `asr`).
 
 ### `domain` (column 3)
 
-Coarse data-domain vocabulary defined by the Galaxy community.  Use one of:
+A broad category for the type of data the model works with. For example:
 
 `image` · `text` · `audio` · `tabular` · `sequence` · `video` · `multimodal`
 
-If a tool needs a narrower or tool-specific value, document that exception
-here before adding rows.  The default expectation is that `domain` uses the
-closed vocabulary above.
 
 ### `free_tag` (column 4)
 
@@ -109,29 +103,19 @@ add it to this table when the tool is ready to be documented publicly.
 
 ### `version` (column 5)
 
-The tool version the row is valid for.  Should match the `@TOOL_VERSION@`
-macro in the consuming tool XML so that the version filter works
-automatically.
+A version string used to filter rows in the tool XML.  Rows are only added
+to the table, never removed or edited, new tool versions get new rows with
+a different version value, while old rows stay in place.
 
 ### `path` (column 6)
 
-**Always a directory — never a file.**  It points at the root folder that
-contains the HuggingFace cache layout understood by the tool, for example:
-
-```
-/data/hf_models/
-└── hub/
-    ├── models--black-forest-labs--FLUX.1-dev/
-    └── models--sentence-transformers--all-MiniLM-L6-v2/
-```
-
-If a tool needs a specific file (e.g. a `.ckpt` checkpoint), it derives the
-path from `$row.path` inside the command block — the `.loc` entry itself
-never points directly at a file.
+The path to the model data on the server. It can be a directory (when the
+tool reads the whole HuggingFace cache layout) or a specific file (e.g. a
+`.ckpt` checkpoint when the tool only needs that one file).
 
 ## XML filter convention
 
-Every tool XML that reads from this table **must** filter by at least
+It is recommended that tool XML filters by at least
 `free_tag` (column 4) and `version` (column 5), so rows belonging to other
 tools do not appear in the select:
 
@@ -139,13 +123,13 @@ tools do not appear in the select:
 <param name="model" type="select" label="Model">
     <options from_data_table="huggingface">
         <filter type="static_value" column="4" value="<free_tag>"/>
-        <filter type="static_value" column="5" value="@TOOL_VERSION@"/>
+        <filter type="static_value" column="5" value="<version>"/>
         <!-- optional: also filter by pipeline_tag or domain -->
     </options>
 </param>
 ```
 
-Canonical example from the Flux tool:
+Example from the Flux tool:
 
 ```xml
 <options from_data_table="huggingface">
@@ -166,34 +150,3 @@ future adopters should follow the same 7-column pattern.
 # Flux
 black-forest-labs/FLUX.1-dev	FLUX.1 [dev]	text-to-image	image	flux	1	/data/hf_models
 ```
-
-## Checklist for tool authors adding HF-backed models
-
-1. **Choose a `free_tag`** — unique lowercase slug. Add it to the table above (via a PR to this post or to the sample file).
-2. **Pick `pipeline_tag`** — use an official HF tag if one exists; document any custom tag.
-3. **Pick `domain`** — use the closed vocabulary above; document deviations.
-4. **Write `tool-data/huggingface.loc.sample`** — include commented example rows with a header linking to this post.
-5. **Write `tool_data_table_conf.xml.sample`** — copy the standard block verbatim.
-6. **Add XML filters** — filter by `free_tag` + `version` at minimum.
-7. **`path` is always a directory** — never point at a file; derive file paths in the command block.
-8. **Test cross-tool isolation** — concatenate your sample with another tool's sample into one `.loc` file and confirm your select shows only your rows.
-
-## For Galaxy administrators
-
-The production `.loc` file (at `/opt/galaxy/tool-data/huggingface.loc` on
-UseGalaxy.eu) is a single flat file that may contain rows from many tools.
-When adding entries:
-
-- Copy the relevant rows from the tool's `huggingface.loc.sample` file.
-- Replace the example `path` values with the actual directories on your server.
-- Rows from different tools coexist safely because every tool XML filters by `free_tag`.
-- You do **not** need to restart Galaxy after editing the `.loc` file — Galaxy
-  reloads data tables on the next job submission.
-
-## Contributing
-
-If you are adding a new HuggingFace-backed tool, open a pull request that includes:
-
-- `tool-data/huggingface.loc.sample` with correctly formatted example rows
-- `tool_data_table_conf.xml.sample` using the standard `huggingface` table block
-- An update to the `free_tag` table in this post when the tool is ready to be documented publicly

--- a/content/news/2026/2026-04-13-huggingface-data-table/index.md
+++ b/content/news/2026/2026-04-13-huggingface-data-table/index.md
@@ -49,7 +49,7 @@ uses the same 7-column layout.
 | 3 | `domain` | Coarse data domain — see controlled vocabulary below |
 | 4 | `free_tag` | Per-tool-family tag; used as the primary XML filter |
 | 5 | `version` | Tool version the row belongs to |
-| 6 | `path` | Path to the model data, a directory or a specific file |
+| 6 | `path` | Path to the model data, a directory or a specific file, depending on the model structure |
 
 ### `value` (column 0)
 

--- a/content/news/2026/2026-04-13-huggingface-data-table/index.md
+++ b/content/news/2026/2026-04-13-huggingface-data-table/index.md
@@ -21,4 +21,4 @@ A growing number of Galaxy tools need to present pre-downloaded Hugging Face-com
 - Rows are only added, never removed, so existing tool configurations stay stable as new models are registered
 - A single `huggingface.loc` file is shared across all tools and maintained by admins
 
-The full schema reference, column conventions, and XML filter examples are being added to the [Galaxy admin documentation](https://docs.galaxyproject.org/en/master/admin/data_tables.html).
+The full schema reference, column conventions, and XML filter examples are being added to the [Galaxy admin documentation](https://docs.galaxyproject.org/en/latest/admin/data_tables.html).

--- a/content/news/2026/2026-04-13-huggingface-data-table/index.md
+++ b/content/news/2026/2026-04-13-huggingface-data-table/index.md
@@ -21,8 +21,7 @@ the Galaxy community is standardizing a [**shared Galaxy data table**](/admin/to
 **Key points:**
 
 - The table has **7 columns**: `value`, `name`, `pipeline_tag`, `domain`, `free_tag`, `version`, `path`
-- It is recommended to **filter by `free_tag` + `version`** so different tools' rows never interfere
-- New tools choose a **unique lowercase `free_tag`** as their namespace in the shared file
+- It is recommended to **filter primarily by `pipeline_tag` and/or `domain`**; use `free_tag` only as a fallback when those are not specific enough
 
 ## The data table
 
@@ -47,21 +46,26 @@ uses the same 7-column layout.
 | 1 | `name` | Human-readable label shown in the Galaxy select widget |
 | 2 | `pipeline_tag` | Model role — see controlled vocabulary below |
 | 3 | `domain` | Coarse data domain — see controlled vocabulary below |
-| 4 | `free_tag` | Per-tool-family tag; used as the primary XML filter |
-| 5 | `version` | Tool version the row belongs to |
+| 4 | `free_tag` | Optional narrowing tag; fallback filter when `pipeline_tag`/`domain` alone are not specific enough |
+| 5 | `version` | Model version |
 | 6 | `path` | Path to the model data, a directory or a specific file, depending on the model structure |
 
 ### `value` (column 0)
 
 Must be **globally unique** across every row in `huggingface.loc`,
-regardless of which tool added it.  Recommended pattern:
+regardless of which tool added it.  HuggingFace already assigns unique model
+IDs (in the form `<owner>/<model-name>`) — use those directly as the value
+wherever possible, since they are stable and unambiguous.  If the same
+underlying model is registered at more than one version, append the version:
 
 ```
-<free_tag>_<version>_<slug>
+<hf-model-id>
+<hf-model-id>_<version>
 ```
 
-Examples: `flux_1_dev`, `embedding_1.0_bge-small-en`,
-`mytool_2.1_base-model`.
+Examples: `black-forest-labs/FLUX.1-dev`,
+`sentence-transformers/all-MiniLM-L6-v2`,
+`openai/whisper-large-v3_3.0`.
 
 ### `pipeline_tag` (column 2)
 
@@ -91,21 +95,26 @@ A broad category for the type of data the model works with. For example:
 
 ### `free_tag` (column 4)
 
-A short, tool-family-specific identifier used as the primary filter in the
-tool XML.  Currently registered public values:
+An optional short identifier used as a **fallback narrowing filter** in the
+tool XML, for cases where `pipeline_tag` and `domain` alone are not specific
+enough.  Because a model can be consumed by multiple tools, the `free_tag`
+should not encode a specific tool name.  Currently registered public values:
 
-| Value | Tool |
-|-------|------|
-| `flux` | Flux image-generation tool |
+| Value | Scope |
+|-------|-------|
+| `flux` | Flux image-generation models |
 
-When adding a new HF-backed tool, choose a unique lowercase `free_tag` and
-add it to this table when the tool is ready to be documented publicly.
+Only add a `free_tag` when you genuinely need to narrow the selection beyond
+what `pipeline_tag`/`domain` provide.  Choose a short, lowercase, descriptive
+identifier and register it here when the tool is ready to be documented
+publicly.
 
 ### `version` (column 5)
 
-A version string used to filter rows in the tool XML.  Rows are only added
-to the table, never removed or edited, new tool versions get new rows with
-a different version value, while old rows stay in place.
+The **model version** string.  A tool declares in its XML which model version(s)
+it can consume, allowing multiple versions of the same model to coexist in the
+table.  Where possible, rows are only added, never removed or edited; when a new model version
+is deployed it gets a new row while old rows stay in place.
 
 ### `path` (column 6)
 
@@ -115,21 +124,25 @@ tool reads the whole HuggingFace cache layout) or a specific file (e.g. a
 
 ## XML filter convention
 
-It is recommended that tool XML filters by at least
-`free_tag` (column 4) and `version` (column 5), so rows belonging to other
-tools do not appear in the select:
+It is recommended that tool XML filters **primarily by `pipeline_tag` (column 2)
+and/or `domain` (column 3)**, so only relevant model types are presented to the
+user.  Add a `free_tag` or `version` filter only when you need to narrow the
+selection further:
 
 ```xml
 <param name="model" type="select" label="Model">
     <options from_data_table="huggingface">
-        <filter type="static_value" column="4" value="<free_tag>"/>
-        <filter type="static_value" column="5" value="<version>"/>
-        <!-- optional: also filter by pipeline_tag or domain -->
+        <filter type="static_value" column="2" value="<pipeline_tag>"/>
+        <filter type="static_value" column="3" value="<domain>"/>
+        <!-- optional: narrow further by version or free_tag -->
+        <!-- <filter type="static_value" column="5" value="<version>"/> -->
+        <!-- <filter type="static_value" column="4" value="<free_tag>"/> -->
     </options>
 </param>
 ```
 
-Example from the Flux tool:
+Example from the Flux tool (filters by `free_tag` to restrict to
+Flux-specific model variants):
 
 ```xml
 <options from_data_table="huggingface">


### PR DESCRIPTION
## Summary

- Adds a reference post for the shared `huggingface` Galaxy data table, covering the 7-column schema, controlled vocabularies, and XML filter conventions
- Links to the existing Galaxy data table documentation
- Includes example `.loc` rows and a tool-author checklist