### PR TITLE
ci: stop image compression bot from self-triggering PR loops

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -43,13 +43,12 @@ jobs:
     if: |
       github.repository == 'galaxyproject/galaxy-hub' &&
       (github.event_name != 'pull_request' ||
-       (github.event.pull_request.head.repo.full_name == github.repository &&
-        github.actor != 'galaxy-hub-bot' &&
-        github.actor != 'galaxy-hub-bot[bot]'))
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v6
       - name: Generate GitHub App token
+        if: github.event_name != 'pull_request'
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
@@ -59,7 +58,9 @@ jobs:
         id: calibre
         uses: calibreapp/image-actions@1.5.0
         with:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # PR runs use GITHUB_TOKEN to avoid recursively triggering this workflow.
+          # Non-PR runs use the App token so create-pull-request can publish updates.
+          GITHUB_TOKEN: ${{ github.event_name == 'pull_request' && github.token || steps.app-token.outputs.token }}
           webpQuality: '90'
           # Non-PR events need compress-only mode so create-pull-request can publish the result.
           compressOnly: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -39,28 +39,35 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # Only run on main repo on and PRs that match the main repo.
+    # Only run on main repo and on PRs that match the main repo.
+    # Skip when the bot's own compression commit re-triggers this workflow
+    # (synchronize + bot actor) to break the infinite loop. Safe for
+    # bot-authored PRs (e.g. GTN imports) because those trigger as
+    # 'opened', not 'synchronize'.
     if: |
       github.repository == 'galaxyproject/galaxy-hub' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository) &&
+      !(github.event_name == 'pull_request' && github.event.action == 'synchronize' && startsWith(github.actor, 'galaxy-hub-bot'))
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Generate GitHub App token
-        if: github.event_name != 'pull_request'
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.HUB_BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-metadata: read
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@1.5.0
         with:
-          # PR runs use GITHUB_TOKEN to avoid recursively triggering this workflow.
-          # Non-PR runs use the App token so create-pull-request can publish updates.
-          GITHUB_TOKEN: ${{ github.event_name == 'pull_request' && github.token || steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           webpQuality: '90'
           # Non-PR events need compress-only mode so create-pull-request can publish the result.
           compressOnly: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -8,10 +8,15 @@
 name: Compress images
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
     paths:
       - "**.jpg"
       - "**.jpeg"
       - "**.png"
+      - "**.webp"
+      - "**.avif"
   push:
     branches:
       - main
@@ -19,9 +24,14 @@ on:
       - "**.jpg"
       - "**.jpeg"
       - "**.png"
+      - "**.webp"
+      - "**.avif"
   workflow_dispatch:
   schedule:
     - cron: "00 23 * * 0"
+concurrency:
+  group: compress-images-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     name: calibreapp/image-actions
@@ -33,7 +43,9 @@ jobs:
     if: |
       github.repository == 'galaxyproject/galaxy-hub' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        github.actor != 'galaxy-hub-bot' &&
+        github.actor != 'galaxy-hub-bot[bot]'))
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v6
@@ -45,12 +57,10 @@ jobs:
           private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@1.4.1
+        uses: calibreapp/image-actions@1.5.0
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          # Attempt to prevent webp recompression by minimizing diff.
           webpQuality: '90'
-          minPctChange: '2.5'
           # Non-PR events need compress-only mode so create-pull-request can publish the result.
           compressOnly: ${{ github.event_name != 'pull_request' }}
       - name: Create Pull Request


### PR DESCRIPTION
## Summary

Fixes the image compression workflow loop seen on #3937, where `galaxy-hub-bot` repeatedly committed optimized images and posted a new Calibre comment for each follow-up run.

The root cause is that this workflow intentionally uses a GitHub App installation token. Per GitHub Actions docs, workflow changes made with `GITHUB_TOKEN` do not usually create new workflow runs, but changes made with a GitHub App token or PAT do. That means every Calibre commit on a PR can trigger another `pull_request.synchronize` run of the same compression workflow.

This PR:
- skips the compression job for PR events authored by `galaxy-hub-bot` / `galaxy-hub-bot[bot]`
- updates `calibreapp/image-actions` from `1.4.1` to `1.5.0`
- removes the custom `minPctChange: '2.5'` override so Calibre’s safer defaults apply
- adds workflow concurrency to avoid overlapping compression runs on the same PR/ref
- adds WebP/AVIF path filters to match the image types supported by Calibre

## References

- Affected PR: #3937
- GitHub docs: triggering workflows from workflows with `GITHUB_TOKEN` vs GitHub App/PAT tokens  
  https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
- GitHub docs: workflow concurrency and `cancel-in-progress`  
  https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
- Calibre image-actions README  
  https://github.com/calibreapp/image-actions
- Calibre image-actions `1.5.0` release notes, adding `minAbsChange` for tiny repeated lossy PNG reductions  
  https://github.com/calibreapp/image-actions/releases/tag/1.5.0

## Local verification

- Parsed workflow YAML locally.
- Ran `git diff --check`.
- Simulated GitHub PR payloads locally:
  - normal user-authored `pull_request.synchronize` remains allowed
  - bot-authored `pull_request.synchronize` is blocked
  - `push`/scheduled/manual flows remain allowed
- Ran `act` against a bot-authored PR event and confirmed the job is skipped before any workflow steps execute.