### PR TITLE
Refresh Galaxy Europe UI sections

### DIFF
--- a/astro/src/components/SubsiteOverview.astro
+++ b/astro/src/components/SubsiteOverview.astro
@@ -20,7 +20,7 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
 
   {
     hasMainContent && (
-      <div class="my-10 max-w-none subsite-inserts">
+      <div class="my-5 max-w-none subsite-inserts">
         <slot name="main-content" />
       </div>
     )

--- a/astro/src/components/SubsiteOverview.astro
+++ b/astro/src/components/SubsiteOverview.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
+import PageHeader from './layout/PageHeader.astro';
 import { formatDate } from '../utils/dateUtils';
 
 interface Props {
@@ -14,15 +15,12 @@ interface Props {
 const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent = false } = Astro.props;
 ---
 
-<div class="max-w-5xl mx-auto">
-  <div class="mb-8 pb-6 border-b border-ebony-clay-100">
-    <h1 class="text-3xl font-bold text-galaxy-dark mb-2">{title}</h1>
-    {!hasMainContent && <p class="text-chicago-600">{description}</p>}
-  </div>
+<div class="max-w-6xl mx-auto">
+  <PageHeader {title} {description} />
 
   {
     hasMainContent && (
-      <div class="mb-10 max-w-none subsite-inserts">
+      <div class="my-10 max-w-none subsite-inserts">
         <slot name="main-content" />
       </div>
     )
@@ -32,7 +30,12 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
     <section>
       <div class="flex items-center justify-between mb-4">
         <h2 class="text-xl font-bold text-galaxy-dark">Upcoming Events</h2>
-        <a href={`/${subsite}/events/`} class="text-sm text-galaxy-primary hover:underline"> View all → </a>
+        <a
+          href={`/${subsite}/events/`}
+          class="text-sm font-medium text-galaxy-primary hover:text-galaxy-gold transition-colors"
+        >
+          View all →
+        </a>
       </div>
 
       {
@@ -43,10 +46,13 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
             {upcomingEvents.map((event) => (
               <a
                 href={`/${event.data.slug}/`}
-                class="block p-3 bg-white rounded-lg border border-ebony-clay-100 hover:border-galaxy-primary hover:shadow-sm transition-all"
+                class="group relative block overflow-hidden p-4 bg-white rounded-lg border border-galaxy-primary/10 shadow-sm hover:border-galaxy-primary/30 transition-all"
               >
+                <span class="absolute left-0 top-0 bottom-0 w-1 bg-galaxy-gold transform origin-left scale-y-0 group-hover:scale-y-100 transition-transform duration-200" />
                 <div class="text-xs text-galaxy-primary font-medium mb-1">{formatDate(event.data.date)}</div>
-                <h3 class="font-medium text-galaxy-dark line-clamp-2">{event.data.title}</h3>
+                <h3 class="font-medium text-galaxy-dark group-hover:text-galaxy-primary transition-colors line-clamp-2">
+                  {event.data.title}
+                </h3>
               </a>
             ))}
           </div>
@@ -57,7 +63,12 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
     <section>
       <div class="flex items-center justify-between mb-4">
         <h2 class="text-xl font-bold text-galaxy-dark">Recent News</h2>
-        <a href={`/${subsite}/news/`} class="text-sm text-galaxy-primary hover:underline"> View all → </a>
+        <a
+          href={`/${subsite}/news/`}
+          class="text-sm font-medium text-galaxy-primary hover:text-galaxy-gold transition-colors"
+        >
+          View all →
+        </a>
       </div>
 
       {
@@ -68,10 +79,13 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
             {subsiteNews.map((article) => (
               <a
                 href={`/${article.data.slug}/`}
-                class="block p-3 bg-white rounded-lg border border-ebony-clay-100 hover:border-galaxy-primary hover:shadow-sm transition-all"
+                class="group relative block overflow-hidden p-4 bg-white rounded-lg border border-galaxy-primary/10 shadow-sm hover:border-galaxy-primary/30 transition-all"
               >
+                <span class="absolute left-0 top-0 bottom-0 w-1 bg-galaxy-gold transform origin-left scale-y-0 group-hover:scale-y-100 transition-transform duration-200" />
                 <div class="text-xs text-chicago-500 mb-1">{formatDate(article.data.date)}</div>
-                <h3 class="font-medium text-galaxy-dark line-clamp-2">{article.data.title}</h3>
+                <h3 class="font-medium text-galaxy-dark group-hover:text-galaxy-primary transition-colors line-clamp-2">
+                  {article.data.title}
+                </h3>
               </a>
             ))}
           </div>
@@ -85,23 +99,41 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <a
         href={`/${subsite}/events/`}
-        class="p-4 bg-galaxy-primary/5 rounded-lg hover:bg-galaxy-primary/10 transition-colors"
+        class="group relative overflow-hidden p-4 bg-white border border-galaxy-primary/10 rounded-lg shadow-sm hover:border-galaxy-primary/30 transition-colors"
       >
+        <span
+          class="absolute left-0 top-0 bottom-0 w-1 bg-galaxy-gold transform origin-left scale-y-0 group-hover:scale-y-100 transition-transform duration-200"
+        ></span>
         <h3 class="font-semibold text-galaxy-dark">Events</h3>
         <p class="text-sm text-chicago-600">Browse all events</p>
       </a>
       <a
         href={`/${subsite}/news/`}
-        class="p-4 bg-galaxy-primary/5 rounded-lg hover:bg-galaxy-primary/10 transition-colors"
+        class="group relative overflow-hidden p-4 bg-white border border-galaxy-primary/10 rounded-lg shadow-sm hover:border-galaxy-primary/30 transition-colors"
       >
+        <span
+          class="absolute left-0 top-0 bottom-0 w-1 bg-galaxy-gold transform origin-left scale-y-0 group-hover:scale-y-100 transition-transform duration-200"
+        ></span>
         <h3 class="font-semibold text-galaxy-dark">News</h3>
         <p class="text-sm text-chicago-600">Read latest news</p>
       </a>
-      <a href="/use/" class="p-4 bg-galaxy-primary/5 rounded-lg hover:bg-galaxy-primary/10 transition-colors">
+      <a
+        href="/use/"
+        class="group relative overflow-hidden p-4 bg-white border border-galaxy-primary/10 rounded-lg shadow-sm hover:border-galaxy-primary/30 transition-colors"
+      >
+        <span
+          class="absolute left-0 top-0 bottom-0 w-1 bg-galaxy-gold transform origin-left scale-y-0 group-hover:scale-y-100 transition-transform duration-200"
+        ></span>
         <h3 class="font-semibold text-galaxy-dark">Platforms</h3>
         <p class="text-sm text-chicago-600">Find Galaxy servers</p>
       </a>
-      <a href="/community/" class="p-4 bg-galaxy-primary/5 rounded-lg hover:bg-galaxy-primary/10 transition-colors">
+      <a
+        href="/community/"
+        class="group relative overflow-hidden p-4 bg-white border border-galaxy-primary/10 rounded-lg shadow-sm hover:border-galaxy-primary/30 transition-colors"
+      >
+        <span
+          class="absolute left-0 top-0 bottom-0 w-1 bg-galaxy-gold transform origin-left scale-y-0 group-hover:scale-y-100 transition-transform duration-200"
+        ></span>
         <h3 class="font-semibold text-galaxy-dark">Community</h3>
         <p class="text-sm text-chicago-600">Get involved</p>
       </a>
@@ -116,29 +148,29 @@ const { subsite, title, description, upcomingEvents, subsiteNews, hasMainContent
     margin-bottom: 1.5rem;
   }
 
-  .subsite-inserts :global(p),
-  .subsite-inserts :global(ul),
-  .subsite-inserts :global(ol) {
+  .subsite-inserts :global(p:not([class])),
+  .subsite-inserts :global(ul:not([class])),
+  .subsite-inserts :global(ol:not([class])) {
     max-width: 65ch;
     line-height: 1.7;
   }
 
-  .subsite-inserts :global(ul) {
+  .subsite-inserts :global(ul:not([class])) {
     list-style-type: disc;
     padding-left: 1.5rem;
   }
 
-  .subsite-inserts :global(li) {
+  .subsite-inserts :global(li:not([class])) {
     margin-bottom: 0.25rem;
   }
 
-  .subsite-inserts :global(a) {
+  .subsite-inserts :global(a:not([class])) {
     color: var(--color-galaxy-primary);
     text-decoration: underline;
     text-underline-offset: 2px;
   }
 
-  .subsite-inserts :global(a:hover) {
+  .subsite-inserts :global(a:not([class]):hover) {
     color: var(--color-galaxy-dark);
   }
 

--- a/astro/src/components/events/EventsList.vue
+++ b/astro/src/components/events/EventsList.vue
@@ -36,6 +36,10 @@ const props = withDefaults(
 );
 
 const $subsite = useStore(currentSubsite);
+const hasMounted = ref(false);
+const effectiveSubsite = computed(() =>
+  !hasMounted.value && props.initialSubsite ? props.initialSubsite : $subsite.value
+);
 const isBrowser = typeof window !== 'undefined';
 
 function getYearFromQuery(): number | null {
@@ -56,6 +60,7 @@ onMounted(() => {
   if (props.initialSubsite && props.initialSubsite !== 'global') {
     currentSubsite.set(props.initialSubsite);
   }
+  hasMounted.value = true;
 });
 
 function loadMorePast() {
@@ -78,7 +83,7 @@ function getSubsites(event: EventData): string[] {
 
 // Filter events based on current subsite
 const filteredEvents = computed(() => {
-  const subsite = $subsite.value;
+  const subsite = effectiveSubsite.value;
 
   // Global shows all events
   if (subsite === 'global') {
@@ -161,7 +166,7 @@ watch(availablePastYears, (years) => {
 });
 
 // Reset pagination when year or subsite changes
-watch([selectedPastYear, $subsite], () => {
+watch([selectedPastYear, effectiveSubsite], () => {
   pastDisplayCount.value = pageSize;
 });
 
@@ -217,9 +222,9 @@ function displaySubsite(subsite: string): string {
 <template>
   <div class="events-list">
     <!-- Subsite indicator -->
-    <div v-if="$subsite !== 'global'" class="mb-6 p-4 bg-galaxy-primary/10 rounded-lg">
+    <div v-if="effectiveSubsite !== 'global'" class="mb-6 p-4 bg-galaxy-primary/10 rounded-lg">
       <p class="text-sm text-galaxy-dark">
-        Showing events for <strong>{{ displaySubsite($subsite) }}</strong> subsite.
+        Showing events for <strong>{{ displaySubsite(effectiveSubsite) }}</strong> subsite.
         <button @click="() => currentSubsite.set('global')" class="ml-2 text-galaxy-primary hover:underline">
           Show all events
         </button>

--- a/astro/src/components/layout/MobileMenu.vue
+++ b/astro/src/components/layout/MobileMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useStore } from '@nanostores/vue';
 import { currentSubsite, navigateToSubsiteMain, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
@@ -60,20 +60,32 @@ const DEFAULT_MOBILE_NAV = {
 
 const props = defineProps<{
   navbar?: NavbarData | null;
+  initialSubsite?: SubsiteId;
 }>();
 
 const isOpen = ref(false);
 const subsite = useStore(currentSubsite);
-const showPeople = computed(() => !!subsite.value && subsite.value !== 'global');
+const hasMounted = ref(false);
+const effectiveSubsite = computed(() =>
+  !hasMounted.value && props.initialSubsite ? props.initialSubsite : subsite.value
+);
+const showPeople = computed(() => !!effectiveSubsite.value && effectiveSubsite.value !== 'global');
 
 const navModel = computed<SidebarNavigation>(
-  () => navbarToSidebarNavigation(props.navbar, subsite.value) || (DEFAULT_MOBILE_NAV as SidebarNavigation)
+  () => navbarToSidebarNavigation(props.navbar, effectiveSubsite.value) || (DEFAULT_MOBILE_NAV as SidebarNavigation)
 );
 const navSections = computed<NavSection[]>(() => navModel.value.sections);
 const topLinks = computed<NavItem[]>(() => navModel.value.topLinks);
 const bottomLinks = computed<NavItem[]>(() => navModel.value.bottomLinks);
 
 const openSections = ref<Set<string>>(new Set(navModel.value.sections.slice(0, 2).map((section) => section.title)));
+
+onMounted(() => {
+  if (props.initialSubsite) {
+    currentSubsite.set(props.initialSubsite);
+  }
+  hasMounted.value = true;
+});
 
 function toggleSection(title: string) {
   if (openSections.value.has(title)) {
@@ -130,7 +142,7 @@ function filteredItems(section: NavSection) {
         <!-- Region Switcher -->
         <div class="px-4 py-4 border-b border-medium-bg">
           <label class="text-xs font-medium text-chicago-400 uppercase tracking-wider mb-2 block"> Region </label>
-          <Select :model-value="subsite" @update:model-value="handleSubsiteChange">
+          <Select :model-value="effectiveSubsite" @update:model-value="handleSubsiteChange">
             <SelectTrigger class="w-full bg-medium-bg border-0 text-white">
               <SelectValue placeholder="Select region" />
             </SelectTrigger>

--- a/astro/src/components/layout/PageHeader.astro
+++ b/astro/src/components/layout/PageHeader.astro
@@ -10,12 +10,14 @@ import { formatDate } from '../../utils/dateUtils';
 interface Props {
   title: string;
   description?: string;
+  eyebrow?: string | { label: string; href?: string };
   date?: Date | string;
   authors?: Array<string | { id?: string; name: string }>;
   tags?: string[];
 }
 
-const { title, description, date, authors: authorsRaw = [], tags: tagsRaw = [] } = Astro.props;
+const { title, description, eyebrow, date, authors: authorsRaw = [], tags: tagsRaw = [] } = Astro.props;
+const eyebrowData = typeof eyebrow === 'string' ? { label: eyebrow } : eyebrow;
 
 // Helpers
 function slugify(value: string): string {
@@ -59,6 +61,19 @@ const formattedDate = formatDate(date, false);
 
 <header class="page-header">
   <div class="page-header-content">
+    {
+      eyebrowData &&
+        (eyebrowData.href ? (
+          <a
+            href={eyebrowData.href}
+            class="mb-3 inline-flex text-sm font-semibold text-galaxy-gold underline-offset-4 hover:text-accent-hover hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-galaxy-gold"
+          >
+            {eyebrowData.label}
+          </a>
+        ) : (
+          <div class="mb-3 text-sm font-semibold text-galaxy-gold">{eyebrowData.label}</div>
+        ))
+    }
     <div class="flex items-center gap-3 mb-4">
       <div class="w-1 h-8 bg-galaxy-gold"></div>
       <h1 class="text-3xl sm:text-4xl font-bold tracking-tight">{title}</h1>

--- a/astro/src/components/layout/Sidebar.astro
+++ b/astro/src/components/layout/Sidebar.astro
@@ -4,12 +4,14 @@
 // Mobile: Hidden (use MobileMenu.vue for mobile)
 import SidebarNav from './SidebarNav.vue';
 import type { NavbarData } from '@/utils/navbar';
+import type { SubsiteId } from '@/stores/subsiteStore';
 
 interface Props {
   navbar?: NavbarData | null;
+  initialSubsite?: SubsiteId;
 }
 
-const { navbar } = Astro.props as Props;
+const { navbar, initialSubsite } = Astro.props as Props;
 ---
 
 <aside class="hidden lg:flex flex-col w-64 bg-galaxy-dark text-white fixed left-0 top-0 h-screen overflow-y-auto z-40">
@@ -45,7 +47,7 @@ const { navbar } = Astro.props as Props;
 
   <!-- Navigation (Vue component for collapsible sections) -->
   <div class="flex-1 p-4 overflow-y-auto">
-    <SidebarNav client:load navbar={navbar} />
+    <SidebarNav client:load navbar={navbar} initialSubsite={initialSubsite} />
   </div>
 
   <!-- Archive notice -->

--- a/astro/src/components/layout/SidebarNav.vue
+++ b/astro/src/components/layout/SidebarNav.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue';
 import { useStore } from '@nanostores/vue';
-import { currentSubsite } from '@/stores/subsiteStore';
+import { currentSubsite, type SubsiteId } from '@/stores/subsiteStore';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { ChevronDown } from 'lucide-vue-next';
 import SubsiteSwitcher from './SubsiteSwitcher.vue';
@@ -27,10 +27,15 @@ const subsite = useStore(currentSubsite);
 
 const props = defineProps<{
   navbar?: NavbarData | null;
+  initialSubsite?: SubsiteId;
 }>();
 
+const hasMounted = ref(false);
+const effectiveSubsite = computed(() =>
+  !hasMounted.value && props.initialSubsite ? props.initialSubsite : subsite.value
+);
 const navModel = computed<SidebarNavigation>(
-  () => navbarToSidebarNavigation(props.navbar, subsite.value) || getDefaultSidebarNavigation()
+  () => navbarToSidebarNavigation(props.navbar, effectiveSubsite.value) || getDefaultSidebarNavigation()
 );
 const topLinks = computed<NavItem[]>(() => navModel.value.topLinks);
 const navSections = computed<NavSection[]>(() => navModel.value.sections);
@@ -41,6 +46,11 @@ const openSections = ref<Set<string>>(new Set());
 
 // On mount, open the section containing the current page
 onMounted(() => {
+  if (props.initialSubsite) {
+    currentSubsite.set(props.initialSubsite);
+  }
+  hasMounted.value = true;
+
   const currentPath = window.location.pathname;
   for (const section of navSections.value) {
     for (const item of section.items) {
@@ -126,7 +136,7 @@ function isOpen(title: string): boolean {
 
     <!-- Region Selector -->
     <div class="pt-4 border-t border-ebony-clay-700">
-      <SubsiteSwitcher />
+      <SubsiteSwitcher :initial-subsite="effectiveSubsite" />
     </div>
 
     <!-- Bottom links (@jxtx Foundation) -->

--- a/astro/src/components/layout/SubsiteSwitcher.vue
+++ b/astro/src/components/layout/SubsiteSwitcher.vue
@@ -1,9 +1,25 @@
 <script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
 import { useStore } from '@nanostores/vue';
 import { currentSubsite, navigateToSubsiteMain, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
+const props = defineProps<{
+  initialSubsite?: SubsiteId;
+}>();
+
 const current = useStore(currentSubsite);
+const hasMounted = ref(false);
+const effectiveCurrent = computed(() =>
+  !hasMounted.value && props.initialSubsite ? props.initialSubsite : current.value
+);
+
+onMounted(() => {
+  if (props.initialSubsite) {
+    currentSubsite.set(props.initialSubsite);
+  }
+  hasMounted.value = true;
+});
 
 function handleChange(value: string) {
   navigateToSubsiteMain(value as SubsiteId);
@@ -13,7 +29,7 @@ function handleChange(value: string) {
 <template>
   <div class="px-3">
     <label class="text-xs font-medium text-chicago-400 uppercase tracking-wider mb-2 block"> Region </label>
-    <Select :model-value="current" @update:model-value="handleChange">
+    <Select :model-value="effectiveCurrent" @update:model-value="handleChange">
       <SelectTrigger class="w-full bg-medium-bg border-0 text-white">
         <SelectValue placeholder="Global" />
       </SelectTrigger>

--- a/astro/src/components/mdx/EuIntro.astro
+++ b/astro/src/components/mdx/EuIntro.astro
@@ -1,44 +1,42 @@
 <section
-  class="rounded-lg border border-galaxy-primary/10 bg-white p-6 shadow-sm sm:p-8"
+  class="rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm sm:p-8"
   aria-labelledby="galaxy-europe-intro"
 >
-  <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.55fr)] lg:items-start">
-    <div>
-      <h2 id="galaxy-europe-intro" class="text-2xl font-bold text-galaxy-dark">
-        Open, reproducible data analysis
-      </h2>
-      <p class="mt-3 text-chicago-700">
-        <strong>Galaxy</strong> is an <strong>open-source</strong> platform for <strong
-          ><a
-            class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
-            href="https://www.go-fair.org/fair-principles/">FAIR data analysis</a
-          ></strong
-        >. It gives researchers a graphical web interface for complex analysis while keeping workflows, histories, and
-        results shareable and reproducible.
-      </p>
-      <p class="mt-4 text-chicago-700">
-        The <strong>Galaxy Community</strong> helps the ecosystem improve and supports researchers in sharing scientific
-        discoveries.
-      </p>
-    </div>
-
-    <ul class="grid gap-3 text-sm text-chicago-700 sm:grid-cols-2 lg:grid-cols-1">
-      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
-        <strong class="block text-galaxy-dark">Tools</strong>
-        Run domain-specific tools through the web interface.
-      </li>
-      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
-        <strong class="block text-galaxy-dark">Workflows</strong>
-        Connect tools into reusable analysis workflows.
-      </li>
-      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
-        <strong class="block text-galaxy-dark">Interactive environments</strong>
-        Use RStudio, Jupyter, and companion tools.
-      </li>
-      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
-        <strong class="block text-galaxy-dark">Reproducibility</strong>
-        Capture the context needed to repeat analyses.
-      </li>
-    </ul>
+  <div class="mb-3">
+    <h2 id="galaxy-europe-intro" class="text-2xl font-bold text-galaxy-dark">Open, reproducible data analysis</h2>
+    <p class="mt-3 text-chicago-700">
+      <strong>Galaxy</strong> is an <strong>open-source</strong> platform for
+      <strong>
+        <a
+          class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
+          href="https://www.go-fair.org/fair-principles/"
+        >
+          FAIR data analysis
+        </a>
+      </strong>. It gives researchers a graphical web interface for complex analysis while keeping workflows, histories,
+      and results shareable and reproducible.
+    </p>
+    <p class="mt-4 text-chicago-700">
+      The <strong>Galaxy Community</strong> helps the ecosystem improve and supports researchers in sharing scientific discoveries.
+    </p>
   </div>
+
+  <ul class="grid gap-3 text-sm text-chicago-700 sm:grid-cols-2">
+    <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+      <strong class="block text-galaxy-dark">Tools</strong>
+      Run domain-specific tools through the web interface.
+    </li>
+    <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+      <strong class="block text-galaxy-dark">Workflows</strong>
+      Connect tools into reusable analysis workflows.
+    </li>
+    <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+      <strong class="block text-galaxy-dark">Interactive environments</strong>
+      Use RStudio, Jupyter, and companion tools.
+    </li>
+    <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+      <strong class="block text-galaxy-dark">Reproducibility</strong>
+      Capture the context needed to repeat analyses.
+    </li>
+  </ul>
 </section>

--- a/astro/src/components/mdx/EuIntro.astro
+++ b/astro/src/components/mdx/EuIntro.astro
@@ -1,0 +1,44 @@
+<section
+  class="rounded-lg border border-galaxy-primary/10 bg-white p-6 shadow-sm sm:p-8"
+  aria-labelledby="galaxy-europe-intro"
+>
+  <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.55fr)] lg:items-start">
+    <div>
+      <h2 id="galaxy-europe-intro" class="text-2xl font-bold text-galaxy-dark">
+        Open, reproducible data analysis
+      </h2>
+      <p class="mt-3 text-chicago-700">
+        <strong>Galaxy</strong> is an <strong>open-source</strong> platform for <strong
+          ><a
+            class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
+            href="https://www.go-fair.org/fair-principles/">FAIR data analysis</a
+          ></strong
+        >. It gives researchers a graphical web interface for complex analysis while keeping workflows, histories, and
+        results shareable and reproducible.
+      </p>
+      <p class="mt-4 text-chicago-700">
+        The <strong>Galaxy Community</strong> helps the ecosystem improve and supports researchers in sharing scientific
+        discoveries.
+      </p>
+    </div>
+
+    <ul class="grid gap-3 text-sm text-chicago-700 sm:grid-cols-2 lg:grid-cols-1">
+      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+        <strong class="block text-galaxy-dark">Tools</strong>
+        Run domain-specific tools through the web interface.
+      </li>
+      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+        <strong class="block text-galaxy-dark">Workflows</strong>
+        Connect tools into reusable analysis workflows.
+      </li>
+      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+        <strong class="block text-galaxy-dark">Interactive environments</strong>
+        Use RStudio, Jupyter, and companion tools.
+      </li>
+      <li class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4">
+        <strong class="block text-galaxy-dark">Reproducibility</strong>
+        Capture the context needed to repeat analyses.
+      </li>
+    </ul>
+  </div>
+</section>

--- a/astro/src/components/mdx/EuSiteFooter.astro
+++ b/astro/src/components/mdx/EuSiteFooter.astro
@@ -1,0 +1,51 @@
+---
+import Icon from './Icon.astro';
+
+const links = [
+  { href: 'mailto:contact@usegalaxy.eu', icon: 'mail', label: 'contact@usegalaxy.eu' },
+  { href: 'https://github.com/usegalaxy-eu', icon: 'github', label: 'GitHub' },
+  { href: 'https://matrix.to/#/#usegalaxy.eu:matrix.org', icon: 'message-circle', label: 'Matrix' },
+  {
+    href: 'https://xn--baw-joa.social/@galaxyfreiburg',
+    icon: 'message-circle',
+    label: 'Mastodon',
+    rel: 'me noopener noreferrer',
+    target: '_blank',
+  },
+  { href: '/eu/feed.atom', icon: 'rss', label: 'Feed' },
+];
+---
+
+<section class="mt-12 rounded-lg border border-galaxy-primary/10 bg-white p-6 text-center shadow-sm">
+  <p class="mx-auto text-chicago-700">
+    UseGalaxy.eu is maintained largely by the <a
+      class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
+      href="https://usegalaxy-eu.github.io/freiburg/">Freiburg Galaxy Team</a
+    > and collectively by groups and individuals from across Europe. All member sites in this repository contribute to
+    the European Galaxy Project. For acknowledgement, please refer to the <a
+      class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
+      href="https://usegalaxy-eu.github.io/about">About section</a
+    >. All content on this site is available under <a
+      class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
+      href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a
+    > unless otherwise specified.
+  </p>
+
+  <ul class="mt-5 flex flex-wrap items-center justify-center gap-3 text-sm">
+    {
+      links.map((link) => (
+        <li>
+          <a
+            class="inline-flex items-center gap-1.5 rounded-md border border-galaxy-primary/15 px-3 py-1.5 text-galaxy-primary hover:border-galaxy-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary"
+            href={link.href}
+            target={link.target}
+            rel={link.rel}
+          >
+            <Icon name={link.icon} size={16} />
+            {link.label}
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</section>

--- a/astro/src/components/mdx/EuSiteFooter.astro
+++ b/astro/src/components/mdx/EuSiteFooter.astro
@@ -21,8 +21,8 @@ const links = [
     UseGalaxy.eu is maintained largely by the <a
       class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
       href="https://usegalaxy-eu.github.io/freiburg/">Freiburg Galaxy Team</a
-    > and collectively by groups and individuals from across Europe. All member sites in this repository contribute to
-    the European Galaxy Project. For acknowledgement, please refer to the <a
+    > and collectively by groups and individuals from across Europe. All member sites in this repository contribute to the
+    European Galaxy Project. For acknowledgement, please refer to the <a
       class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
       href="https://usegalaxy-eu.github.io/about">About section</a
     >. All content on this site is available under <a

--- a/astro/src/components/mdx/index.ts
+++ b/astro/src/components/mdx/index.ts
@@ -13,6 +13,7 @@ export { default as Supporters } from './Supporters.astro';
 export { default as Contacts } from './Contacts.astro';
 export { default as Icon } from './Icon.astro';
 export { default as CopyButton } from './CopyButton.astro';
+export { default as EuIntro } from './EuIntro.astro';
 
 // Component map using kebab-case keys for MDX
 // Note: When passing to MDX Content, use the PascalCase exports above

--- a/astro/src/components/news/NewsList.vue
+++ b/astro/src/components/news/NewsList.vue
@@ -22,6 +22,10 @@ const props = defineProps<{
 }>();
 
 const $subsite = useStore(currentSubsite);
+const hasMounted = ref(false);
+const effectiveSubsite = computed(() =>
+  !hasMounted.value && props.initialSubsite ? props.initialSubsite : $subsite.value
+);
 
 // Year-based navigation - null means "show recent" (no year filter)
 const isBrowser = typeof window !== 'undefined';
@@ -43,6 +47,7 @@ onMounted(() => {
   if (props.initialSubsite && props.initialSubsite !== 'global') {
     currentSubsite.set(props.initialSubsite);
   }
+  hasMounted.value = true;
 });
 
 // Helper to normalize subsites to array
@@ -54,7 +59,7 @@ function getSubsites(article: NewsArticle): string[] {
 
 // Filter articles based on current subsite
 const filteredBySubsite = computed(() => {
-  const subsite = $subsite.value;
+  const subsite = effectiveSubsite.value;
   if (subsite === 'global') {
     return props.articles;
   }
@@ -97,7 +102,7 @@ const recentYears = computed(() => availableYears.value.slice(0, 5));
 const olderYears = computed(() => availableYears.value.slice(5));
 
 // Reset pagination when year or subsite changes
-watch([selectedYear, $subsite], () => {
+watch([selectedYear, effectiveSubsite], () => {
   displayCount.value = pageSize;
 });
 
@@ -155,9 +160,9 @@ function displaySubsite(subsite: string): string {
 <template>
   <div class="news-list">
     <!-- Subsite indicator -->
-    <div v-if="$subsite !== 'global'" class="mb-6 p-4 bg-galaxy-primary/10 rounded-lg">
+    <div v-if="effectiveSubsite !== 'global'" class="mb-6 p-4 bg-galaxy-primary/10 rounded-lg">
       <p class="text-sm text-galaxy-dark">
-        Showing news for <strong>{{ displaySubsite($subsite) }}</strong> subsite.
+        Showing news for <strong>{{ displaySubsite(effectiveSubsite) }}</strong> subsite.
         <button @click="() => currentSubsite.set('global')" class="ml-2 text-galaxy-primary hover:underline">
           Show all news
         </button>

--- a/astro/src/layouts/ArticleLayout.astro
+++ b/astro/src/layouts/ArticleLayout.astro
@@ -22,6 +22,7 @@ interface Props {
   autotoc?: boolean;
   headings?: Heading[];
   image?: string;
+  eyebrow?: string | { label: string; href?: string };
   backLink?: {
     href: string;
     label: string;
@@ -38,6 +39,7 @@ const {
   authors: authorsRaw = [],
   tags: tagsRaw = [],
   image,
+  eyebrow,
   backLink,
   autotoc = true,
   headings = [],
@@ -62,7 +64,7 @@ const hasMetadata =
   <article class="max-w-6xl mx-auto bg-white relative">
     {
       hasMetadata && (
-        <PageHeader title={title} description={description} date={date} authors={authors} tags={tags}>
+        <PageHeader title={title} description={description} eyebrow={eyebrow} date={date} authors={authors} tags={tags}>
           {fairSection && <FairSectionHero sectionSlug={fairSection} />}
         </PageHeader>
       )

--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -37,14 +37,14 @@ const navbar = await getSubsiteNavbar(currentSubsite);
   <body class="min-h-screen bg-background text-foreground">
     <div class="flex min-h-screen overflow-hidden">
       <!-- Sidebar (desktop only) -->
-      <Sidebar transition:persist navbar={navbar} />
+      <Sidebar transition:persist navbar={navbar} initialSubsite={currentSubsite} />
 
       <!-- Mobile header with Vue-powered menu -->
       <div class="lg:hidden fixed top-0 left-0 right-0 z-50 bg-galaxy-dark p-4 flex items-center justify-between">
         <a href="/" class="block">
           <img src="/images/galaxy_logo_hub_white.svg" alt="Galaxy Community Hub" class="h-8 w-auto" />
         </a>
-        <MobileMenu client:load navbar={navbar} />
+        <MobileMenu client:load navbar={navbar} initialSubsite={currentSubsite} />
       </div>
 
       <!-- Main content area -->

--- a/astro/src/pages/[...slug].astro
+++ b/astro/src/pages/[...slug].astro
@@ -40,6 +40,7 @@ const fairSection =
   article.data.slug === 'fair' || article.data.slug.startsWith('fair/') ? article.data.slug : undefined;
 
 const { title, date, tags = [], tease, image, autotoc } = article.data;
+const eyebrow = article.data.slug.startsWith('eu/') ? { label: 'Galaxy Europe', href: '/eu/' } : undefined;
 
 // MDX components map - keys match PascalCase names used in preprocessed content
 const components = {
@@ -65,6 +66,7 @@ const components = {
   date={date}
   tags={tags}
   image={image}
+  eyebrow={eyebrow}
   headings={headings}
   autotoc={autotoc}
   sourceFile={sourceFile}

--- a/astro/src/pages/[subsite]/citations.astro
+++ b/astro/src/pages/[subsite]/citations.astro
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHeader from '../../components/layout/PageHeader.astro';
 import { subsites } from '../../stores/subsiteStore';
 import { Cite } from '@citation-js/core';
 import '@citation-js/plugin-bibtex';
@@ -18,6 +19,14 @@ export function getStaticPaths() {
 }
 
 const { subsite } = Astro.params;
+const { subsiteInfo } = Astro.props;
+const subsiteName = subsiteInfo?.name || subsite.toUpperCase();
+const isEurope = subsite === 'eu';
+const pageTitle = isEurope ? 'Galaxy Europe Citations' : `${subsiteName} Citations`;
+const headerTitle = isEurope ? 'Citations' : `${subsiteName} Citations`;
+const serverLabel = isEurope ? 'European Galaxy server' : `${subsiteName} Galaxy instance`;
+const pageDescription = `Scientific publications that cited the ${serverLabel}.`;
+const eyebrow = isEurope ? { label: 'Galaxy Europe', href: '/eu/' } : undefined;
 
 const projectRoot = path.resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
 const contentRoot = path.join(projectRoot, 'content');
@@ -104,85 +113,82 @@ const years = Object.keys(yearCounts).sort((a, b) => {
 const emptyHint = `No citations found for ${subsite}. Add a BibTeX file at content/${subsite}/citations/.`;
 ---
 
-<BaseLayout
-  title={`Scientific research using & citing the ${subsite.toUpperCase()} Galaxy server`}
-  description={`Scientific research using & citing the ${subsite.toUpperCase()} Galaxy server.`}
->
-  <div class="max-w-5xl mx-auto space-y-6">
-    <header class="border-b border-ebony-clay-100 pb-4">
-      <h1 class="text-3xl font-bold text-galaxy-dark">{subsite.toUpperCase()} Citations</h1>
-      <p class="text-chicago-600">
-        This is the list of scientific publications that cited the {subsite.toUpperCase()} Galaxy instance. Please help us
-        to support this project with your acknowledgement.
-      </p>
-    </header>
+<BaseLayout title={pageTitle} description={pageDescription}>
+  <div class="max-w-5xl mx-auto">
+    <PageHeader title={headerTitle} description={pageDescription} {eyebrow} />
 
-    {
-      !exists || citations.length === 0 ? (
-        <div class="rounded-md border border-dashed border-ebony-clay-200 bg-ebony-clay-50 p-6 text-chicago-700">
-          <p>{emptyHint}</p>
-        </div>
-      ) : (
-        <div class="space-y-6">
-          <section class="rounded-md border border-ebony-clay-100 bg-ebony-clay-50 p-4 space-y-3">
-            <p class="text-sm text-chicago-700 font-medium">Filter by year</p>
-            <div class="flex flex-wrap items-center gap-2">
-              <a
-                data-year-button
-                data-year="all"
-                href="."
-                class="px-3 py-1.5 text-sm font-medium rounded-md bg-galaxy-primary text-white"
-                aria-pressed="true"
-              >
-                All <span class="ml-1 text-xs opacity-80">({citations.length})</span>
-              </a>
-              {years.map((year) => (
+    <div class="bg-white rounded-b-lg shadow-sm px-6 sm:px-8 py-8">
+      <p class="mb-6 max-w-3xl text-chicago-600">
+        Please help us support this project by acknowledging the service in publications that use it.
+      </p>
+
+      {
+        !exists || citations.length === 0 ? (
+          <div class="rounded-lg border border-dashed border-ebony-clay-200 bg-ebony-clay-50 p-6 text-chicago-700">
+            <p>{emptyHint}</p>
+          </div>
+        ) : (
+          <div class="space-y-6">
+            <section class="rounded-lg border border-galaxy-primary/10 bg-bay-of-many-50 p-4 space-y-3">
+              <p class="text-sm text-chicago-700 font-medium">Filter by year</p>
+              <div class="flex flex-wrap items-center gap-2">
                 <a
                   data-year-button
-                  data-year={year}
-                  href={`?year=${encodeURIComponent(year)}`}
-                  class="px-3 py-1.5 text-sm font-medium rounded-md bg-ebony-clay-50 text-chicago-700 hover:bg-ebony-clay-100"
-                  aria-pressed="false"
+                  data-year="all"
+                  href="."
+                  class="px-3 py-1.5 text-sm font-medium rounded-md bg-galaxy-primary text-white"
+                  aria-pressed="true"
                 >
-                  {year === 'unknown' ? 'Unknown year' : year}
-                  <span class="ml-1 text-xs opacity-80">({yearCounts[year]})</span>
+                  All <span class="ml-1 text-xs opacity-80">({citations.length})</span>
                 </a>
-              ))}
-            </div>
-            <p class="text-sm text-chicago-500" data-filter-count>
-              Showing {citations.length} citation{citations.length === 1 ? '' : 's'}
-            </p>
-          </section>
-
-          {citations.map((c, idx) => (
-            <article
-              class="border border-ebony-clay-100 rounded-md p-4 shadow-sm"
-              key={`${c.title || 'citation'}-${idx}`}
-              data-citation-year={c.year ? String(c.year) : 'unknown'}
-            >
-              <div class="flex items-start justify-between gap-4">
-                <div>
-                  <h2 class="text-lg font-semibold text-galaxy-dark">
-                    {c.url ? (
-                      <a
-                        href={c.url}
-                        class="hover:text-galaxy-primary transition-colors"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        set:html={c.title || 'Untitled'}
-                      />
-                    ) : (
-                      <span set:html={c.title || 'Untitled'} />
-                    )}
-                  </h2>
-                  {c.authors && <p class="text-sm text-chicago-600 mt-1">{c.authors}</p>}
-                </div>
+                {years.map((year) => (
+                  <a
+                    data-year-button
+                    data-year={year}
+                    href={`?year=${encodeURIComponent(year)}`}
+                    class="px-3 py-1.5 text-sm font-medium rounded-md bg-ebony-clay-50 text-chicago-700 hover:bg-ebony-clay-100"
+                    aria-pressed="false"
+                  >
+                    {year === 'unknown' ? 'Unknown year' : year}
+                    <span class="ml-1 text-xs opacity-80">({yearCounts[year]})</span>
+                  </a>
+                ))}
               </div>
-            </article>
-          ))}
-        </div>
-      )
-    }
+              <p class="text-sm text-chicago-500" data-filter-count>
+                Showing {citations.length} citation{citations.length === 1 ? '' : 's'}
+              </p>
+            </section>
+
+            {citations.map((c, idx) => (
+              <article
+                class="rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm"
+                key={`${c.title || 'citation'}-${idx}`}
+                data-citation-year={c.year ? String(c.year) : 'unknown'}
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 class="text-lg font-semibold text-galaxy-dark">
+                      {c.url ? (
+                        <a
+                          href={c.url}
+                          class="hover:text-galaxy-primary transition-colors"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          set:html={c.title || 'Untitled'}
+                        />
+                      ) : (
+                        <span set:html={c.title || 'Untitled'} />
+                      )}
+                    </h2>
+                    {c.authors && <p class="text-sm text-chicago-600 mt-1">{c.authors}</p>}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )
+      }
+    </div>
   </div>
 
   <script>

--- a/astro/src/pages/[subsite]/events/archive/index.astro
+++ b/astro/src/pages/[subsite]/events/archive/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
+import PageHeader from '../../../../components/layout/PageHeader.astro';
 import EventsList from '../../../../components/events/EventsList.vue';
 import { subsites } from '../../../../stores/subsiteStore';
 
@@ -14,6 +15,11 @@ export function getStaticPaths() {
 }
 
 const { subsiteName, subsiteId } = Astro.props;
+const isEurope = subsiteId === 'eu';
+const pageTitle = isEurope ? 'Galaxy Europe Events Archive' : `${subsiteName} Events Archive`;
+const headerTitle = isEurope ? 'Events Archive' : `${subsiteName} Events Archive`;
+const pageDescription = `Past events for the ${subsiteName} Galaxy community.`;
+const eyebrow = isEurope ? { label: 'Galaxy Europe', href: '/eu/' } : undefined;
 
 const events = await getCollection('events');
 
@@ -29,22 +35,20 @@ const eventData = events.map((e) => ({
 }));
 ---
 
-<BaseLayout
-  title={`${subsiteName} Events Archive`}
-  description={`Past events for the ${subsiteName} Galaxy community.`}
->
-  <div class="max-w-6xl mx-auto bg-white">
-    <header class="px-6 sm:px-8 pt-6 pb-6 border-b-4 border-b-galaxy-gold">
-      <h1 class="text-3xl sm:text-4xl font-bold text-galaxy-dark mb-2">{subsiteName} Events Archive</h1>
-      <p class="text-lg text-chicago-600">
-        Past events for the {subsiteName} Galaxy community.
-        <a class="text-sm text-galaxy-primary hover:underline ml-2" href={`/${subsiteId}/events/`}>
+<BaseLayout title={pageTitle} description={pageDescription}>
+  <div class="max-w-6xl mx-auto">
+    <PageHeader title={headerTitle} description={pageDescription} {eyebrow}>
+      <div class="mt-6">
+        <a
+          class="inline-flex items-center rounded-lg border border-white/30 px-3 py-1.5 text-sm font-medium text-white hover:border-galaxy-gold hover:bg-white/10 transition-colors"
+          href={`/${subsiteId}/events/`}
+        >
           View upcoming events
         </a>
-      </p>
-    </header>
+      </div>
+    </PageHeader>
 
-    <div class="px-6 sm:px-8 py-6">
+    <div class="bg-white rounded-b-lg shadow-sm px-6 sm:px-8 py-6">
       <EventsList
         client:only="vue"
         events={eventData}

--- a/astro/src/pages/[subsite]/events/index.astro
+++ b/astro/src/pages/[subsite]/events/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
+import PageHeader from '../../../components/layout/PageHeader.astro';
 import EventsList from '../../../components/events/EventsList.vue';
 import { subsites } from '../../../stores/subsiteStore';
 
@@ -15,6 +16,11 @@ export function getStaticPaths() {
 }
 
 const { subsiteName, subsiteId } = Astro.props;
+const isEurope = subsiteId === 'eu';
+const pageTitle = isEurope ? 'Galaxy Europe Events' : `${subsiteName} Events`;
+const headerTitle = isEurope ? 'Events' : `${subsiteName} Events`;
+const pageDescription = 'Workshops, conferences, and community gatherings';
+const eyebrow = isEurope ? { label: 'Galaxy Europe', href: '/eu/' } : undefined;
 
 // Get all events and prepare data for client component
 const events = await getCollection('events');
@@ -32,14 +38,20 @@ const eventData = events.map((e) => ({
 }));
 ---
 
-<BaseLayout title={`${subsiteName} Events`} description={`Galaxy Project events for ${subsiteName}`}>
-  <div class="max-w-6xl mx-auto bg-white">
-    <header class="px-6 sm:px-8 pt-6 pb-6 border-b-4 border-b-galaxy-gold">
-      <h1 class="text-3xl sm:text-4xl font-bold text-galaxy-dark mb-2">{subsiteName} Events</h1>
-      <p class="text-lg text-chicago-600">Workshops, conferences, and community gatherings</p>
-    </header>
+<BaseLayout title={pageTitle} description={`Galaxy Project events for ${subsiteName}`}>
+  <div class="max-w-6xl mx-auto">
+    <PageHeader title={headerTitle} description={pageDescription} {eyebrow}>
+      <div class="mt-6">
+        <a
+          href={`/${subsiteId}/events/archive/`}
+          class="inline-flex items-center rounded-lg border border-white/30 px-3 py-1.5 text-sm font-medium text-white hover:border-galaxy-gold hover:bg-white/10 transition-colors"
+        >
+          View events archive
+        </a>
+      </div>
+    </PageHeader>
 
-    <div class="px-6 sm:px-8 py-6">
+    <div class="bg-white rounded-b-lg shadow-sm px-6 sm:px-8 py-6">
       <EventsList client:only="vue" events={eventData} initialSubsite={subsiteId} />
     </div>
   </div>

--- a/astro/src/pages/[subsite]/index.astro
+++ b/astro/src/pages/[subsite]/index.astro
@@ -5,6 +5,8 @@ import { getSubsiteStaticPaths, subsiteLabels } from '../../stores/subsiteStore'
 import { getUpcomingEvents, getPublishedNews, getInsert } from '../../utils/content';
 import { render } from 'astro:content';
 import * as mdxComponents from '../../components/mdx/index.ts';
+import EuIntro from '../../components/mdx/EuIntro.astro';
+import EuSiteFooter from '../../components/mdx/EuSiteFooter.astro';
 
 export const getStaticPaths = getSubsiteStaticPaths;
 
@@ -46,6 +48,14 @@ const footerEntries = (await Promise.all(FOOTER_INSERTS.map((name) => getInsert(
 
 const renderedBody = await Promise.all(bodyEntries.map((ins) => render(ins)));
 const renderedFooter = await Promise.all(footerEntries.map((ins) => render(ins)));
+const hasEuLead = subsite === 'eu' && bodyEntries.some((entry) => entry.data.slug === 'eu/lead');
+const renderedMarkdownBody = renderedBody.filter(
+  (_, index) => !(subsite === 'eu' && bodyEntries[index]?.data.slug === 'eu/lead')
+);
+const hasEuSiteFooter = subsite === 'eu' && footerEntries.some((entry) => entry.data.slug === 'eu/site-footer');
+const renderedMarkdownFooter = renderedFooter.filter(
+  (_, index) => !(subsite === 'eu' && footerEntries[index]?.data.slug === 'eu/site-footer')
+);
 ---
 
 <BaseLayout title={title} description={description}>
@@ -57,7 +67,9 @@ const renderedFooter = await Promise.all(footerEntries.map((ins) => render(ins))
     {subsiteNews}
     hasMainContent={renderedBody.length > 0}
   >
-    {renderedBody.map(({ Content }) => <Content slot="main-content" components={mdxComponents} />)}
-    {renderedFooter.map(({ Content }) => <Content slot="footer-content" components={mdxComponents} />)}
+    {hasEuLead && <EuIntro slot="main-content" />}
+    {renderedMarkdownBody.map(({ Content }) => <Content slot="main-content" components={mdxComponents} />)}
+    {hasEuSiteFooter && <EuSiteFooter slot="footer-content" />}
+    {renderedMarkdownFooter.map(({ Content }) => <Content slot="footer-content" components={mdxComponents} />)}
   </SubsiteOverview>
 </BaseLayout>

--- a/astro/src/pages/[subsite]/news/index.astro
+++ b/astro/src/pages/[subsite]/news/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
+import PageHeader from '../../../components/layout/PageHeader.astro';
 import NewsList from '../../../components/news/NewsList.vue';
 import { subsites } from '../../../stores/subsiteStore';
 import { getPublishedNews } from '../../../utils/content';
@@ -15,6 +16,11 @@ export function getStaticPaths() {
 }
 
 const { subsiteName, subsiteId } = Astro.props;
+const isEurope = subsiteId === 'eu';
+const pageTitle = isEurope ? 'Galaxy Europe News' : `${subsiteName} News`;
+const headerTitle = isEurope ? 'News' : `${subsiteName} News`;
+const pageDescription = `Latest updates from the Galaxy ${subsiteName} community`;
+const eyebrow = isEurope ? { label: 'Galaxy Europe', href: '/eu/' } : undefined;
 
 // Get published news articles (excludes future-dated articles)
 const newsArticles = await getPublishedNews();
@@ -31,14 +37,11 @@ const articleData = newsArticles.map((a) => ({
 }));
 ---
 
-<BaseLayout title={`${subsiteName} News`} description={`Latest news from Galaxy ${subsiteName}`}>
-  <div class="max-w-6xl mx-auto bg-white">
-    <header class="px-6 sm:px-8 pt-6 pb-6 border-b-4 border-b-galaxy-gold">
-      <h1 class="text-3xl sm:text-4xl font-bold text-galaxy-dark mb-2">{subsiteName} News</h1>
-      <p class="text-lg text-chicago-600">Latest updates from the Galaxy {subsiteName} community</p>
-    </header>
+<BaseLayout title={pageTitle} description={`Latest news from Galaxy ${subsiteName}`}>
+  <div class="max-w-6xl mx-auto">
+    <PageHeader title={headerTitle} description={pageDescription} {eyebrow} />
 
-    <div class="px-6 sm:px-8 py-6">
+    <div class="bg-white rounded-b-lg shadow-sm px-6 sm:px-8 py-6">
       <NewsList client:load articles={articleData} initialSubsite={subsiteId} />
     </div>
   </div>

--- a/astro/src/pages/[subsite]/people/index.astro
+++ b/astro/src/pages/[subsite]/people/index.astro
@@ -46,7 +46,8 @@ const groups = sectionOrder.map((id) => ({
   people: peopleData[id] || [],
 }));
 
-const pageTitle = `${labelForSite(subsite)} People`;
+const pageTitle = subsite === 'eu' ? 'Galaxy Europe People' : `${labelForSite(subsite)} People`;
+const headerTitle = subsite === 'eu' ? 'People' : `${labelForSite(subsite)} People`;
 const pageDescription =
   subsite === 'eu'
     ? 'Contributors across the European Galaxy Project, grouped by their home site.'
@@ -64,12 +65,13 @@ const hallOfFameUrlFor = (groupId: string, personId: string) => {
   const url = hallUrl((peopleData[groupId] || []).find((p) => p.id === personId)?.hallOfFameSlug || '');
   return url;
 };
+const eyebrow = subsite === 'eu' ? { label: 'Galaxy Europe', href: '/eu/' } : undefined;
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
   <div class="max-w-6xl mx-auto">
     <SubsiteSetter client:load subsiteId={subsite} />
-    <PageHeader title={pageTitle} description={pageDescription}>
+    <PageHeader title={headerTitle} description={pageDescription} {eyebrow}>
       {subsite === 'eu' && <SiteNavigation client:load sites={europeSites} />}
       {subsite === 'us' && <SiteNavigation client:load sites={usSites} />}
     </PageHeader>

--- a/content/eu/common/about-galaxy.md
+++ b/content/eu/common/about-galaxy.md
@@ -1,9 +1,1 @@
-
-**Galaxy** is an **open-source** platform for **[FAIR](https://www.go-fair.org/fair-principles/) data analysis** that enables users to: 
-
-- use **tools** from various domains (that can be plugged into **workflows**) through its graphical web interface.
-- run code in **interactive environments** (RStudio, Jupyter...) along with other tools or workflows.
-- **manage data** by sharing and publishing results, workflows, and visualizations.
-- **ensure reproducibility** by capturing the necessary information to repeat and understand data analyses.
-
-The **Galaxy Community** is actively involved in helping the ecosystem improve and sharing scientific discoveries.
+<EuIntro />

--- a/content/eu/common/about-usegalaxy-eu.md
+++ b/content/eu/common/about-usegalaxy-eu.md
@@ -7,7 +7,7 @@ subtitle: The homepage of the European Galaxy community
   <div class="grid gap-6 lg:grid-cols-[1fr_18rem] lg:items-start">
     <div>
       <h2 id="european-galaxy-server" class="text-2xl font-bold text-galaxy-dark">The European Galaxy server</h2>
-      <p class="mt-3 max-w-3xl text-chicago-700">
+      <p class="mt-3 text-chicago-700">
         The European Galaxy server <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy.eu/">UseGalaxy.eu</a> is maintained primarily by the Freiburg Galaxy Team in collaboration with academic groups across Europe and the US Galaxy team. Please check our <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy-eu.github.io/gdpr/tos.html">Terms of Service</a> and <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy-eu.github.io/gdpr/">data retention policy</a> before using the server. We offer thousands of tools, temporary quota increases, and compute infrastructure for trainers through Training Infrastructure as a Service (TIaaS).
       </p>
     </div>

--- a/content/eu/common/about-usegalaxy-eu.md
+++ b/content/eu/common/about-usegalaxy-eu.md
@@ -3,19 +3,22 @@ title: Galaxy Europe
 subtitle: The homepage of the European Galaxy community
 ---
 
-{/*  Color palette: https://www.color-hex.com/color-palette/9983  */}
-{/*  "The European Galaxy server" info box  */}
-
-<div class="card border-secondary bg-secondary" style="width: 100%;">
-  <div class="card-body">
-    <h2 class="card-title text-dark">The European Galaxy server</h2>
-    <p class="card-text">The European Galaxy server <a href="https://usegalaxy.eu/">UseGalaxy.eu</a> is maintained primarily by the Freiburg Galaxy Team in collaboration with other academic groups across Europe and with the US Galaxy team. Please check our <a href="https://usegalaxy-eu.github.io/gdpr/tos.html">Terms of Service</a> and <a href="">data retention policy</a> before using the server. We offer thousands of tools, increased quota on temporary basis, and compute infrastructure for trainers through Training Infrastructure as a Service (TIaaS).</p>
-    <div class="text-center">
-        <a href="https://usegalaxy-eu.github.io/tools" class="btn btn-light btn-outline-dark mx-3">Browse installed tools</a>
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9w2MOS6KOlu9XdhRSDqWnCDkzoVBqHJ3zH_My4p8D8ZgkIQ/viewform" class="btn btn-light btn-outline-dark mx-3">Request temporary increase of quota</a>
-        <a href="https://usegalaxy-eu.github.io/tiaas" class="btn btn-light btn-outline-dark mx-3">Request TIaaS</a>
-        <a href="https://status.galaxyproject.org/" class="btn btn-light btn-outline-dark mx-3">Check the status of the server</a>
-        <a href="https://stats.galaxyproject.eu/" class="btn btn-light btn-outline-dark mx-3">See the statistics</a>
-      </div>
+<section class="rounded-lg border border-galaxy-primary/10 bg-white p-6 shadow-sm sm:p-8" aria-labelledby="european-galaxy-server">
+  <div class="grid gap-6 lg:grid-cols-[1fr_18rem] lg:items-start">
+    <div>
+      <h2 id="european-galaxy-server" class="text-2xl font-bold text-galaxy-dark">The European Galaxy server</h2>
+      <p class="mt-3 max-w-3xl text-chicago-700">
+        The European Galaxy server <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy.eu/">UseGalaxy.eu</a> is maintained primarily by the Freiburg Galaxy Team in collaboration with academic groups across Europe and the US Galaxy team. Please check our <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy-eu.github.io/gdpr/tos.html">Terms of Service</a> and <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy-eu.github.io/gdpr/">data retention policy</a> before using the server. We offer thousands of tools, temporary quota increases, and compute infrastructure for trainers through Training Infrastructure as a Service (TIaaS).
+      </p>
+    </div>
+  <a href="https://usegalaxy.eu/" class="inline-flex min-h-12 items-center justify-center rounded-lg bg-galaxy-gold px-5 py-3 text-center font-semibold text-galaxy-dark transition-colors hover:bg-galaxy-gold-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Open UseGalaxy.eu</a>
   </div>
-</div>
+
+  <div class="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    <a href="https://usegalaxy-eu.github.io/tools" class="rounded-lg border border-galaxy-primary/15 bg-bay-of-many-50 px-4 py-3 text-sm font-semibold text-galaxy-primary transition-colors hover:border-galaxy-primary hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Browse installed tools</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9w2MOS6KOlu9XdhRSDqWnCDkzoVBqHJ3zH_My4p8D8ZgkIQ/viewform" class="rounded-lg border border-galaxy-primary/15 bg-bay-of-many-50 px-4 py-3 text-sm font-semibold text-galaxy-primary transition-colors hover:border-galaxy-primary hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Request quota increase</a>
+    <a href="https://usegalaxy-eu.github.io/tiaas" class="rounded-lg border border-galaxy-primary/15 bg-bay-of-many-50 px-4 py-3 text-sm font-semibold text-galaxy-primary transition-colors hover:border-galaxy-primary hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Request TIaaS</a>
+    <a href="https://status.galaxyproject.org/" class="rounded-lg border border-galaxy-primary/15 bg-bay-of-many-50 px-4 py-3 text-sm font-semibold text-galaxy-primary transition-colors hover:border-galaxy-primary hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Server status</a>
+    <a href="https://stats.galaxyproject.eu/" class="rounded-lg border border-galaxy-primary/15 bg-bay-of-many-50 px-4 py-3 text-sm font-semibold text-galaxy-primary transition-colors hover:border-galaxy-primary hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary sm:col-span-2 xl:col-span-4">See usage statistics</a>
+  </div>
+</section>

--- a/content/eu/jumbotron.md
+++ b/content/eu/jumbotron.md
@@ -1,6 +1,0 @@
-{/*  Color palette: https://www.color-hex.com/color-palette/9983  */}
-
-{/* 
-[![GBCC2025](https://gbcc2025.bioconductor.org/img/gbcc_logo_transparent.png){width=430}](/events/2025-06-23-gbc-c2025/)
-<p style="text-align: center">Registration is now open for <a href="http://gbcc2025.org/">GBCC2025</a></p>
- */}

--- a/content/eu/main2.md
+++ b/content/eu/main2.md
@@ -3,54 +3,46 @@ title: Galaxy Europe
 subtitle: The homepage of the European Galaxy community
 ---
 
-{/*  Color palette: https://www.color-hex.com/color-palette/9983  */}
-{/*  Projects/Communities/Citation/Team cards  */}
-
-<div class="card-deck">
-  <div class="card border-secondary bg-light mb-1 mx-1" style="width: 18rem">
-    <div class="card-body">
-      <h2 class="card-title text-dark">Projects</h2>
-      <p class="card-text">The European Galaxy community participates in several projects at the European, national and regional levels.</p>
-      <div class="text-center">
-          <img src="/images/undraw-illustrations/projects.svg" alt="projects" height="100" />
-          <br /><br />
-          <a href="https://usegalaxy-eu.github.io/freiburg/projects" class="btn btn-primary">See all the projects</a>
-      </div>
-    </div>
+<section aria-labelledby="galaxy-europe-sections">
+  <h2 id="galaxy-europe-sections" class="sr-only">Galaxy Europe sections</h2>
+  <div class="grid gap-2 md:gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <article class="flex min-h-full flex-col rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm">
+      <h3 class="text-xl font-bold text-galaxy-dark">Projects</h3>
+      <p class="mt-3 text-chicago-700">
+        The European Galaxy community participates in projects at European, national, and regional levels.
+      </p>
+      <img src="/images/undraw-illustrations/projects.svg" alt="" class="mx-auto my-6 h-36 w-full max-w-52 object-contain" loading="lazy" />
+      <a href="https://usegalaxy-eu.github.io/freiburg/projects" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">See all projects</a>
+    </article>
+    <article class="flex min-h-full flex-col rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm">
+      <h3 class="text-xl font-bold text-galaxy-dark">Communities</h3>
+      <p class="mt-3 text-chicago-700">
+        Customized Galaxy front pages support scientific and local communities across Europe.
+      </p>
+      <img src="/images/undraw-illustrations/communities.svg" alt="" class="mx-auto my-6 h-36 w-full max-w-52 object-contain" loading="lazy" />
+      <a href="/eu/subdomains/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">
+        Browse subdomains
+      </a>
+    </article>
+    <article class="flex min-h-full flex-col rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm">
+      <h3 class="text-xl font-bold text-galaxy-dark">Citation</h3>
+      <p class="mt-3 text-chicago-700">
+        Used the European Galaxy server for data analysis? Cite the service in your publication.
+      </p>
+      <img src="/images/undraw-illustrations/citations.svg" alt="" class="mx-auto my-6 h-36 w-full max-w-52 object-contain" loading="lazy" />
+      <a href="/eu/citations/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">
+        Learn how to cite
+      </a>
+    </article>
+    <article class="flex min-h-full flex-col rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm">
+      <h3 class="text-xl font-bold text-galaxy-dark">Team</h3>
+      <p class="mt-3 text-chicago-700">
+        The European Galaxy team is distributed across countries, institutes, and community sites.
+      </p>
+      <img src="/images/undraw-illustrations/team.svg" alt="" class="mx-auto my-6 h-36 w-full max-w-52 object-contain" loading="lazy" />
+      <a href="/eu/people/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">
+        Meet the team
+      </a>
+    </article>
   </div>
-  <div class="card border-secondary bg-light mb-1 mx-1" style="width: 18rem">
-    <div class="card-body">
-      <h2 class="card-title text-dark">Communities</h2>
-      <p class="card-text">To address the needs of scientific & local communities, we offer customized Galaxy frontpages.</p>
-      <div class="text-center">
-        <img src="/images/undraw-illustrations/communities.svg" alt="communities" height="100" />
-        <br /><br /><br />
-        <a href="/eu/subdomains/" class="btn btn-primary">Check all the subdomains</a>        
-      </div>
-    </div>
-  </div>
-  <div class="card border-secondary bg-light mb-1 mx-1" style="width: 18rem">
-    <div class="card-body">
-      <h2 class="card-title text-dark">Citation</h2>
-      <p class="card-text">Have you used the European Galaxy server for your data analysis?</p>
-      <br /><br />
-      <div class="text-center">
-        <img src="/images/undraw-illustrations/citations.svg" alt="projects" height="100" />
-        <br /><br />
-        <a href="https://usegalaxy-eu.github.io/citations" class="btn btn-primary">Learn how to cite the server</a>
-      </div>
-    </div>
-  </div>
-  <div class="card border-secondary bg-light mb-1 ml-1 mr-3" style="width: 18rem">
-    <div class="card-body">
-      <h2 class="card-title text-dark">Team</h2>
-      <p class="card-text">The European Galaxy team is distributed across different countries in Europe.</p>
-      <br /><br />
-      <div class="text-center">
-        <img src="/images/undraw-illustrations/team.svg" alt="team" height="100" />
-        <br /><br />
-        <a href="https://usegalaxy-eu.github.io/people" class="btn btn-primary">Meet the team</a>
-      </div>
-    </div>
-  </div>
-</div>
+</section>

--- a/content/eu/site-footer.md
+++ b/content/eu/site-footer.md
@@ -1,12 +1,1 @@
-<div class="text-center" style="font-family: arial, helvetica, sans-serif">
-
-UseGalaxy.eu is maintained largely by the [Freiburg Galaxy Team](https://usegalaxy-eu.github.io/freiburg/) but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project. For **acknowledgement**, please refer to the [About](https://usegalaxy-eu.github.io/about) section.
-All content on this site is available under [CC0-1.0](https://creativecommons.org/share-your-work/public-domain/cc0/) unless otherwise specified.
-
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:inline-block;vertical-align:middle;color: #777"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg> [contact@usegalaxy.eu](mailto:contact@usegalaxy.eu) &nbsp;
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:inline-block;vertical-align:middle;color: #777"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg> [usegalaxy-eu](https://github.com/usegalaxy-eu) &nbsp;
-[<b aria-hidden="true" style="font-size: 0.9em; color: #777">[m]</b>]() [usegalaxy.eu space](https://matrix.to/#/#usegalaxy.eu:matrix.org) &nbsp;
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:inline-block;vertical-align:middle;color: #777"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg> <a href="https://xn--baw-joa.social/@galaxyfreiburg" target="_blank" rel="me noopener noreferrer"><span style="font-size: 0.9em">@</span>galaxyfreiburg</a> &nbsp;
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:inline-block;vertical-align:middle;color: #777"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg> [usegalaxy.eu feed](/eu/feed.atom)
-
-</div>
+{/* Rendered by the EuSiteFooter Astro component on the Galaxy Europe homepage. */}


### PR DESCRIPTION
## Summary

- refreshes Galaxy Europe homepage sections and related copy
- adds contextual subsite page headers across Europe index, news, events, people, citations, and archive pages
- introduces reusable `EuIntro` and `EuSiteFooter` MDX components for Europe-specific content blocks
- adjusts responsive navigation, sidebar, list, and overview spacing for the updated Europe UI

## Screenshots

| Area | Before | After |
| --- | --- | --- |
| Europe homepage | <img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/b3948701-7dc1-4c7d-9c08-30a3256d699c" /> | <img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/f21cd2ac-f1a9-4d86-8b50-360f7f7728fa" /> |
| Europe homepage | <img width="1920" height="2455" alt="before-galaxyproject-org-eu" src="https://github.com/user-attachments/assets/82ffffe4-6e76-41e5-83e4-63cb2e4b3d85" /> | <img width="1920" height="2974" alt="after-galaxyproject-org-eu" src="https://github.com/user-attachments/assets/ef14145b-1340-4854-9e2b-e2b49c700a34" /> |
| Europe News subsite header | <img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/c96fca85-7c72-47c4-8f48-afb74934ecef" /> | <img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/1bc32509-535f-41cc-be60-cfa5b8de7bcb" /> |
| Europe Events subsite header | <img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/aa4ce426-97ef-4716-8983-8388137b992c" /> | <img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/fd36456f-fc5e-4e3a-af18-c79c31bf82de" /> |