### PR TITLE
fix(ci): migrate EU citations workflow to GitHub App auth

### DIFF
--- a/.github/workflows/update-eu-citations.yml
+++ b/.github/workflows/update-eu-citations.yml
@@ -16,6 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.HUB_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -27,6 +34,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore(eu): update citations'
           title: 'Update EU citation bibliographies'
           body: 'Auto-generated PR with updated citation bibliographies for Galaxy Europe and its subsites.'


### PR DESCRIPTION
Continues the work done in #3997 by migrating the remaining automated PR workflow (`update-eu-citations.yml`) to use the GitHub App token for pull request creation, so that the generated pull requests will trigger CI/CD checks.