### PR TITLE
fix(ci): migrate automated PR workflows to GitHub App auth

### DIFF
--- a/.github/workflows/sync-training-material-metadata.yml
+++ b/.github/workflows/sync-training-material-metadata.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.HUB_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
+
       - name: Download files from training-material
         run: |
           # Download the YAML files directly from GitHub's raw content
@@ -45,7 +52,7 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: |
             Sync files from galaxyproject/training-material
             

--- a/.github/workflows/update-eu-tools.yml
+++ b/.github/workflows/update-eu-tools.yml
@@ -16,6 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.HUB_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -30,6 +37,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore(eu): update tools report'
           title: 'Update EU Tools Report'
           body: 'Auto-generated PR with the updated inventory of tools available at [Galaxy EU](https://usegalaxy.eu).'


### PR DESCRIPTION
Migrates the following workflows to use the GitHub App token for pull request creation, so that the generated pull requests will trigger CI/CD checks:

1. `update-eu-tools.yml` (Update EU Tools Report)
2. `sync-training-material-metadata.yml` (Sync Training Material Files)