### PR TITLE
Add a BOFs tab to the GCC26 page

### DIFF
--- a/content/events/gcc2026/bofs/index.md
+++ b/content/events/gcc2026/bofs/index.md
@@ -1,0 +1,15 @@
+# BoFs: Birds of Feathers  
+
+BoFs are a great opportunity to gather with other Galaxy community members around shared topics, ideas, questions, or challenges. 
+If there is something you would like to discuss with others during the conference, we encourage you to submit a BoF idea.
+
+These moments of discussions on a specific topic will be held Monday 22nd from 5 to 6pm and Wednesday 24th from 5:15 to 6:30pm.
+
+The Sessions can be structured in whatever way works best for the topic, whether that includes short presentations, a guided discussion, or an open conversation. 
+We just ask that sessions be designed to encourage participation and discussion among attendees.
+
+Please note that BoFs are intended for in-person participation and unfortunately virtual attendees cannot be accommodated.
+
+![Submit your BoF idea here](https://docs.google.com/forms/d/e/1FAIpQLScIklaO7gB-gVtPCrLynGL1NUMlbJOcPcC-S2RqIKMTKtNIPg/viewform?usp=sharing&ouid=105563739106270555791)
+
+The deadline to submit is **June 15, 2026**, but earlier submissions are encouraged so we can begin planning the schedule.

--- a/content/events/gcc2026/bofs/index.md
+++ b/content/events/gcc2026/bofs/index.md
@@ -1,15 +1,22 @@
-# BoFs: Birds of Feathers  
+---
+autotoc: false
+nav_title: BoFs
+---
 
-BoFs are a great opportunity to gather with other Galaxy community members around shared topics, ideas, questions, or challenges. 
+# BoFs: Birds of a Feather
+
+BoFs are a great opportunity to gather with other Galaxy community members around shared topics, ideas, questions, or challenges.
 If there is something you would like to discuss with others during the conference, we encourage you to submit a BoF idea.
 
 These moments of discussions on a specific topic will be held Monday 22nd from 5 to 6pm and Wednesday 24th from 5:15 to 6:30pm.
 
-The Sessions can be structured in whatever way works best for the topic, whether that includes short presentations, a guided discussion, or an open conversation. 
+The sessions can be structured in whatever way works best for the topic, whether that includes short presentations, a guided discussion, or an open conversation.
 We just ask that sessions be designed to encourage participation and discussion among attendees.
 
 Please note that BoFs are intended for in-person participation and unfortunately virtual attendees cannot be accommodated.
 
-![Submit your BoF idea here](https://docs.google.com/forms/d/e/1FAIpQLScIklaO7gB-gVtPCrLynGL1NUMlbJOcPcC-S2RqIKMTKtNIPg/viewform?usp=sharing&ouid=105563739106270555791)
+<div class="flex justify-center my-5">
+  <a target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLScIklaO7gB-gVtPCrLynGL1NUMlbJOcPcC-S2RqIKMTKtNIPg/viewform" class="inline-flex items-center justify-center rounded px-8 py-2 text-sm font-semibold text-white bg-galaxy-primary hover:bg-galaxy-dark no-underline hover:no-underline">Submit your BoF idea</a>
+</div>
 
 The deadline to submit is **June 15, 2026**, but earlier submissions are encouraged so we can begin planning the schedule.

--- a/content/schema-events.yaml
+++ b/content/schema-events.yaml
@@ -16,6 +16,9 @@ mapping:
             title:
                 type: str
                 description: Event title
+            nav_title:
+                type: str
+                description: Override label shown in conference sub-navigation
             date:
                 type: any
                 description: Start date (YYYY-MM-DD)


### PR DESCRIPTION
Hi all, 
Sorry to bother With the new look of the community hub, I totally forgot how I can add this new tab to the GCC website. I created the content, I remember that for it to show I need to go sowhere in the astro part but I don't know where.

Anyone can help me ?

Thanks !!