### PR TITLE
standardize subsite filtering across listings, feeds, and bare pages

### DIFF
--- a/astro/src/components/events/EventsList.vue
+++ b/astro/src/components/events/EventsList.vue
@@ -4,6 +4,7 @@ import { useStore } from '@nanostores/vue';
 import { currentSubsite, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { renderMarkdownInline } from '@/utils/markdown';
 import { formatDateRange, getUTCYear } from '@/utils/dateUtils';
+import { contentMatchesSubsite, normalizeSubsites } from '@/utils/subsites';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface EventData {
@@ -74,13 +75,6 @@ function getYear(event: EventData): number | null {
   return isNaN(date.getTime()) ? null : getUTCYear(date);
 }
 
-// Helper to normalize subsites to array
-function getSubsites(event: EventData): string[] {
-  if (!event.subsites) return ['all'];
-  if (Array.isArray(event.subsites)) return event.subsites;
-  return [event.subsites];
-}
-
 // Filter events based on current subsite
 const filteredEvents = computed(() => {
   const subsite = effectiveSubsite.value;
@@ -90,14 +84,8 @@ const filteredEvents = computed(() => {
     return props.events;
   }
 
-  // Filter by subsite - include events tagged with this subsite or 'all'
   return props.events.filter((event) => {
-    const eventSubsites = getSubsites(event);
-    return (
-      eventSubsites.includes('all') ||
-      eventSubsites.includes(subsite) ||
-      eventSubsites.some((s) => s.toLowerCase() === subsite.toLowerCase())
-    );
+    return contentMatchesSubsite(normalizeSubsites(event.subsites), subsite);
   });
 });
 

--- a/astro/src/components/events/EventsList.vue
+++ b/astro/src/components/events/EventsList.vue
@@ -4,7 +4,7 @@ import { useStore } from '@nanostores/vue';
 import { currentSubsite, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { renderMarkdownInline } from '@/utils/markdown';
 import { formatDateRange, getUTCYear } from '@/utils/dateUtils';
-import { contentMatchesSubsite, normalizeSubsites } from '@/utils/subsites';
+import { contentMatchesSubsite } from '@/utils/subsites';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface EventData {
@@ -85,7 +85,7 @@ const filteredEvents = computed(() => {
   }
 
   return props.events.filter((event) => {
-    return contentMatchesSubsite(normalizeSubsites(event.subsites), subsite);
+    return contentMatchesSubsite(event.subsites, subsite);
   });
 });
 

--- a/astro/src/components/news/NewsList.vue
+++ b/astro/src/components/news/NewsList.vue
@@ -4,6 +4,7 @@ import { useStore } from '@nanostores/vue';
 import { currentSubsite, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { renderMarkdownInline } from '@/utils/markdown';
 import { formatDate, getUTCYear } from '@/utils/dateUtils';
+import { contentMatchesSubsite, normalizeSubsites } from '@/utils/subsites';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface NewsArticle {
@@ -50,13 +51,6 @@ onMounted(() => {
   hasMounted.value = true;
 });
 
-// Helper to normalize subsites to array
-function getSubsites(article: NewsArticle): string[] {
-  if (!article.subsites) return ['all'];
-  if (Array.isArray(article.subsites)) return article.subsites;
-  return [article.subsites];
-}
-
 // Filter articles based on current subsite
 const filteredBySubsite = computed(() => {
   const subsite = effectiveSubsite.value;
@@ -64,12 +58,7 @@ const filteredBySubsite = computed(() => {
     return props.articles;
   }
   return props.articles.filter((article) => {
-    const articleSubsites = getSubsites(article);
-    return (
-      articleSubsites.includes('all') ||
-      articleSubsites.includes(subsite) ||
-      articleSubsites.some((s) => s.toLowerCase() === subsite.toLowerCase())
-    );
+    return contentMatchesSubsite(normalizeSubsites(article.subsites), subsite);
   });
 });
 

--- a/astro/src/components/news/NewsList.vue
+++ b/astro/src/components/news/NewsList.vue
@@ -4,7 +4,7 @@ import { useStore } from '@nanostores/vue';
 import { currentSubsite, subsites, type SubsiteId } from '@/stores/subsiteStore';
 import { renderMarkdownInline } from '@/utils/markdown';
 import { formatDate, getUTCYear } from '@/utils/dateUtils';
-import { contentMatchesSubsite, normalizeSubsites } from '@/utils/subsites';
+import { contentMatchesSubsite } from '@/utils/subsites';
 import ExternalIcon from '../common/ExternalIcon.vue';
 
 interface NewsArticle {
@@ -58,7 +58,7 @@ const filteredBySubsite = computed(() => {
     return props.articles;
   }
   return props.articles.filter((article) => {
-    return contentMatchesSubsite(normalizeSubsites(article.subsites), subsite);
+    return contentMatchesSubsite(article.subsites, subsite);
   });
 });
 

--- a/astro/src/pages/bare/eu/events.astro
+++ b/astro/src/pages/bare/eu/events.astro
@@ -8,21 +8,14 @@ import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import EventsTable from '../../../components/bare/EventsTable.astro';
 import Insert from '../../../components/Insert.astro';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
 
 const now = new Date();
 const twelveMonthsAgo = new Date(now);
 twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
 
 const allEvents = await getCollection('events', (entry) => {
-  const subsites = entry.data.subsites || [];
-  return (
-    (subsites.includes('eu') ||
-      subsites.includes('all') ||
-      subsites.includes('all-eu') ||
-      subsites.includes('global') ||
-      subsites.length === 0) &&
-    !entry.data.draft
-  );
+  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'eu') && !entry.data.draft;
 });
 
 const upcomingEvents = allEvents

--- a/astro/src/pages/bare/eu/events.astro
+++ b/astro/src/pages/bare/eu/events.astro
@@ -8,14 +8,14 @@ import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import EventsTable from '../../../components/bare/EventsTable.astro';
 import Insert from '../../../components/Insert.astro';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../utils/subsites';
 
 const now = new Date();
 const twelveMonthsAgo = new Date(now);
 twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
 
 const allEvents = await getCollection('events', (entry) => {
-  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'eu') && !entry.data.draft;
+  return contentMatchesSubsite(entry.data.subsites, 'eu') && !entry.data.draft;
 });
 
 const upcomingEvents = allEvents

--- a/astro/src/pages/bare/eu/latest/events.astro
+++ b/astro/src/pages/bare/eu/latest/events.astro
@@ -5,20 +5,12 @@
  * Embedded in Galaxy EU interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
 
 const now = new Date();
 
 const allEvents = await getCollection('events', (entry) => {
-  const subsites = entry.data.subsites || [];
-  // Filter for EU subsite
-  return (
-    (subsites.includes('eu') ||
-      subsites.includes('all') ||
-      subsites.includes('all-eu') ||
-      subsites.includes('global') ||
-      subsites.length === 0) &&
-    !entry.data.draft
-  );
+  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'eu') && !entry.data.draft;
 });
 
 // Get upcoming events

--- a/astro/src/pages/bare/eu/latest/events.astro
+++ b/astro/src/pages/bare/eu/latest/events.astro
@@ -5,12 +5,12 @@
  * Embedded in Galaxy EU interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../../utils/subsites';
 
 const now = new Date();
 
 const allEvents = await getCollection('events', (entry) => {
-  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'eu') && !entry.data.draft;
+  return contentMatchesSubsite(entry.data.subsites, 'eu') && !entry.data.draft;
 });
 
 // Get upcoming events

--- a/astro/src/pages/bare/eu/latest/news.astro
+++ b/astro/src/pages/bare/eu/latest/news.astro
@@ -5,18 +5,12 @@
  * Embedded in Galaxy EU interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    const subsites = article.data.subsites || [];
-    const isEU =
-      subsites.includes('eu') ||
-      subsites.includes('all') ||
-      subsites.includes('all-eu') ||
-      subsites.includes('global') ||
-      subsites.length === 0;
-    return isEU && !article.data.draft;
+    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/bare/eu/latest/news.astro
+++ b/astro/src/pages/bare/eu/latest/news.astro
@@ -5,12 +5,12 @@
  * Embedded in Galaxy EU interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu') && !article.data.draft;
+    return contentMatchesSubsite(article.data.subsites, 'eu') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/bare/eu/news.astro
+++ b/astro/src/pages/bare/eu/news.astro
@@ -8,18 +8,12 @@ import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import NewsTable from '../../../components/bare/NewsTable.astro';
 import Insert from '../../../components/Insert.astro';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    const subsites = article.data.subsites || [];
-    const isEU =
-      subsites.includes('eu') ||
-      subsites.includes('all') ||
-      subsites.includes('all-eu') ||
-      subsites.includes('global') ||
-      subsites.length === 0;
-    return isEU && !article.data.draft;
+    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/bare/eu/news.astro
+++ b/astro/src/pages/bare/eu/news.astro
@@ -8,12 +8,12 @@ import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import NewsTable from '../../../components/bare/NewsTable.astro';
 import Insert from '../../../components/Insert.astro';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu') && !article.data.draft;
+    return contentMatchesSubsite(article.data.subsites, 'eu') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/bare/fr/events.astro
+++ b/astro/src/pages/bare/fr/events.astro
@@ -7,21 +7,14 @@
 import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import EventsTable from '../../../components/bare/EventsTable.astro';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
 
 const now = new Date();
 const twelveMonthsAgo = new Date(now);
 twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
 
 const allEvents = await getCollection('events', (entry) => {
-  const subsites = entry.data.subsites || [];
-  return (
-    (subsites.includes('fr') ||
-      subsites.includes('all') ||
-      subsites.includes('all-fr') ||
-      subsites.includes('global') ||
-      subsites.length === 0) &&
-    !entry.data.draft
-  );
+  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'fr') && !entry.data.draft;
 });
 
 const upcomingEvents = allEvents

--- a/astro/src/pages/bare/fr/events.astro
+++ b/astro/src/pages/bare/fr/events.astro
@@ -7,14 +7,14 @@
 import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import EventsTable from '../../../components/bare/EventsTable.astro';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../utils/subsites';
 
 const now = new Date();
 const twelveMonthsAgo = new Date(now);
 twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
 
 const allEvents = await getCollection('events', (entry) => {
-  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'fr') && !entry.data.draft;
+  return contentMatchesSubsite(entry.data.subsites, 'fr') && !entry.data.draft;
 });
 
 const upcomingEvents = allEvents

--- a/astro/src/pages/bare/fr/latest/events.astro
+++ b/astro/src/pages/bare/fr/latest/events.astro
@@ -5,20 +5,12 @@
  * Embedded in Galaxy FR interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
 
 const now = new Date();
 
 const allEvents = await getCollection('events', (entry) => {
-  const subsites = entry.data.subsites || [];
-  // Filter for FR subsite
-  return (
-    (subsites.includes('fr') ||
-      subsites.includes('all') ||
-      subsites.includes('all-fr') ||
-      subsites.includes('global') ||
-      subsites.length === 0) &&
-    !entry.data.draft
-  );
+  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'fr') && !entry.data.draft;
 });
 
 // Get upcoming events

--- a/astro/src/pages/bare/fr/latest/events.astro
+++ b/astro/src/pages/bare/fr/latest/events.astro
@@ -5,12 +5,12 @@
  * Embedded in Galaxy FR interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../../utils/subsites';
 
 const now = new Date();
 
 const allEvents = await getCollection('events', (entry) => {
-  return contentMatchesSubsite(normalizeSubsites(entry.data.subsites), 'fr') && !entry.data.draft;
+  return contentMatchesSubsite(entry.data.subsites, 'fr') && !entry.data.draft;
 });
 
 // Get upcoming events

--- a/astro/src/pages/bare/fr/latest/news.astro
+++ b/astro/src/pages/bare/fr/latest/news.astro
@@ -5,18 +5,12 @@
  * Embedded in Galaxy FR interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    const subsites = article.data.subsites || [];
-    const isFR =
-      subsites.includes('fr') ||
-      subsites.includes('all') ||
-      subsites.includes('all-fr') ||
-      subsites.includes('global') ||
-      subsites.length === 0;
-    return isFR && !article.data.draft;
+    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'fr') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/bare/fr/latest/news.astro
+++ b/astro/src/pages/bare/fr/latest/news.astro
@@ -5,12 +5,12 @@
  * Embedded in Galaxy FR interface - high visibility feed
  */
 import { getCollection } from 'astro:content';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'fr') && !article.data.draft;
+    return contentMatchesSubsite(article.data.subsites, 'fr') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/bare/fr/news.astro
+++ b/astro/src/pages/bare/fr/news.astro
@@ -7,18 +7,12 @@
 import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import NewsTable from '../../../components/bare/NewsTable.astro';
+import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    const subsites = article.data.subsites || [];
-    const isFR =
-      subsites.includes('fr') ||
-      subsites.includes('all') ||
-      subsites.includes('all-fr') ||
-      subsites.includes('global') ||
-      subsites.length === 0;
-    return isFR && !article.data.draft;
+    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'fr') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/bare/fr/news.astro
+++ b/astro/src/pages/bare/fr/news.astro
@@ -7,12 +7,12 @@
 import { getCollection } from 'astro:content';
 import BareArticleLayout from '../../../layouts/BareArticleLayout.astro';
 import NewsTable from '../../../components/bare/NewsTable.astro';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../utils/subsites';
 
 const allNews = await getCollection('news');
 const newsArticles = allNews
   .filter((article) => {
-    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'fr') && !article.data.draft;
+    return contentMatchesSubsite(article.data.subsites, 'fr') && !article.data.draft;
   })
   .sort((a, b) => {
     const dateA = a.data.date ? new Date(a.data.date) : new Date(0);

--- a/astro/src/pages/eu/events/calendar.ics.ts
+++ b/astro/src/pages/eu/events/calendar.ics.ts
@@ -1,5 +1,6 @@
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
+import { contentMatchesSubsite } from '../../../utils/subsites';
 
 // Format date for iCalendar (YYYYMMDDTHHMMSSZ)
 function formatICSDate(date: Date): string {
@@ -40,9 +41,8 @@ export async function GET(context: APIContext) {
   // Get events from the past year and all future events, filtered to subsite 'eu'
   const relevantEvents = events
     .filter((event) => {
-      const subsites = event.data.subsites;
-      const subsiteList = Array.isArray(subsites) ? subsites : subsites ? [subsites] : [];
-      if (!subsiteList.includes('eu')) return false;
+      if (event.data.draft) return false;
+      if (!contentMatchesSubsite(event.data.subsites, 'eu')) return false;
 
       const eventDate = event.data.date instanceof Date ? event.data.date : new Date(event.data.date || '');
       return eventDate >= oneYearAgo;

--- a/astro/src/pages/eu/events/feed.atom.ts
+++ b/astro/src/pages/eu/events/feed.atom.ts
@@ -1,19 +1,5 @@
 import { getCollection } from 'astro:content';
-
-function normalizeSubsites(value: unknown): string[] {
-  if (!value) return [];
-  return Array.isArray(value) ? value.map((item) => String(item)) : [String(value)];
-}
-
-function isEuSubsite(subsites: string[]): boolean {
-  return (
-    subsites.includes('eu') ||
-    subsites.includes('all') ||
-    subsites.includes('all-eu') ||
-    subsites.includes('global') ||
-    subsites.length === 0
-  );
-}
+import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
 
 function escapeXML(text: string): string {
   return text
@@ -43,8 +29,7 @@ export async function GET() {
   const euEvents = events
     .filter((event) => {
       if (event.data.draft) return false;
-      const subsites = normalizeSubsites(event.data.subsites);
-      return isEuSubsite(subsites);
+      return contentMatchesSubsite(normalizeSubsites(event.data.subsites), 'eu');
     })
     .sort((a, b) => {
       const dateA = a.data.date instanceof Date ? a.data.date : new Date(a.data.date || 0);

--- a/astro/src/pages/eu/events/feed.atom.ts
+++ b/astro/src/pages/eu/events/feed.atom.ts
@@ -1,5 +1,5 @@
 import { getCollection } from 'astro:content';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../utils/subsites';
 
 function escapeXML(text: string): string {
   return text
@@ -29,7 +29,7 @@ export async function GET() {
   const euEvents = events
     .filter((event) => {
       if (event.data.draft) return false;
-      return contentMatchesSubsite(normalizeSubsites(event.data.subsites), 'eu');
+      return contentMatchesSubsite(event.data.subsites, 'eu');
     })
     .sort((a, b) => {
       const dateA = a.data.date instanceof Date ? a.data.date : new Date(a.data.date || 0);

--- a/astro/src/pages/eu/feed.atom.ts
+++ b/astro/src/pages/eu/feed.atom.ts
@@ -5,6 +5,7 @@
  */
 import { getCollection } from 'astro:content';
 import { marked } from 'marked';
+import { contentMatchesSubsite, normalizeSubsites } from '../../utils/subsites';
 
 const SITE_URL = 'https://galaxyproject.org';
 const FEED_TITLE = 'Galaxy Europe';
@@ -32,15 +33,7 @@ export async function GET() {
     .filter((article) => {
       // Must have a date
       if (!article.data.date) return false;
-      // Must be for EU subsite
-      const subsites = article.data.subsites
-        ? Array.isArray(article.data.subsites)
-          ? article.data.subsites
-          : [article.data.subsites]
-        : [];
-      return (
-        subsites.includes('eu') || subsites.includes('all') || subsites.includes('global') || subsites.length === 0
-      );
+      return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu');
     })
     .sort((a, b) => {
       const dateA = a.data.date instanceof Date ? a.data.date : new Date(a.data.date || 0);

--- a/astro/src/pages/eu/feed.atom.ts
+++ b/astro/src/pages/eu/feed.atom.ts
@@ -5,7 +5,7 @@
  */
 import { getCollection } from 'astro:content';
 import { marked } from 'marked';
-import { contentMatchesSubsite, normalizeSubsites } from '../../utils/subsites';
+import { contentMatchesSubsite } from '../../utils/subsites';
 
 const SITE_URL = 'https://galaxyproject.org';
 const FEED_TITLE = 'Galaxy Europe';
@@ -33,7 +33,7 @@ export async function GET() {
     .filter((article) => {
       // Must have a date
       if (!article.data.date) return false;
-      return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu');
+      return contentMatchesSubsite(article.data.subsites, 'eu');
     })
     .sort((a, b) => {
       const dateA = a.data.date instanceof Date ? a.data.date : new Date(a.data.date || 0);

--- a/astro/src/pages/eu/news/feed.atom.ts
+++ b/astro/src/pages/eu/news/feed.atom.ts
@@ -1,20 +1,6 @@
 import { getCollection } from 'astro:content';
 import { isPublishedDate } from '../../../utils/dateUtils';
-
-function normalizeSubsites(value: unknown): string[] {
-  if (!value) return [];
-  return Array.isArray(value) ? value.map((item) => String(item)) : [String(value)];
-}
-
-function isEuSubsite(subsites: string[]): boolean {
-  return (
-    subsites.includes('eu') ||
-    subsites.includes('all') ||
-    subsites.includes('all-eu') ||
-    subsites.includes('global') ||
-    subsites.length === 0
-  );
-}
+import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
 
 function escapeXML(text: string): string {
   return text
@@ -40,8 +26,7 @@ export async function GET() {
     .filter((article) => {
       if (article.data.draft) return false;
       if (!isPublishedDate(article.data.date, now)) return false;
-      const subsites = normalizeSubsites(article.data.subsites);
-      return isEuSubsite(subsites);
+      return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu');
     })
     .sort((a, b) => {
       const dateA = a.data.date instanceof Date ? a.data.date : new Date(a.data.date || 0);

--- a/astro/src/pages/eu/news/feed.atom.ts
+++ b/astro/src/pages/eu/news/feed.atom.ts
@@ -1,6 +1,6 @@
 import { getCollection } from 'astro:content';
 import { isPublishedDate } from '../../../utils/dateUtils';
-import { contentMatchesSubsite, normalizeSubsites } from '../../../utils/subsites';
+import { contentMatchesSubsite } from '../../../utils/subsites';
 
 function escapeXML(text: string): string {
   return text
@@ -26,7 +26,7 @@ export async function GET() {
     .filter((article) => {
       if (article.data.draft) return false;
       if (!isPublishedDate(article.data.date, now)) return false;
-      return contentMatchesSubsite(normalizeSubsites(article.data.subsites), 'eu');
+      return contentMatchesSubsite(article.data.subsites, 'eu');
     })
     .sort((a, b) => {
       const dateA = a.data.date instanceof Date ? a.data.date : new Date(a.data.date || 0);

--- a/astro/src/pages/events/feed.json.ts
+++ b/astro/src/pages/events/feed.json.ts
@@ -5,6 +5,7 @@
  */
 import { getCollection } from 'astro:content';
 import { marked } from 'marked';
+import { expandSubsites, normalizeSubsites } from '../../utils/subsites';
 
 const JSONFEED_DAYS_AGO_LIMIT = 30;
 
@@ -25,28 +26,6 @@ function generateShortId(str: string): string {
     hash = hash & hash;
   }
   return Math.abs(hash).toString(16).slice(0, 8);
-}
-
-// Expand "all" subsite to full list of regional subsites
-const ALL_SUBSITES = [
-  'freiburg',
-  'pasteur',
-  'belgium',
-  'ifb',
-  'genouest',
-  'erasmusmc',
-  'elixir-it',
-  'au',
-  'eu',
-  'us',
-  'global',
-];
-
-function expandSubsites(subsites: string[]): string[] {
-  if (subsites.includes('all')) {
-    return ALL_SUBSITES;
-  }
-  return subsites;
 }
 
 function getDaysAgo(date: Date): number {
@@ -84,12 +63,7 @@ export async function GET() {
           }
         }
 
-        // Normalize subsites to array and expand "all"
-        let subsites: string[] = [];
-        if (data.subsites) {
-          subsites = Array.isArray(data.subsites) ? data.subsites : [data.subsites];
-        }
-        subsites = expandSubsites(subsites);
+        const subsites = expandSubsites(normalizeSubsites(data.subsites));
 
         // Get contact info - can be string or array
         let contact = '';

--- a/astro/src/pages/events/feed.json.ts
+++ b/astro/src/pages/events/feed.json.ts
@@ -5,7 +5,7 @@
  */
 import { getCollection } from 'astro:content';
 import { marked } from 'marked';
-import { expandSubsites, normalizeSubsites } from '../../utils/subsites';
+import { expandSubsites } from '../../utils/subsites';
 
 const JSONFEED_DAYS_AGO_LIMIT = 30;
 
@@ -63,7 +63,7 @@ export async function GET() {
           }
         }
 
-        const subsites = expandSubsites(normalizeSubsites(data.subsites));
+        const subsites = expandSubsites(data.subsites);
 
         // Get contact info - can be string or array
         let contact = '';

--- a/astro/src/pages/news/feed.json.ts
+++ b/astro/src/pages/news/feed.json.ts
@@ -6,6 +6,7 @@
 import { getCollection } from 'astro:content';
 import { marked } from 'marked';
 import { extractAuthors } from '../../utils/contributors';
+import { expandSubsites, normalizeSubsites } from '../../utils/subsites';
 
 const JSONFEED_DAYS_AGO_LIMIT = 30;
 
@@ -34,28 +35,6 @@ function generateShortId(str: string): string {
   return Math.abs(hash).toString(16).slice(0, 8);
 }
 
-// Expand "all" subsite to full list of regional subsites
-const ALL_SUBSITES = [
-  'freiburg',
-  'pasteur',
-  'belgium',
-  'ifb',
-  'genouest',
-  'erasmusmc',
-  'elixir-it',
-  'au',
-  'eu',
-  'us',
-  'global',
-];
-
-function expandSubsites(subsites: string[]): string[] {
-  if (subsites.includes('all')) {
-    return ALL_SUBSITES;
-  }
-  return subsites;
-}
-
 export async function GET() {
   const allNews = await getCollection('news');
 
@@ -80,9 +59,7 @@ export async function GET() {
       const daysAgo = getDaysAgo(date);
       const slug = (data.slug || article.id).replace(/\/$/, '');
 
-      // Normalize arrays and expand "all" subsites
-      let subsites = data.subsites ? (Array.isArray(data.subsites) ? data.subsites : [data.subsites]) : [];
-      subsites = expandSubsites(subsites);
+      const subsites = expandSubsites(normalizeSubsites(data.subsites));
 
       const tags = data.tags ? (Array.isArray(data.tags) ? data.tags : [data.tags]) : [];
       const authors = extractAuthors(data as Record<string, unknown>).join(', ');

--- a/astro/src/pages/news/feed.json.ts
+++ b/astro/src/pages/news/feed.json.ts
@@ -6,7 +6,7 @@
 import { getCollection } from 'astro:content';
 import { marked } from 'marked';
 import { extractAuthors } from '../../utils/contributors';
-import { expandSubsites, normalizeSubsites } from '../../utils/subsites';
+import { expandSubsites } from '../../utils/subsites';
 
 const JSONFEED_DAYS_AGO_LIMIT = 30;
 
@@ -59,7 +59,7 @@ export async function GET() {
       const daysAgo = getDaysAgo(date);
       const slug = (data.slug || article.id).replace(/\/$/, '');
 
-      const subsites = expandSubsites(normalizeSubsites(data.subsites));
+      const subsites = expandSubsites(data.subsites);
 
       const tags = data.tags ? (Array.isArray(data.tags) ? data.tags : [data.tags]) : [];
       const authors = extractAuthors(data as Record<string, unknown>).join(', ');

--- a/astro/src/pages/projects/esg/events.astro
+++ b/astro/src/pages/projects/esg/events.astro
@@ -13,6 +13,7 @@ const solo = Astro.url.searchParams.get('solo') === 'true';
 const events = await getCollection('events');
 const now = new Date();
 
+// ESG is a project surface, so it intentionally uses narrow project tags rather than subsite-wide matching.
 const allEsgEvents = events
   .filter((e) => {
     const subsites = e.data.subsites || [];

--- a/astro/src/pages/projects/esg/index.astro
+++ b/astro/src/pages/projects/esg/index.astro
@@ -19,6 +19,7 @@ const externalLinks = datasets.find((d) => d.data.slug === 'projects/esg/externa
 
 // Load ESG news
 const allNews = await getCollection('news');
+// ESG is a project surface, so it intentionally uses narrow project tags rather than subsite-wide matching.
 const esgNews = allNews
   .filter((a) => a.data.subsites?.includes('esg'))
   .sort((a, b) => {
@@ -31,6 +32,7 @@ const esgNews = allNews
 // Load ESG events (upcoming)
 const events = await getCollection('events');
 const now = new Date();
+// EU-tagged events are included here only because they are relevant to this project page.
 const esgEvents = events
   .filter((e) => {
     const subsites = e.data.subsites || [];

--- a/astro/src/pages/projects/esg/news.astro
+++ b/astro/src/pages/projects/esg/news.astro
@@ -11,6 +11,7 @@ const solo = Astro.url.searchParams.get('solo') === 'true';
 
 // Load ESG news
 const allNews = await getCollection('news');
+// ESG is a project surface, so it intentionally uses narrow project tags rather than subsite-wide matching.
 const esgNews = allNews
   .filter((a) => a.data.subsites?.includes('esg'))
   .sort((a, b) => {

--- a/astro/src/utils/content.ts
+++ b/astro/src/utils/content.ts
@@ -5,6 +5,7 @@
 
 import { getCollection, type CollectionEntry } from 'astro:content';
 import { isPublishedDate, formatDate as formatDateUtil, formatDateRange as formatDateRangeUtil } from './dateUtils';
+import { contentMatchesSubsite, normalizeSubsites } from './subsites';
 
 type ArticleEntry = CollectionEntry<'articles'>;
 export type NewsEntry = CollectionEntry<'news'>;
@@ -18,13 +19,12 @@ type InsertEntry = CollectionEntry<'inserts'>;
 export async function getArticles(subsite?: string): Promise<ArticleEntry[]> {
   const articles = await getCollection('articles');
 
-  if (!subsite || subsite === 'global') {
+  if (!subsite) {
     return articles;
   }
 
   return articles.filter((article) => {
-    const subsites = article.data.subsites || [];
-    return subsites.includes(subsite) || subsites.includes('all');
+    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), subsite);
   });
 }
 
@@ -34,13 +34,12 @@ export async function getArticles(subsite?: string): Promise<ArticleEntry[]> {
 export async function getEvents(subsite?: string): Promise<EventEntry[]> {
   const events = await getCollection('events');
 
-  if (!subsite || subsite === 'global') {
+  if (!subsite) {
     return events;
   }
 
   return events.filter((event) => {
-    const subsites = event.data.subsites || [];
-    return subsites.includes(subsite) || subsites.includes('all');
+    return contentMatchesSubsite(normalizeSubsites(event.data.subsites), subsite);
   });
 }
 
@@ -224,13 +223,11 @@ export async function getInsert(slug: string): Promise<InsertEntry | undefined> 
 export async function getNews(subsite?: string): Promise<NewsEntry[]> {
   const news = await getCollection('news');
 
-  const filtered =
-    !subsite || subsite === 'global'
-      ? news
-      : news.filter((article) => {
-          const subsites = article.data.subsites || [];
-          return subsites.includes(subsite) || subsites.includes('all');
-        });
+  const filtered = !subsite
+    ? news
+    : news.filter((article) => {
+        return contentMatchesSubsite(normalizeSubsites(article.data.subsites), subsite);
+      });
 
   return filtered.sort((a, b) => {
     const dateA = new Date(a.data.date || 0);

--- a/astro/src/utils/content.ts
+++ b/astro/src/utils/content.ts
@@ -5,7 +5,7 @@
 
 import { getCollection, type CollectionEntry } from 'astro:content';
 import { isPublishedDate, formatDate as formatDateUtil, formatDateRange as formatDateRangeUtil } from './dateUtils';
-import { contentMatchesSubsite, normalizeSubsites } from './subsites';
+import { contentMatchesSubsite } from './subsites';
 
 type ArticleEntry = CollectionEntry<'articles'>;
 export type NewsEntry = CollectionEntry<'news'>;
@@ -24,7 +24,7 @@ export async function getArticles(subsite?: string): Promise<ArticleEntry[]> {
   }
 
   return articles.filter((article) => {
-    return contentMatchesSubsite(normalizeSubsites(article.data.subsites), subsite);
+    return contentMatchesSubsite(article.data.subsites, subsite);
   });
 }
 
@@ -39,7 +39,7 @@ export async function getEvents(subsite?: string): Promise<EventEntry[]> {
   }
 
   return events.filter((event) => {
-    return contentMatchesSubsite(normalizeSubsites(event.data.subsites), subsite);
+    return contentMatchesSubsite(event.data.subsites, subsite);
   });
 }
 
@@ -226,7 +226,7 @@ export async function getNews(subsite?: string): Promise<NewsEntry[]> {
   const filtered = !subsite
     ? news
     : news.filter((article) => {
-        return contentMatchesSubsite(normalizeSubsites(article.data.subsites), subsite);
+        return contentMatchesSubsite(article.data.subsites, subsite);
       });
 
   return filtered.sort((a, b) => {

--- a/astro/src/utils/subsites.test.ts
+++ b/astro/src/utils/subsites.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { ALL_SUBSITE_IDS, contentMatchesSubsite, expandSubsites, normalizeSubsites } from './subsites';
+
+describe('normalizeSubsites', () => {
+  it('normalizes missing values to an empty list', () => {
+    expect(normalizeSubsites(undefined)).toEqual([]);
+    expect(normalizeSubsites(null)).toEqual([]);
+    expect(normalizeSubsites('')).toEqual([]);
+  });
+
+  it('normalizes strings and arrays case-insensitively', () => {
+    expect(normalizeSubsites(' EU ')).toEqual(['eu']);
+    expect(normalizeSubsites(['Global', ' US ', 'all-EU'])).toEqual(['global', 'us', 'all-eu']);
+  });
+});
+
+describe('contentMatchesSubsite', () => {
+  it('treats missing or empty subsites as visible everywhere', () => {
+    expect(contentMatchesSubsite([], 'eu')).toBe(true);
+    expect(contentMatchesSubsite([], 'global')).toBe(true);
+  });
+
+  it('treats all as visible on every subsite', () => {
+    expect(contentMatchesSubsite(['all'], 'global')).toBe(true);
+    expect(contentMatchesSubsite(['all'], 'eu')).toBe(true);
+    expect(contentMatchesSubsite(['all'], 'us')).toBe(true);
+  });
+
+  it('treats global as a regular subsite id', () => {
+    expect(contentMatchesSubsite(['global', 'us'], 'global')).toBe(true);
+    expect(contentMatchesSubsite(['global', 'us'], 'us')).toBe(true);
+    expect(contentMatchesSubsite(['global', 'us'], 'eu')).toBe(false);
+  });
+
+  it('matches direct subsite ids case-insensitively', () => {
+    expect(contentMatchesSubsite(['EU'], 'eu')).toBe(true);
+    expect(contentMatchesSubsite(['eu'], 'EU')).toBe(true);
+    expect(contentMatchesSubsite(['freiburg'], 'eu')).toBe(false);
+  });
+
+  it('matches all-eu only for EU-affiliated subsites', () => {
+    expect(contentMatchesSubsite(['all-eu'], 'eu')).toBe(true);
+    expect(contentMatchesSubsite(['all-eu'], 'freiburg')).toBe(true);
+    expect(contentMatchesSubsite(['all-eu'], 'ifb')).toBe(true);
+    expect(contentMatchesSubsite(['all-eu'], 'global')).toBe(false);
+    expect(contentMatchesSubsite(['all-eu'], 'us')).toBe(false);
+  });
+
+  it('matches all-fr only for FR-affiliated subsites', () => {
+    expect(contentMatchesSubsite(['all-fr'], 'fr')).toBe(true);
+    expect(contentMatchesSubsite(['all-fr'], 'ifb')).toBe(true);
+    expect(contentMatchesSubsite(['all-fr'], 'genouest')).toBe(true);
+    expect(contentMatchesSubsite(['all-fr'], 'global')).toBe(false);
+    expect(contentMatchesSubsite(['all-fr'], 'eu')).toBe(false);
+  });
+
+  it('keeps arbitrary tags as direct matches only', () => {
+    expect(contentMatchesSubsite(['esg'], 'esg')).toBe(true);
+    expect(contentMatchesSubsite(['esg'], 'eu')).toBe(false);
+  });
+});
+
+describe('expandSubsites', () => {
+  it('expands all to the configured subsite ids', () => {
+    expect(expandSubsites(['all'])).toEqual(ALL_SUBSITE_IDS);
+  });
+
+  it('normalizes and returns non-all values unchanged', () => {
+    expect(expandSubsites(['Global', ' US '])).toEqual(['global', 'us']);
+  });
+});

--- a/astro/src/utils/subsites.test.ts
+++ b/astro/src/utils/subsites.test.ts
@@ -15,9 +15,9 @@ describe('normalizeSubsites', () => {
 });
 
 describe('contentMatchesSubsite', () => {
-  it('treats missing or empty subsites as visible everywhere', () => {
-    expect(contentMatchesSubsite([], 'eu')).toBe(true);
-    expect(contentMatchesSubsite([], 'global')).toBe(true);
+  it('keeps untagged content off every subsite', () => {
+    expect(contentMatchesSubsite([], 'eu')).toBe(false);
+    expect(contentMatchesSubsite([], 'global')).toBe(false);
   });
 
   it('treats all as visible on every subsite', () => {

--- a/astro/src/utils/subsites.test.ts
+++ b/astro/src/utils/subsites.test.ts
@@ -38,20 +38,22 @@ describe('contentMatchesSubsite', () => {
     expect(contentMatchesSubsite(['freiburg'], 'eu')).toBe(false);
   });
 
-  it('matches all-eu only for EU-affiliated subsites', () => {
-    expect(contentMatchesSubsite(['all-eu'], 'eu')).toBe(true);
-    expect(contentMatchesSubsite(['all-eu'], 'freiburg')).toBe(true);
-    expect(contentMatchesSubsite(['all-eu'], 'ifb')).toBe(true);
-    expect(contentMatchesSubsite(['all-eu'], 'global')).toBe(false);
-    expect(contentMatchesSubsite(['all-eu'], 'us')).toBe(false);
+  it('matches all-eu for every EU-affiliated subsite', () => {
+    for (const subsite of ['eu', 'freiburg', 'erasmusmc', 'belgium', 'pasteur', 'elixir-it', 'ifb']) {
+      expect(contentMatchesSubsite(['all-eu'], subsite)).toBe(true);
+    }
   });
 
-  it('matches all-fr only for FR-affiliated subsites', () => {
-    expect(contentMatchesSubsite(['all-fr'], 'fr')).toBe(true);
-    expect(contentMatchesSubsite(['all-fr'], 'ifb')).toBe(true);
-    expect(contentMatchesSubsite(['all-fr'], 'genouest')).toBe(true);
-    expect(contentMatchesSubsite(['all-fr'], 'global')).toBe(false);
-    expect(contentMatchesSubsite(['all-fr'], 'eu')).toBe(false);
+  it('does not match all-eu outside the EU group', () => {
+    expect(contentMatchesSubsite(['all-eu'], 'global')).toBe(false);
+    expect(contentMatchesSubsite(['all-eu'], 'us')).toBe(false);
+    expect(contentMatchesSubsite(['all-eu'], 'genouest')).toBe(false);
+  });
+
+  it('treats all-fr as an ordinary tag, not a group', () => {
+    expect(contentMatchesSubsite(['all-fr'], 'fr')).toBe(false);
+    expect(contentMatchesSubsite(['all-fr'], 'ifb')).toBe(false);
+    expect(contentMatchesSubsite(['all-fr'], 'genouest')).toBe(false);
   });
 
   it('keeps arbitrary tags as direct matches only', () => {

--- a/astro/src/utils/subsites.test.ts
+++ b/astro/src/utils/subsites.test.ts
@@ -18,6 +18,8 @@ describe('contentMatchesSubsite', () => {
   it('keeps untagged content off every subsite', () => {
     expect(contentMatchesSubsite([], 'eu')).toBe(false);
     expect(contentMatchesSubsite([], 'global')).toBe(false);
+    expect(contentMatchesSubsite(undefined, 'eu')).toBe(false);
+    expect(contentMatchesSubsite(null, 'eu')).toBe(false);
   });
 
   it('treats all as visible on every subsite', () => {
@@ -69,5 +71,14 @@ describe('expandSubsites', () => {
 
   it('normalizes and returns non-all values unchanged', () => {
     expect(expandSubsites(['Global', ' US '])).toEqual(['global', 'us']);
+  });
+
+  it('expands a case-normalized all and discards accompanying tags', () => {
+    expect(expandSubsites(['ALL', 'esg'])).toEqual(ALL_SUBSITE_IDS);
+  });
+
+  it('returns an empty list for untagged content', () => {
+    expect(expandSubsites(undefined)).toEqual([]);
+    expect(expandSubsites([])).toEqual([]);
   });
 });

--- a/astro/src/utils/subsites.ts
+++ b/astro/src/utils/subsites.ts
@@ -1,0 +1,37 @@
+import { subsites } from '../stores/subsiteStore';
+
+export const SUBSITE_GROUPS: Record<string, readonly string[]> = {
+  'all-eu': ['eu', 'freiburg', 'erasmusmc', 'belgium', 'pasteur', 'elixir-it', 'ifb'],
+  'all-fr': ['fr', 'ifb', 'genouest'],
+} as const;
+
+export const ALL_SUBSITE_IDS = subsites.map((subsite) => subsite.id);
+
+function normalizeSubsiteId(value: unknown): string {
+  return String(value).trim().toLowerCase();
+}
+
+export function normalizeSubsites(value: unknown): string[] {
+  if (value == null) return [];
+
+  const values = Array.isArray(value) ? value : [value];
+  return values.map(normalizeSubsiteId).filter(Boolean);
+}
+
+export function contentMatchesSubsite(contentSubsites: string[], targetSubsite: string): boolean {
+  const normalizedSubsites = normalizeSubsites(contentSubsites);
+  const target = normalizeSubsiteId(targetSubsite);
+
+  if (normalizedSubsites.length === 0) return true;
+  if (normalizedSubsites.includes('all')) return true;
+  if (normalizedSubsites.includes(target)) return true;
+
+  return Object.entries(SUBSITE_GROUPS).some(([group, groupSubsites]) => {
+    return normalizedSubsites.includes(group) && groupSubsites.includes(target);
+  });
+}
+
+export function expandSubsites(contentSubsites: string[]): string[] {
+  const normalizedSubsites = normalizeSubsites(contentSubsites);
+  return normalizedSubsites.includes('all') ? [...ALL_SUBSITE_IDS] : normalizedSubsites;
+}

--- a/astro/src/utils/subsites.ts
+++ b/astro/src/utils/subsites.ts
@@ -1,8 +1,9 @@
 import { subsites } from '../stores/subsiteStore';
 
+// Group tags that fan out to a set of subsites. Keep in sync with content/SUBSITES.yaml,
+// which is the vocabulary content validation accepts.
 export const SUBSITE_GROUPS: Record<string, readonly string[]> = {
   'all-eu': ['eu', 'freiburg', 'erasmusmc', 'belgium', 'pasteur', 'elixir-it', 'ifb'],
-  'all-fr': ['fr', 'ifb', 'genouest'],
 } as const;
 
 export const ALL_SUBSITE_IDS = subsites.map((subsite) => subsite.id);

--- a/astro/src/utils/subsites.ts
+++ b/astro/src/utils/subsites.ts
@@ -23,7 +23,8 @@ export function contentMatchesSubsite(contentSubsites: string[], targetSubsite: 
   const normalizedSubsites = normalizeSubsites(contentSubsites);
   const target = normalizeSubsiteId(targetSubsite);
 
-  if (normalizedSubsites.length === 0) return true;
+  // Untagged content belongs to the root site only, so it never matches a subsite.
+  if (normalizedSubsites.length === 0) return false;
   if (normalizedSubsites.includes('all')) return true;
   if (normalizedSubsites.includes(target)) return true;
 

--- a/astro/src/utils/subsites.ts
+++ b/astro/src/utils/subsites.ts
@@ -19,7 +19,7 @@ export function normalizeSubsites(value: unknown): string[] {
   return values.map(normalizeSubsiteId).filter(Boolean);
 }
 
-export function contentMatchesSubsite(contentSubsites: string[], targetSubsite: string): boolean {
+export function contentMatchesSubsite(contentSubsites: unknown, targetSubsite: string): boolean {
   const normalizedSubsites = normalizeSubsites(contentSubsites);
   const target = normalizeSubsiteId(targetSubsite);
 
@@ -33,7 +33,7 @@ export function contentMatchesSubsite(contentSubsites: string[], targetSubsite: 
   });
 }
 
-export function expandSubsites(contentSubsites: string[]): string[] {
+export function expandSubsites(contentSubsites: unknown): string[] {
   const normalizedSubsites = normalizeSubsites(contentSubsites);
   return normalizedSubsites.includes('all') ? [...ALL_SUBSITE_IDS] : normalizedSubsites;
 }

--- a/content/news/2026/2026-07-06-gcc2026-recap/index.md
+++ b/content/news/2026/2026-07-06-gcc2026-recap/index.md
@@ -3,7 +3,7 @@ title: "GCC2026 Recap: Science, Collaboration, and Community in Clermont-Ferrand
 date: "2026-07-06"
 tease: "A look back at the 2026 Galaxy Community Conference in Clermont-Ferrand, France."
 tags: [conference, community, gcc]
-subsites: [global]
+subsites: [all]
 main_subsite: global
 ---
 

--- a/content/news/2026/2026-07-09-gcc2026-fishbowl-summary/index.md
+++ b/content/news/2026/2026-07-09-gcc2026-fishbowl-summary/index.md
@@ -3,7 +3,7 @@ title: "GCC2026 Fishbowl Discussion: AI, Galaxy, and Trustworthy Scientific Soft
 date: "2026-07-09"
 tease: "At GCC2026, the Galaxy community came together to ask how AI can support scientific discovery while preserving the trust, transparency, reproducibility, and human-centered values that define Galaxy."
 tags: [gcc, conference, ai]
-subsites: [global]
+subsites: [all]
 main_subsite: global
 ---
 

--- a/content/news/2026/2026-07-20-gcc2026-cofest-outcomes/index.md
+++ b/content/news/2026/2026-07-20-gcc2026-cofest-outcomes/index.md
@@ -6,7 +6,7 @@ contributions:
   authorship:
     - ahmedhamidawan
 tags: [conference, community, gcc, cofest]
-subsites: [global]
+subsites: [all]
 main_subsite: global
 autotoc: false
 components: true


### PR DESCRIPTION
## Summary

Replaces 5+ inconsistent inline subsite-filter implementations with one shared utility (`astro/src/utils/subsites.ts`) and routes every news/event/article listing, atom feed, JSON feed, ICS calendar, and bare page through it. Locks in the semantics agreed in #3839: `global` is a regular subsite ID (the root site), `all` is broadcast, `all-eu` is a regional group.

Three latent bugs fall out of this:

- `/eu/feed.atom` dropped `all-eu`-tagged content because it never checked the group tag.
- `/eu/events/calendar.ics` required a literal `eu` tag, so it excluded everything tagged `all` or `all-eu` -- the calendar was carrying 12 events where it should carry 69. It also wasn't filtering drafts, unlike every sibling feed.
- Untagged content matched every subsite on some surfaces and none on others. It's now consistently root-only, matching the "global if not specified otherwise" reading from #3839.

`all-fr` is not implemented. It was never in `content/SUBSITES.yaml`, so content validation would have rejected it, and no content uses it. `/bare/fr/*` matches on `fr`, `ifb`, `genouest` and `all` instead.

## Behavior changes

Measured by building `main` and this branch and diffing rendered output. Note these routes are capped or date-windowed -- `/bare/*/news/` slices to 50, the atom feeds to 25/50, the bare events pages show upcoming plus a trailing 12 months -- so on the capped routes the change is *which* items appear, not how many.

| Route | Before | After | Change |
|---|---|---|---|
| /bare/eu/news/ | 50 | 50 | 5 items swapped |
| /bare/eu/events/ | 75 | 69 | -6 untagged |
| /bare/fr/news/ | 50 | 50 | 16 items swapped |
| /bare/fr/events/ | 73 | 38 | -35 |
| /eu/feed.atom | 25 | 25 | 4 swapped |
| /eu/news/feed.atom | 50 | 50 | 5 swapped |
| /eu/events/feed.atom | 50 | 50 | 6 swapped |
| /eu/events/calendar.ics | 12 | 69 | +57 |

The unfiltered main listings (`/news/`, `/events/`, `/us/news/`, JSON feeds) are unchanged, and untagged content still appears there.

## Heads-up for embedders

@bgruening @natalie-wa -- the one route that materially shrinks is `/bare/fr/events/`, 73 to 38. Those 35 are pan-community events tagged `[global, us]` or untagged: the recurring small-scale admin meetings, SPOC and GCB meets, microGalaxy, EMBL-EBI. If you want them on the FR page the fix is retagging that content, not reverting this PR.

The EU routes barely move. I retagged the three GCC2026 recap articles from `global` to `all` in this PR so they stay on EU surfaces -- they're a good example of pan-community content that was mis-tagged `global` when it meant `all`, and there is likely more of it.

## Test plan

- [x] `npm run test:unit` -- 205 tests pass
- [x] `npm run build` -- exits clean
- [x] `npx playwright test tests/bare-pages.spec.ts tests/feed-conformance.spec.ts` -- 24 pass
- [x] `npm run lint` and `npm run format:check` -- clean
- [x] `scripts/validate_news.py` -- passes on the retagged content
- [x] Before/after counts captured per route by building both sides and diffing rendered output

Supersedes the documentation in #3839 -- docs follow in a separate PR once this is consistent.
