### PR TITLE
Restrict 2 more GitHub workflows to galaxyproject owner

### DIFF
--- a/.github/workflows/update-eu-citations.yml
+++ b/.github/workflows/update-eu-citations.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   update-citations:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-eu-tools.yml
+++ b/.github/workflows/update-eu-tools.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   update-tools:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Otherwise they open PRs on forks.