### PR TITLE
Fix image compression workflow on main pushes

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -51,6 +51,8 @@ jobs:
           # Attempt to prevent webp recompression by minimizing diff.
           webpQuality: '90'
           minPctChange: '2.5'
+          # Non-PR events need compress-only mode so create-pull-request can publish the result.
+          compressOnly: ${{ github.event_name != 'pull_request' }}
       - name: Create Pull Request
         # If it's not a Pull Request then commit any changes as a new PR.
         if: |


### PR DESCRIPTION
## Summary
- Run image-actions in compress-only mode for non-PR events
- Preserve normal PR behavior while allowing main-push/scheduled/manual runs to create follow-up compression PRs

## Why
The workflow currently triggers on image pushes to main, but calibreapp/image-actions fails outside PR events unless compressOnly is enabled.

## Testing
- Parsed .github/workflows/optimize-images.yml successfully with Ruby YAML loader