### PR TITLE
Fix EU bare iframe layout

### DIFF
--- a/astro/src/layouts/BareArticleLayout.astro
+++ b/astro/src/layouts/BareArticleLayout.astro
@@ -149,6 +149,19 @@ const { title, description } = Astro.props;
     }
   }
 
+  .prose-galaxy [data-name='/eu/main1'] .usegalaxy-launch-link {
+    display: none !important;
+  }
+
+  .prose-galaxy [data-name='/eu/main1'] section > .mt-6 a {
+    text-decoration: none;
+
+    &:hover {
+      color: var(--color-galaxy-primary);
+      text-decoration: none;
+    }
+  }
+
   [data-name='/eu/main2'] {
     margin: 3rem 0;
 
@@ -195,13 +208,6 @@ const { title, description } = Astro.props;
       gap: 0;
     }
 
-    img {
-      margin: 0 auto;
-      display: block;
-      height: 100px;
-      width: auto;
-    }
-
     .btn {
       margin-top: 0.5rem;
       font-size: 1rem;
@@ -209,6 +215,34 @@ const { title, description } = Astro.props;
 
       &:hover {
         text-decoration: underline;
+      }
+    }
+
+    article h3 {
+      margin: 0;
+    }
+
+    article p {
+      margin: 0.75rem 0 0;
+      line-height: inherit;
+    }
+
+    article img {
+      display: block;
+      width: 100%;
+      max-width: 13rem;
+      height: 9rem;
+      margin: 1.5rem auto;
+      border-radius: 0;
+      object-fit: contain;
+    }
+
+    article a {
+      text-decoration: none;
+
+      &:hover {
+        color: #fff;
+        text-decoration: none;
       }
     }
   }
@@ -356,17 +390,31 @@ const { title, description } = Astro.props;
   .prose-galaxy {
     iframe[title='Recent Galaxy France news'],
     iframe[title='Recent Galaxy Europe news'] {
-      margin-right: 16px;
-      float: left;
+      display: inline-block;
+      width: calc(50% - 20px) !important;
+      margin: 0 16px 3rem 0;
+      vertical-align: top;
     }
 
     iframe[title*='Recent Galaxy France events'],
     iframe[title*='Recent Galaxy Europe events'] {
-      margin-bottom: 3rem;
       width: calc(50% - 20px) !important;
       display: inline-block;
       vertical-align: top;
-      float: right;
+      margin: 0 0 3rem;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .prose-galaxy {
+      iframe[title='Recent Galaxy France news'],
+      iframe[title='Recent Galaxy Europe news'],
+      iframe[title*='Recent Galaxy France events'],
+      iframe[title*='Recent Galaxy Europe events'] {
+        display: block;
+        width: 100% !important;
+        margin: 0 0 1rem;
+      }
     }
   }
 

--- a/astro/src/utils/iframe.ts
+++ b/astro/src/utils/iframe.ts
@@ -28,7 +28,7 @@ function resizeIFrame(iframe: HTMLIFrameElement): void {
 
 function addResizeListeners(root: Document | EventTarget): void {
   const doc = root instanceof Document ? root : document;
-  for (const iframe of doc.querySelectorAll<HTMLIFrameElement>('iframe.resize-y')) {
+  for (const iframe of doc.querySelectorAll<HTMLIFrameElement>('iframe.js-resize-iframe')) {
     resizeIFrame(iframe);
     iframe.addEventListener('load', () => resizeIFrame(iframe));
     try {
@@ -40,7 +40,7 @@ function addResizeListeners(root: Document | EventTarget): void {
 }
 
 /**
- * Set up automatic resizing for iframes with class="resize-y".
+ * Set up automatic resizing for iframes with class="js-resize-iframe".
  * Call this from the parent page that contains the iframes (e.g. BareArticleLayout).
  */
 export function setupIframeResize(): void {

--- a/astro/tests/bare-pages.spec.ts
+++ b/astro/tests/bare-pages.spec.ts
@@ -199,9 +199,65 @@ test.describe('Bare Pages', () => {
       await expect(dataPolicy).toBeVisible();
 
       // Iframes for latest news/events feeds should be present
-      const iframes = page.locator('iframe.resize-y');
+      const iframes = page.locator('iframe.js-resize-iframe');
       const iframeCount = await iframes.count();
       expect(iframeCount).toBe(2);
+    });
+
+    test('/bare/eu/usegalaxy/main/ does not expose native iframe resize handles', async ({ page }) => {
+      await page.goto('/bare/eu/usegalaxy/main/');
+
+      const iframes = page.locator('iframe.js-resize-iframe');
+      await expect(iframes).toHaveCount(2);
+      await expect(iframes.first()).toHaveCSS('resize', 'none');
+      await expect(iframes.nth(1)).toHaveCSS('resize', 'none');
+    });
+
+    test('/bare/eu/usegalaxy/main/ keeps lead content below latest feeds', async ({ page }) => {
+      await page.goto('/bare/eu/usegalaxy/main/');
+
+      const latestFeeds = page.locator('iframe.js-resize-iframe');
+      await expect(latestFeeds).toHaveCount(2);
+
+      const lastFeedBox = await latestFeeds.nth(1).boundingBox();
+      const leadBox = await page.locator('[data-name="/eu/main1"]').boundingBox();
+
+      expect(lastFeedBox).not.toBeNull();
+      expect(leadBox).not.toBeNull();
+      expect(leadBox!.y).toBeGreaterThanOrEqual(lastFeedBox!.y + lastFeedBox!.height - 1);
+    });
+
+    test('/bare/eu/usegalaxy/main/ hides UseGalaxy.eu launch button', async ({ page }) => {
+      await page.goto('/bare/eu/usegalaxy/main/');
+
+      await expect(page.getByRole('link', { name: 'Open UseGalaxy.eu' })).toBeHidden();
+    });
+
+    test('/bare/eu/usegalaxy/main/ keeps section buttons compact', async ({ page }) => {
+      await page.goto('/bare/eu/usegalaxy/main/');
+
+      for (const label of ['See all projects', 'Browse subdomains', 'Learn how to cite', 'Meet the team']) {
+        const button = page.getByRole('link', { name: label });
+        await expect(button).toBeVisible();
+        await expect(button.locator('p')).toHaveCount(0);
+
+        const box = await button.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.height).toBeLessThanOrEqual(52);
+      }
+    });
+
+    test('/bare/eu/usegalaxy/main/ keeps space between section images and buttons', async ({ page }) => {
+      await page.goto('/bare/eu/usegalaxy/main/');
+
+      for (const card of await page.locator('[data-name="/eu/main2"] article').all()) {
+        const imageBox = await card.locator('img').boundingBox();
+        const buttonBox = await card.getByRole('link').boundingBox();
+
+        expect(imageBox).not.toBeNull();
+        expect(buttonBox).not.toBeNull();
+        expect(buttonBox!.y - (imageBox!.y + imageBox!.height)).toBeGreaterThanOrEqual(12);
+      }
     });
 
     test('/bare/eu/usegalaxy/main/ has no bare layout chrome', async ({ page }) => {

--- a/content/bare/eu/usegalaxy/main/index.md
+++ b/content/bare/eu/usegalaxy/main/index.md
@@ -12,11 +12,11 @@ components: true
 "Anyone, anywhere in the world should have free, unhindered access to not just my research, but to the research of every great and enquiring mind across the spectrum of human understanding." – Prof. Stephen Hawking
 
 <iframe title="Recent Galaxy Europe news" height="450"
- class="resize-y" src="/bare/eu/latest/news/" scrolling="no"
+ class="js-resize-iframe" src="/bare/eu/latest/news/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 <iframe title="Recent Galaxy Europe events" height="450"
- class="resize-y" src="/bare/eu/latest/events/" scrolling="no"
+ class="js-resize-iframe" src="/bare/eu/latest/events/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 

--- a/content/bare/eu/usegalaxy/metabolomics/index.md
+++ b/content/bare/eu/usegalaxy/metabolomics/index.md
@@ -96,11 +96,11 @@ Other metabolomics specialized Galaxy servers:
 {/* TODO: carousel content */}
 
 <iframe title="Recent Galaxy Europe news"
- class="resize-y" src="/bare/eu/latest/news/" scrolling="no"
+ class="js-resize-iframe" src="/bare/eu/latest/news/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 <iframe title="Recent Galaxy Europe events"
- class="resize-y" src="/bare/eu/latest/events/" scrolling="no"
+ class="js-resize-iframe" src="/bare/eu/latest/events/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 
@@ -126,4 +126,3 @@ Other metabolomics specialized Galaxy servers:
 <footer>
 <slot name="/eu/site-footer" />
 </footer>
-

--- a/content/bare/eu/usegalaxy/proteomics/index.md
+++ b/content/bare/eu/usegalaxy/proteomics/index.md
@@ -98,11 +98,11 @@ MetaQuantome | Quantitative analysis of the function and taxonomy of microbiomes
 {/* TODO: carousel content */}
 
 <iframe title="Recent Galaxy Europe news"
- class="resize-y" src="/bare/eu/latest/news/" scrolling="no"
+ class="js-resize-iframe" src="/bare/eu/latest/news/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 <iframe title="Recent Galaxy Europe events"
- class="resize-y" src="/bare/eu/latest/events/" scrolling="no"
+ class="js-resize-iframe" src="/bare/eu/latest/events/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 

--- a/content/bare/fr/usegalaxy/main/index.md
+++ b/content/bare/fr/usegalaxy/main/index.md
@@ -13,11 +13,11 @@ components: true
 <br/>
 
 <iframe title="Recent Galaxy France news" height="450"
- class="resize-y" src="/bare/fr/latest/news/" scrolling="no"
+ class="js-resize-iframe" src="/bare/fr/latest/news/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 <iframe title="Recent Galaxy France events" height="450"
- class="resize-y" src="/bare/fr/latest/events/" scrolling="no"
+ class="js-resize-iframe" src="/bare/fr/latest/events/" scrolling="no"
  style="width: 50%; border: none; vertical-align: top">
 </iframe>
 

--- a/content/eu/common/about-usegalaxy-eu.md
+++ b/content/eu/common/about-usegalaxy-eu.md
@@ -11,7 +11,7 @@ subtitle: The homepage of the European Galaxy community
         The European Galaxy server <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy.eu/">UseGalaxy.eu</a> is maintained primarily by the Freiburg Galaxy Team in collaboration with academic groups across Europe and the US Galaxy team. Please check our <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy-eu.github.io/gdpr/tos.html">Terms of Service</a> and <a class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold" href="https://usegalaxy-eu.github.io/gdpr/">data retention policy</a> before using the server. We offer thousands of tools, temporary quota increases, and compute infrastructure for trainers through Training Infrastructure as a Service (TIaaS).
       </p>
     </div>
-  <a href="https://usegalaxy.eu/" class="inline-flex min-h-12 items-center justify-center rounded-lg bg-galaxy-gold px-5 py-3 text-center font-semibold text-galaxy-dark transition-colors hover:bg-galaxy-gold-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Open UseGalaxy.eu</a>
+  <a href="https://usegalaxy.eu/" class="usegalaxy-launch-link inline-flex min-h-12 items-center justify-center rounded-lg bg-galaxy-gold px-5 py-3 text-center font-semibold text-galaxy-dark transition-colors hover:bg-galaxy-gold-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Open UseGalaxy.eu</a>
   </div>
 
   <div class="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">

--- a/content/eu/main2.md
+++ b/content/eu/main2.md
@@ -20,9 +20,7 @@ subtitle: The homepage of the European Galaxy community
         Customized Galaxy front pages support scientific and local communities across Europe.
       </p>
       <img src="/images/undraw-illustrations/communities.svg" alt="" class="mx-auto my-6 h-36 w-full max-w-52 object-contain" loading="lazy" />
-      <a href="/eu/subdomains/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">
-        Browse subdomains
-      </a>
+      <a href="/eu/subdomains/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Browse subdomains</a>
     </article>
     <article class="flex min-h-full flex-col rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm">
       <h3 class="text-xl font-bold text-galaxy-dark">Citation</h3>
@@ -30,9 +28,7 @@ subtitle: The homepage of the European Galaxy community
         Used the European Galaxy server for data analysis? Cite the service in your publication.
       </p>
       <img src="/images/undraw-illustrations/citations.svg" alt="" class="mx-auto my-6 h-36 w-full max-w-52 object-contain" loading="lazy" />
-      <a href="/eu/citations/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">
-        Learn how to cite
-      </a>
+      <a href="/eu/citations/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Learn how to cite</a>
     </article>
     <article class="flex min-h-full flex-col rounded-lg border border-galaxy-primary/10 bg-white p-4 shadow-sm">
       <h3 class="text-xl font-bold text-galaxy-dark">Team</h3>
@@ -40,9 +36,7 @@ subtitle: The homepage of the European Galaxy community
         The European Galaxy team is distributed across countries, institutes, and community sites.
       </p>
       <img src="/images/undraw-illustrations/team.svg" alt="" class="mx-auto my-6 h-36 w-full max-w-52 object-contain" loading="lazy" />
-      <a href="/eu/people/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">
-        Meet the team
-      </a>
+      <a href="/eu/people/" class="mt-auto inline-flex min-h-11 items-center justify-center rounded-lg bg-galaxy-primary px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-bay-of-many-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-galaxy-primary">Meet the team</a>
     </article>
   </div>
 </section>

--- a/content/news/2026/2026-03-20-ecology-ai-imaging/index.md
+++ b/content/news/2026/2026-03-20-ecology-ai-imaging/index.md
@@ -9,7 +9,7 @@ contributions:
   authorship:
     - yvanlebras
     - TuturBaba
-    - nadinelebris
+    - NadineLeBris
   funding:
     - moorev         # grant
     - fondfrance     # grant


### PR DESCRIPTION
## Summary
- Fix EU bare iframe news/events layout so following content no longer wraps into the iframe row
- Hide the redundant “Open UseGalaxy.eu” CTA in the embedded bare page
- Match EU section card styling in the bare page with the normal `/eu/` page
- Rename iframe resize hook from `resize-y` to `js-resize-iframe` to avoid Tailwind’s native vertical resize handle

|Before|After|
|---|---|
| <img width="1920" height="2942" alt="galaxyproject-org-bare-eu-usegalaxy-main-before" src="https://github.com/user-attachments/assets/1c4a2d2a-78bc-4499-84bb-bc24dfa5d100" /> | <img width="1920" height="2512" alt="galaxyproject-org-bare-eu-usegalaxy-main-after" src="https://github.com/user-attachments/assets/1778909e-0006-47de-9774-6c2348997017" /> |


## Testing
- `pnpm test astro/tests/bare-pages.spec.ts`
