### PR TITLE
Allow contributors without label permissions to indicate testing state

### DIFF
--- a/astro/src/build/release-guardians-projection.mjs
+++ b/astro/src/build/release-guardians-projection.mjs
@@ -8,6 +8,19 @@
 
 import { extractPlainTease } from './release-guardians-tease.mjs';
 
+/* Exact PR comments equivalent to applying workflow labels, for users who
+ * lack label permissions. Case-insensitive; surrounding whitespace is ignored. */
+const RX_IN_PROGRESS_COMMENT = /^release testing in progress$/i;
+const RX_COMPLETE_COMMENT = /^release testing complete$/i;
+
+/** Map a comment body to its equivalent workflow label, or null if no match. */
+export function commentToLabel(body, config) {
+  const trimmed = (body || '').trim();
+  if (RX_IN_PROGRESS_COMMENT.test(trimmed)) return config.inProgressLabel;
+  if (RX_COMPLETE_COMMENT.test(trimmed)) return config.completeLabel;
+  return null;
+}
+
 /** The actor who most recently applied the given label on this PR. */
 export function findGuardian(pr, label) {
   const events = pr.labelingEvents.filter((e) => e.label === label);

--- a/astro/src/build/release-guardians-projection.test.mjs
+++ b/astro/src/build/release-guardians-projection.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildSnapshot,
+  commentToLabel,
   findGuardian,
   partitionPrs,
   projectPr,
@@ -37,6 +38,54 @@ describe('withStableAvatar', () => {
       avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
     });
     expect(result.avatarUrl).toBe('https://github.com/alice.png');
+  });
+});
+
+describe('commentToLabel', () => {
+  it('returns null for empty / null / undefined body', () => {
+    expect(commentToLabel('', CONFIG)).toBeNull();
+    expect(commentToLabel(null, CONFIG)).toBeNull();
+    expect(commentToLabel(undefined, CONFIG)).toBeNull();
+  });
+
+  it('matches the canonical in-progress phrase', () => {
+    expect(commentToLabel('Release testing in progress', CONFIG)).toBe(CONFIG.inProgressLabel);
+  });
+
+  it('matches the canonical complete phrase', () => {
+    expect(commentToLabel('Release testing complete', CONFIG)).toBe(CONFIG.completeLabel);
+  });
+
+  it('is case-insensitive', () => {
+    expect(commentToLabel('RELEASE TESTING IN PROGRESS', CONFIG)).toBe(CONFIG.inProgressLabel);
+    expect(commentToLabel('release testing complete', CONFIG)).toBe(CONFIG.completeLabel);
+    expect(commentToLabel('Release Testing Complete', CONFIG)).toBe(CONFIG.completeLabel);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(commentToLabel('  Release testing in progress  ', CONFIG)).toBe(CONFIG.inProgressLabel);
+    expect(commentToLabel('\nRelease testing complete\n', CONFIG)).toBe(CONFIG.completeLabel);
+  });
+
+  it('rejects dashes between words', () => {
+    expect(commentToLabel('release-testing-in-progress', CONFIG)).toBeNull();
+    expect(commentToLabel('release-testing-complete', CONFIG)).toBeNull();
+    expect(commentToLabel('Release-testing in progress', CONFIG)).toBeNull();
+  });
+
+  it('rejects any additional characters in the body', () => {
+    expect(commentToLabel('Release testing in progress!', CONFIG)).toBeNull();
+    expect(commentToLabel('Release testing in progress for this PR', CONFIG)).toBeNull();
+    expect(commentToLabel('FYI: Release testing in progress', CONFIG)).toBeNull();
+    expect(commentToLabel('**Release testing in progress**', CONFIG)).toBeNull();
+    expect(commentToLabel('Release  testing  in  progress', CONFIG)).toBeNull();
+    expect(commentToLabel('Release_testing_in_progress', CONFIG)).toBeNull();
+  });
+
+  it('returns null for unrelated comments', () => {
+    expect(commentToLabel('LGTM', CONFIG)).toBeNull();
+    expect(commentToLabel('release testing pending', CONFIG)).toBeNull();
+    expect(commentToLabel('testing in progress', CONFIG)).toBeNull();
   });
 });
 

--- a/astro/src/build/release-guardians-sync-event.mjs
+++ b/astro/src/build/release-guardians-sync-event.mjs
@@ -21,7 +21,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { buildSnapshot, snapshotFingerprint } from './release-guardians-projection.mjs';
+import { buildSnapshot, commentToLabel, snapshotFingerprint } from './release-guardians-projection.mjs';
 
 // ── Paths and constants ───────────────────────────────────────────────────
 
@@ -44,6 +44,7 @@ const PRS_PER_PAGE = 100;
 const MAX_PAGES = 10;
 const LABELS_PER_PR = 20;
 const LABELING_EVENTS_PER_PR = 100;
+const COMMENTS_PER_PR = 100;
 
 const QUERY = `
 query ($searchQuery: String!, $after: String) {
@@ -63,6 +64,13 @@ query ($searchQuery: String!, $after: String) {
                             actor { login url }
                             label { name }
                         }
+                    }
+                }
+                comments(last: ${COMMENTS_PER_PR}) {
+                    nodes {
+                        author { login url }
+                        createdAt
+                        body
                     }
                 }
             }
@@ -142,17 +150,30 @@ async function fetchPrs(config) {
   }
   return all
     .filter((n) => n && typeof n.number === 'number')
-    .map((n) => ({
-      number: n.number,
-      title: n.title,
-      url: n.url,
-      body: n.body || '',
-      author: n.author,
-      labels: n.labels.nodes.map((l) => l.name),
-      labelingEvents: (n.timelineItems?.nodes ?? [])
+    .map((n) => {
+      const labels = n.labels.nodes.map((l) => l.name);
+      const labelingEvents = (n.timelineItems?.nodes ?? [])
         .filter((e) => e && e.label && e.actor)
-        .map((e) => ({ createdAt: e.createdAt, actor: e.actor, label: e.label.name })),
-    }))
+        .map((e) => ({ createdAt: e.createdAt, actor: e.actor, label: e.label.name }));
+      // Treat matching comments as equivalent label applications for users
+      // who lack permission to add labels themselves.
+      for (const c of n.comments?.nodes ?? []) {
+        if (!c || !c.author) continue;
+        const label = commentToLabel(c.body, config);
+        if (!label) continue;
+        if (!labels.includes(label)) labels.push(label);
+        labelingEvents.push({ createdAt: c.createdAt, actor: c.author, label });
+      }
+      return {
+        number: n.number,
+        title: n.title,
+        url: n.url,
+        body: n.body || '',
+        author: n.author,
+        labels,
+        labelingEvents,
+      };
+    })
     .sort((a, b) => b.number - a.number);
 }
 

--- a/astro/src/templates/release-guardians-event.md.template
+++ b/astro/src/templates/release-guardians-event.md.template
@@ -32,6 +32,8 @@ Pick a pull request from the list below, test the change on the [**Galaxy Test S
 4. [**Open a new issue**]({{issueLink}}) describing your findings, reference the PR number, and include screenshots, regressions, deployment notes, and any edge cases you hit.
 5. When validation is complete, replace <ReleaseGuardiansLabelPill label="{{inProgressLabel}}" kind="inProgress" /> with <ReleaseGuardiansLabelPill label="{{completeLabel}}" kind="complete" />.
 
+> <small>If you do not have permission to apply labels, post `Release testing in progress` or `Release testing complete` as a PR comment instead.</small>
+
 <ReleaseGuardiansSummary version="{{version}}" />
 
 <h2 id="needs-validation"><Icon name="circle-dashed" /> Needs Validation</h2>
@@ -45,7 +47,3 @@ Pick a pull request from the list below, test the change on the [**Galaxy Test S
 <h2 id="complete"><Icon name="circle-check" /> Complete</h2>
 
 <ReleaseGuardiansSection version="{{version}}" kind="complete" emptyMessage="No PRs marked complete yet." />
-
----
-
-GitHub labels are the source of truth (`{{testingLabel}}` for in-scope, `{{inProgressLabel}}` while being tested, `{{completeLabel}}` for done). This page is regenerated every 12 hours from the live labels.

--- a/content/events/2026-06-01-release-guardians-26-1/index.md
+++ b/content/events/2026-06-01-release-guardians-26-1/index.md
@@ -33,6 +33,8 @@ Pick a pull request from the list below, test the change on the [**Galaxy Test S
 4. [**Open a new issue**](https://github.com/galaxyproject/galaxy/issues/new?template=bug_report.md) describing your findings, reference the PR number, and include screenshots, regressions, deployment notes, and any edge cases you hit.
 5. When validation is complete, replace <ReleaseGuardiansLabelPill label="release-testing-in-progress" kind="inProgress" /> with <ReleaseGuardiansLabelPill label="release-testing-complete" kind="complete" />.
 
+> <small>If you do not have permission to apply labels, post `Release testing in progress` or `Release testing complete` as a PR comment instead.</small>
+
 <ReleaseGuardiansSummary version="26.1" />
 
 <h2 id="needs-validation"><Icon name="circle-dashed" /> Needs Validation</h2>
@@ -46,7 +48,3 @@ Pick a pull request from the list below, test the change on the [**Galaxy Test S
 <h2 id="complete"><Icon name="circle-check" /> Complete</h2>
 
 <ReleaseGuardiansSection version="26.1" kind="complete" emptyMessage="No PRs marked complete yet." />
-
----
-
-GitHub labels are the source of truth (`release-testing-26.1` for in-scope, `release-testing-in-progress` while being tested, `release-testing-complete` for done). This page is regenerated every 12 hours from the live labels.


### PR DESCRIPTION
Follow up #4003. As mentioned during the discussion, one limitation of the labeling approach is that some contributors can participate in release testing but do not have permission to apply labels on Galaxy PRs. This change allows the canonical release testing phrases to be posted as PR comments as an alternative.