### PR TITLE
fix(ci): migrate image compression workflow to GitHub App auth

### DIFF
--- a/.github/workflows/gtn-import.yml
+++ b/.github/workflows/gtn-import.yml
@@ -21,8 +21,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.GTN_IMPORT_APP_CLIENT_ID }}
-          private-key: ${{ secrets.GTN_IMPORT_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.HUB_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -36,14 +36,18 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.HUB_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@1.4.1
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          # For non-Pull Requests, run in compressOnly mode and we'll PR after.
-          ## compressOnly: ${{ github.event_name != 'pull_request' }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Attempt to prevent webp recompression by minimizing diff.
           webpQuality: '90'
           minPctChange: '2.5'
@@ -52,8 +56,9 @@ jobs:
         if: |
           github.event_name != 'pull_request' &&
           steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ steps.app-token.outputs.token }}
           title: Auto Compress Images
           branch: action_compress_images
           commit-message: Compress Images


### PR DESCRIPTION
## Summary

- Replace `GITHUB_TOKEN` with GitHub App token in `optimize-images.yml` so auto-compress PRs trigger downstream CI workflows
- Rename `GTN_IMPORT_APP_*` secrets to `HUB_BOT_APP_*` in both `optimize-images.yml` and `gtn-import.yml` for a single shared app
- Pin `calibreapp/image-actions` from `@main` to `@1.4.1`
- Update `actions/checkout` to v6, `peter-evans/create-pull-request` to v8

## Before merging

Add two repo secrets:
- `HUB_BOT_APP_CLIENT_ID`
- `HUB_BOT_APP_PRIVATE_KEY`

Rename (or replace) the existing `GTN_IMPORT_APP_*` secrets accordingly.