### PR TITLE
Refresh the GCC2026 conference pages and remove their Bootstrap usage

### DIFF
--- a/astro/DESIGN.md
+++ b/astro/DESIGN.md
@@ -159,6 +159,7 @@ Special Interest Groups and Working Groups use dedicated category colors. Applie
 | Card Title (H3) | `text-xl font-semibold text-galaxy-dark` | Card headers, subsections |
 | Subheading (H4) | `text-lg font-semibold text-galaxy-dark` | Minor sections |
 | Body | `text-base text-galaxy-grey` | Paragraph text |
+| Lead / intro | `text-lg text-galaxy-grey` | Intro paragraph under a title (replaces Bootstrap `lead`) |
 | Muted | `text-sm text-galaxy-grey/70` | Metadata, help text, timestamps |
 | Links | `text-galaxy-primary hover:text-galaxy-gold` | All interactive links |
 
@@ -244,6 +245,59 @@ When placing prose inside cards, trim default margins:
   <!-- markdown content -->
 </div>
 ```
+
+### Tile Grid / Content Cards
+
+The `gx-tile` system is the content-authored counterpart to the card pattern above -- reusable CSS classes (defined in `global.css`) for cards written in Markdown/MDX content, used across the conference pages. Reach for these when authoring content; use the Tailwind utilities above when building Astro/Vue components.
+
+> **Why `tile`, not `card`:** the content preprocessor marks any class attribute containing the token `card` (or `alert`, `lead`, `table`) as legacy `.bs-compat`. The `gx-` names sidestep that, so new content stays out of the compat layer.
+
+```html
+<div class="gx-tile-grid">                              <!-- responsive grid: auto-fit, minmax(260px, 1fr) -->
+  <a class="gx-tile gx-tile--link" href="/somewhere">   <!-- whole-tile link + gold hover bar -->
+    <img class="gx-tile__media" src="..." alt="..." />  <!-- 160px cover image -->
+    <div class="gx-tile__title">Title</div>             <!-- galaxy-dark, semibold -->
+    <p class="gx-tile__teaser">A one- or two-line hook.</p>
+    <span class="gx-tile__more">Learn more →</span>     <!-- galaxy-primary, gold on hover -->
+  </a>
+</div>
+```
+
+Variants and elements:
+
+- `gx-tile` -- base tile: white, `border-galaxy-primary/10`, `rounded-lg`, `shadow-sm`.
+- `gx-tile--link` -- the whole tile is an `<a>`; adds the signature gold hover bar (left edge, `scaleX`) and lifts to `shadow-md`. Keep contents plain (no nested links/markdown).
+- `gx-tile--feature` -- galaxy-primary left border for emphasized tiles.
+- `gx-tile__media` (160px cover image), `gx-tile__title`, `gx-tile__body` (richer markdown bodies -- separate inner content with blank lines so Markdown renders), `gx-tile__teaser` (short plain text), `gx-tile__credit` (small chicago-500 caption, e.g. photo credits), `gx-tile__more` (link affordance).
+
+### Callout / Note
+
+Brand-tinted note box for asides and "good to know" content. Replaces Bootstrap `alert-*`. Intentionally blue (not gold), so gold stays reserved for high-impact moments.
+
+```html
+<div class="callout">
+  Training on June 25-26 is separate from the main conference.
+</div>
+```
+
+`.callout`: `bg-bay-of-many-100`, `border-l-4 border-l-galaxy-primary`, rounded right corners, galaxy-dark text.
+
+### Profile Row
+
+Photo + bio row for people (fellowship awardees, organizers, etc.). Photo left / bio right on desktop; stacks (photo on top) below 768px.
+
+```html
+<div class="profile-row">
+  <img class="profile-row__photo" src="..." alt="Jane Doe" />
+  <div class="profile-row__bio">
+
+Jane Doe is ... (markdown bio)
+
+  </div>
+</div>
+```
+
+`.profile-row`: flex row, 200px photo column with a `rounded-lg` photo.
 
 ### Buttons
 

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -433,6 +433,172 @@ body {
   }
 }
 
+/* ==========================================================================
+   Galaxy tile/card system -- reusable content cards & responsive grid.
+   Replaces the legacy bs-compat .card-deck/.card. Composes inside .prose.
+   NOTE: named "tile" (not "card") because the preprocessor's bs-compat
+   detector marks any class containing the token "card". See DESIGN.md §4.
+   ========================================================================== */
+.gx-tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.gx-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background-color: #fff;
+  border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 10%, transparent);
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.gx-tile .gx-tile__media {
+  display: block;
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 0;
+  margin: 0;
+}
+
+.gx-tile .gx-tile__title {
+  margin: 0;
+  padding: 0.9rem 1.15rem 0.3rem;
+  color: var(--color-galaxy-dark);
+  font-weight: 600;
+  font-size: 1.15rem;
+  line-height: 1.3;
+}
+
+.gx-tile__body {
+  padding: 0 1.15rem 1rem;
+  color: var(--color-galaxy-grey);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+.gx-tile__body > :first-child {
+  margin-top: 0;
+}
+.gx-tile__body > :last-child {
+  margin-bottom: 0;
+}
+
+.gx-tile__teaser {
+  margin: 0;
+  padding: 0 1.15rem;
+  color: var(--color-galaxy-grey);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.gx-tile__credit {
+  display: block;
+  padding: 0.5rem 1.15rem 0;
+  color: var(--color-chicago-500);
+  font-size: 0.75rem;
+}
+
+.gx-tile__more {
+  margin-top: auto;
+  padding: 0.6rem 1.15rem 1rem;
+  color: var(--color-galaxy-primary);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+/* Link variant: the whole tile is an <a>. Gold hover bar + lift (the DESIGN.md signature). */
+a.gx-tile--link {
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.2s ease;
+}
+a.gx-tile--link::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background-color: var(--color-galaxy-gold);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+  z-index: 2;
+}
+a.gx-tile--link:hover {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+}
+a.gx-tile--link:hover::before {
+  transform: scaleX(1);
+}
+a.gx-tile--link:hover .gx-tile__more {
+  color: var(--color-galaxy-gold);
+}
+
+/* Feature variant: galaxy-primary left border for emphasized content tiles. */
+.gx-tile--feature {
+  border-left: 4px solid var(--color-galaxy-primary);
+}
+
+/* ==========================================================================
+   Callout / note box -- replaces the legacy bs-compat .alert. See DESIGN.md §4.
+   ========================================================================== */
+.callout {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  background-color: var(--color-bay-of-many-100);
+  border-left: 4px solid var(--color-galaxy-primary);
+  border-radius: 0 0.5rem 0.5rem 0;
+  color: var(--color-galaxy-dark);
+}
+.callout > :first-child {
+  margin-top: 0;
+}
+.callout > :last-child {
+  margin-bottom: 0;
+}
+
+/* ==========================================================================
+   Profile row -- photo + bio. Replaces fellowship layout tables. See DESIGN.md §4.
+   ========================================================================== */
+.profile-row {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  margin: 1.5rem 0;
+}
+.profile-row .profile-row__photo {
+  flex: 0 0 200px;
+  width: 200px;
+  height: auto;
+  border-radius: 0.5rem;
+  margin: 0;
+}
+.profile-row__bio > :first-child {
+  margin-top: 0;
+}
+.profile-row__bio > :last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+  .profile-row {
+    flex-direction: column;
+  }
+  .profile-row .profile-row__photo {
+    flex-basis: auto;
+    width: 100%;
+    max-width: 280px;
+  }
+}
+
 /* Trim paragraph margins in certain contexts */
 .trim-p p:first-child {
   margin-top: 0;

--- a/content/events/gcc2026/cofest/index.md
+++ b/content/events/gcc2026/cofest/index.md
@@ -8,7 +8,7 @@ autotoc: false
 
 #### June 25-26, 2026
 
-  <div class="lead">
+  <div class="text-lg text-galaxy-grey">
     CoFest is a community gathering by those interested in
     contributing to Galaxy's tool set, documentation, training materials, code base,
     and anywhere else that expands the Galaxy ecosystem.
@@ -23,9 +23,9 @@ autotoc: false
 
 ## What to Expect at CoFest
 
-<p class="alert alert-info text-center">
+<div class="callout text-center">
     The goals of CoFest are to expand the Galaxy contributor community and its ecosystem.
-</p>
+</div>
 
 CoFest participants will collaborate around **project tracks**, each with real, achievable goals and a team of people to work on them together. Tracks will span the full breadth of the Galaxy ecosystem:
 
@@ -63,47 +63,59 @@ The registration cost is EUR50, added on top of the GCC2026 conference registrat
 
 ## Past projects (GCC 2024 & 2025)
 
-<div class="card-deck lead">
+<div class="gx-tile-grid">
 
-  <div class="card" style="flex: 1 1 280px;">
-    <div class="card-header">Deploying an R Shiny App on Galaxy</div>
+  <div class="gx-tile">
+    <div class="gx-tile__title">Deploying an R Shiny App on Galaxy</div>
+    <div class="gx-tile__body">
 
 This project involved deploying custom Shiny apps on Galaxy by converting them into R packages and containerizing them with Docker for consistency and portability. Galaxy configuration files were implemented to enable seamless user access. Additionally, existing Shiny apps—such as the **[Pampa Performance Indicators of Marine Protected Areas](https://github.com/usegalaxy-eu/galaxy/blob/release_25.0_europe/tools/interactive/interactivetool_pampa.xml)**—were updated to enhance functionality, showcasing the integration of interactive tools for research and resource management.
 
   </div>
+  </div>
 
-  <div class="card" style="flex: 1 1 280px;">
-    <div class="card-header">Making Your First Contribution to the Galaxy Training Network</div>
+  <div class="gx-tile">
+    <div class="gx-tile__title">Making Your First Contribution to the Galaxy Training Network</div>
+    <div class="gx-tile__body">
 
 Two tutorials were created for the Galaxy Training Network (GTN): **"Best Practices for Citing Galaxy"**—guiding proper attribution in publications—and **"Hybrid Genome Assembly – Nanopore and Illumina"**—a workflow for combining sequencing data. Both tutorials followed GTN standards to improve accessibility for researchers.
 
   </div>
+  </div>
 
-  <div class="card" style="flex: 1 1 280px;">
-    <div class="card-header">Improve User Defined Tools</div>
+  <div class="gx-tile">
+    <div class="gx-tile__title">Improve User Defined Tools</div>
+    <div class="gx-tile__body">
 
 Planemo was improved to support user-defined tools in Galaxy, enabling direct uploads to the Test Tool Shed and allowing resource requirements (CPU, RAM, GPU) to be specified. Community feedback refined functionality, while support for R scripts and documentation were enhanced to simplify tool development and deployment.
 
   </div>
+  </div>
 
-  <div class="card" style="flex: 1 1 280px;">
-    <div class="card-header">Galaxy tours - fixing existing ones and add tours for popular tools. </div>
+  <div class="gx-tile">
+    <div class="gx-tile__title">Galaxy tours - fixing existing ones and add tours for popular tools. </div>
+    <div class="gx-tile__body">
 
 This project focused on modernizing and enhancing the Galaxy interactive tours. Existing tours were thoroughly tested, and all HTML elements were replaced with standardized selectors as defined in the Galaxy navigation configuration. Every core tour was validated for functionality and accuracy, with detailed results documented. Additionally, help text from the deeptools Galaxy integration was converted into interactive tours, improving user guidance and accessibility. The updates ensured a more robust and user-friendly experience for navigating Galaxy’s features.
 
   </div>
-  <div class="card" style="flex: 1 1 280px;">
-    <div class="card-header">Biodiversity & Ecology Resources</div>
+  </div>
+  <div class="gx-tile">
+    <div class="gx-tile__title">Biodiversity & Ecology Resources</div>
+    <div class="gx-tile__body">
 
 This project curated Galaxy tools for biodiversity research, adding EDAM annotations and creating filtered collections for the **Ecology** and **Earth** SIGs. A wish list for new tools was developed, existing wrappers were reviewed and annotated, and contributions were made to **Bio.tools**—all to improve accessibility and support for researchers.
 
   </div>
+  </div>
 
-  <div class="card" style="flex: 1 1 280px;">
-    <div class="card-header">Galaxy ITs</div>
+  <div class="gx-tile">
+    <div class="gx-tile__title">Galaxy ITs</div>
+    <div class="gx-tile__body">
 
 Galaxy 24.0 introduced path-based ITs, removing the need for wildcard DNS/SSL and simplifying deployment. This project enabled direct URL path access for ITs, reducing technical barriers and improving flexibility, as outlined in the **[F1000 Research presentation](https://f1000research.com/slides/12-1163)**.
 
+  </div>
   </div>
 
 </div>

--- a/content/events/gcc2026/conduct/index.md
+++ b/content/events/gcc2026/conduct/index.md
@@ -4,7 +4,7 @@ autotoc: false
 
 # Code of Conduct
 
-<p class="lead">
+<p class="text-lg text-galaxy-grey">
 We are committed to providing a welcoming and inspiring community for all.
 If you participate in GCC2026, then you too are committed to this goal.
 </p>

--- a/content/events/gcc2026/fellowships/index.md
+++ b/content/events/gcc2026/fellowships/index.md
@@ -10,29 +10,17 @@ We are pleased to offer several fellowship opportunities to support attendance a
 
 We are please to annouce the two awardees of the [JJ Fund](https://jxtxfoundation.org/scholarships/jj-fund) !
 
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/zarlish-attique.jpg" style="max-height: 200px;" alt="Zarlish Attique" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/zarlish-attique.jpg" alt="Zarlish Attique" />
+  <div class="profile-row__bio">
 
 Zarlish Attique is a Bioinformatics Analyst (Level III) at Ayass Bioscience, USA (remote from Pakistan), specializing in large-scale transcriptomic and functional genomics with an emphasis on reproducible, workflow-driven computational biology. Her work focuses on the development of end-to-end, scalable pipelines for total RNA-seq (bulk and single-cell), CRISPR pooled and perturbation screens, and multi-omics integration, leveraging Nextflow, Linux-based environments, and cloud computing frameworks. She has engineered FASTQ-to-gene-effect systems integrating differential expression, guide-level enrichment and dysregulation, dependency-informed gene essentiality, and drug perturbation modeling to enable causality-driven therapeutic prioritization. Zarlish holds an MPhil in Bioinformatics from Quaid-i-Azam University (Chancellor Fellowship recipient) and a BS in Bioinformatics (Gold Medalist), and her research spans cancer genomics, including pancreatic and metastatic breast cancer, where she applied integrative multi-omics and deep neural network models (PCP-DNN) to identify regulatory hubs and mutation-agnostic drivers of disease progression. She has contributed to multiple peer-reviewed publications in immunoinformatics, computational drug discovery, and machine learning-based disease modeling, and is currently advancing agentic AI-driven frameworks for biomarker discovery and clinical decision support.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/priscilla-garcia.jpg" style="max-height: 200px;" alt="Priscilla Garcia" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/priscilla-garcia.jpg" alt="Priscilla Garcia" />
+  <div class="profile-row__bio">
 
 Priscilla Garcia is a Master’s student in Biological Sciences at California State University, Stanislaus, where she conducts research under the supervision of Dr. Tricia Van Laar. Her work focuses on how land use and seasonal hydrology influence microbial community composition and antibiotic resistance genes in freshwater systems, using a combination of field sampling, quantitative PCR, and sequencing approaches. She is particularly interested in microbial ecology, water quality, and applying bioinformatics tools to environmental systems.
 
@@ -40,69 +28,45 @@ In addition to her research, Priscilla is a Graduate Teaching Fellow, where she 
 
 Priscilla plans to pursue a Ph.D. in microbiology or bioinformatics, with a focus on environmental systems and antibiotic resistance. Outside of research, she enjoys spending time with her Chihuahua.
 
-<hr/>
+  </div>
+</div>
 
 ## JXTX Foundation Scholarships
 
 We are pleased to annouce the 3 awardees of the [JXTX Foundation](https://jxtxfoundation.org/) scholarships !
 
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/daniel-golparian.png" style="max-height: 200px;" alt="Daniel Golparian" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/daniel-golparian.png" alt="Daniel Golparian" />
+  <div class="profile-row__bio">
 
 Daniel Golparian is a Scientific Officer at the WHO Collaborating Centre for Gonorrhoea and Other STIs in Örebro, Sweden, and is affiliated with Örebro University Hospital, Örebro, Sweden. His research focuses on microbial genomics and antimicrobial resistance in Neisseria gonorrhoeae, with an emphasis on genomic surveillance, molecular epidemiology, and the evolution and spread of resistant lineages. He has contributed to international research on sexually transmitted infections and the application of genomics in public health microbiology.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/finn-beruldsen.jpg" style="max-height: 200px;" alt="Finn Beruldsen" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/finn-beruldsen.jpg" alt="Finn Beruldsen" />
+  <div class="profile-row__bio">
 
 Finn Beruldsen is a Ph.D. candidate in Biochemistry at the University of Houston whose work sits at the interface of molecular dynamics, computational immunology, and software development. He builds computational tools that help researchers better understand T-cell systems and make sense of complex simulation data, with a particular focus on RMSX and Flipbook for high-resolution analysis and visualization of protein motion in time and space. His broader research interests focus on building scientific software that makes complex biological data easier to interpret and more useful.
 
-<hr/>
-
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/olyad-erba.jpg" style="max-height: 200px;" alt="Olyad Erba Urgessa" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/olyad-erba.jpg" alt="Olyad Erba Urgessa" />
+  <div class="profile-row__bio">
 
 Olyad Erba Urgessa is an Assistant Professor and Senior Lecturer at Haramaya University, Ethiopia, currently pursuing a PhD in Animal Biotechnology at Adama Science and Technology University (ASTU). With over 13 years of academic experience, Olyad specializes in biotechnology and sustainable animal production solutions. His current research focuses on the "Omics" revolution in animal biotechnology, specifically feed enzyme production. As a JXTX Scholar, Olyad is dedicated to leveraging computational biology and Galaxy-based workflows to advance genomic research and mentorship in East Africa.
 
-<hr/>
-
+  </div>
+</div>
 
 ## Galaxy Community Fund Scholarships
 
 We are pleased to annouce the 18 awardees of the Galaxy Community Fund Scholarships (including 10 virtual 4 registration and 4 travel and registration) !
 
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/betselot.jpeg" style="max-height: 200px;" alt="Betselot Zerihun Ayano" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/betselot.jpeg" alt="Betselot Zerihun Ayano" />
+  <div class="profile-row__bio">
 
 Betselot Zerihun Ayano is a Bioinformatician at the Ethiopian Public Health Institute (EPHI),
 specializing in pathogen genomics and bioinformatics. He has contributed to infectious disease
@@ -115,47 +79,29 @@ epidemiological data to strengthen antimicrobial resistance (AMR) surveillance a
 health decision-making. He is also committed to building bioinformatics capacity and advancing
 genomic epidemiology in Ethiopia.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/kevin.JPG" style="max-height: 200px;" alt="Kevin Rue-Albrecht" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/kevin.JPG" alt="Kevin Rue-Albrecht" />
+  <div class="profile-row__bio">
 
 Kevin Rue-Albrecht is a researcher in single-cell biology and user-friendly genomic data analysis. He holds a Ph.D. in Computational Infection Biology from University College Dublin and has contributed to a wide range of high-impact biomedical research projects. He has led the development of several bioinformatics software packages for the analysis and interactive visualisation of diverse omics data types, including the interactive SummarizedExperiment Explorer (iSEE) framework.
 
 A long-time contributor to the Bioconductor project and an active community leader, he has played a key role in shaping initiatives that support sustainable open-source software, as well as mentoring and training in computational biology. He is a 2026 Software Sustainability Fellow and, since April 2026, leads a BioFAIR Pathfinder project focused on improving software discoverability in the life sciences.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/walter-randazzo.jpg" style="max-height: 200px;" alt="Walter Randazzo" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/walter-randazzo.jpg" alt="Walter Randazzo" />
+  <div class="profile-row__bio">
 
 Dr. Walter Randazzo focused his career on understanding how to prevent and control foodborne pathogens with the final goal of protecting public health by developing and evaluating novel strategies, technologies and processes. W. Randazzo received his BSc, MSc degrees in Agricultural Science and Food Technology (2009; 2012), and an International PhD in Agricultural Microbiology from the University of Palermo (Italy) (2015). He developed his research portfolio at UCC (Ireland), UPV (Spain), University of Valencia (Spain), Centre for Disease Prevention and Control (GA, USA), and IATA-CSIC (Spain) focusing on foodborne bacterial and viral pathogens. He has greatly contributed to develop methods for enteric virus detection in food and environment During 2020-22, he supported the Spanish SARS-CoV-2 wastewater-based epidemiology program validating a standard operating procedure for SARS-CoV-2 RNA detection implemented nationwide. Since Dec 2023, he is Principal Investigator of SafEATS group at the Institute of Agrochemistry and Food Technology (IATA) center of the National Research Council (CSIC). Dr. Randazzo has published more than 67 (WoS) scientific papers in high-rated Journals, with an h-index of 31 (WoS) and more than 3700 citations (Scopus). He contributed to 3 book chapters and presented more than 74 communications at congresses. He regularly contributes to editorial activities as reviewer, as Associated Editor for the Food Science and Technology International and Food Humanity journals, and as an external project evaluator for multiple international agencies. He attracted >650k € in research founds as PI and participated as a team member in 18 competitively funded (3 EU, 4 US, 8 Spain, 3 Italy) and 24 projects with private companies. He supervised 3 PhD, 34 MSc or BSc, and more than 10 visiting students. Dr. Randazzo is a member of several scientific societies (e.g., World Society for Virology, International Society of Food and Environmental Virology, European Virus Bioinformatics Center, SEM, IAFP), and scientific national networks (Red OneHealth4Food, Red PLASpain). He is currently the Chair of the Food Safety working group of the Plataforma Tecnológica Food for Life-Spain (PTF4LS). His research focuses on microbiological food safety by integrating well-stablished laboratory methods with novel strategies to prevent foodborne illness.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/prabhat.jpg" style="max-height: 200px;" alt="Prabhat Tripathi" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/prabhat.jpg" alt="Prabhat Tripathi" />
+  <div class="profile-row__bio">
 
 Prabhat Tripathi is an aspiring bioinformatician with a strong focus on computational biology, cancer research, and artificial intelligence. His work primarily revolves around the analysis of next-generation sequencing (NGS) data and the design of anti-cancer peptides, aiming to contribute to the development of novel therapeutic strategies for breast cancer.
 
@@ -165,31 +111,19 @@ Prabhat is deeply interested in generative AI applications in bioinformatics, pa
 
 Through his work, he aims to bridge the gap between computational approaches and real-world biomedical challenges, contributing to precision medicine and next-generation drug discovery.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/victor-lopez.jpg" style="max-height: 200px;" alt="Victor Lopez Rodriguez" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/victor-lopez.jpg" alt="Victor Lopez Rodriguez" />
+  <div class="profile-row__bio">
 
 Victor Lopez Rodriguez is a board-certified Medical Geneticist with a fellowship in ophthalmic genetics based in Mexico City, currently serving as a University Professor at Westhill University’s Faculty of Medicine and as a Master of Medical Sciences candidate at the Universidad Nacional Autónoma de México (UNAM). He is particularly interested in leveraging advanced genomic data analysis tools to improve diagnostic precision for rare genetic disorders.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/omnia.jpg" style="max-height: 200px;" alt="Omnia A. Elnasser" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/omnia.jpg" alt="Omnia A. Elnasser" />
+  <div class="profile-row__bio">
 
 Omnia A. Elnasser is a bioinformatics specialist, researcher, and teaching assistant with a strong focus on tissue bioengineering, regenerative medicine, and next-generation sequencing (NGS). She is currently working at the Tissue Bioengineering Department while also serving as a teaching assistant at the German University, where she mentors and trains students in bioinformatics and advanced molecular techniques.
 Omnia’s research bridges biotechnology and computational biology, with particular expertise in drug delivery systems, chronic wound healing, and microbiome-basedtherapies. She is a published author in Scientific Reports (Nature), contributing to innovative therapeutic formulations for antimicrobial and wound care applications. Her
@@ -198,152 +132,92 @@ Beyond academia, Omnia is the founder of Omnigenics, a biotechnology and bioinfo
 practical, industry-relevant skills. She is also actively involved in science communication and digital health content creation. Omnia manages medical and aesthetic content for wellness platforms and is the creator of the upcoming LinkedIn newsletter “Daily of Scientist,” where she shares insights on bioinformatics, research, and career development in science. With a vision to build a leading biotechnology company, Omnia aims to integrate
 bioinformatics, regenerative medicine, and material-based innovation to create impactful healthcare solutions. She is passionate about education, entrepreneurship, and advancing personalized medicine, positioning herself as a rising voice in the future of biotechnology.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/nadia.JPG" style="max-height: 200px;" alt="Nadia Afandi" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/nadia.JPG" alt="Nadia Afandi" />
+  <div class="profile-row__bio">
 
 Nadia Afandi is a PhD candidate in biosciences and bioinformatics at the International Islamic University Malaysia. Specializing in bacterial diseases in aquaculture. Her research investigates the bacterial community in the Pahang River and their impact on aquaculture sustainability, specifically in pathogen identification with virulence factors, and antimicrobial resistance (AMR) genes using bioinformatics tools.
 
 She utilizes the Galaxy platform for bioinformatics analyses, supporting her study including data quality analysis, pathogen identification, and AMR profiling. As a recipient of the GCC scholarship award, Nadia is committed to apply bioinformatics for future aquaculture research and contributing to the global Galaxy community.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/oluwapelumi.jpeg" style="max-height: 200px;" alt="Oluwapelumi Solagbade" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/oluwapelumi.jpeg" alt="Oluwapelumi Solagbade" />
+  <div class="profile-row__bio">
 
 Oluwapelumi Solagbade is a medical student and computational researcher at Obafemi Awolowo University in Nigeria, specializing in computational neuroscience and cognitive neurology. He is driven by a vision to build a multiscale understanding of the brain and its disease mechanisms, integrating spatial transcriptomics (omics) with macro-level neuroimaging. Deeply invested in global health equity, Oluwapelumi develops accessible, reproducible computational pipelines to empower researchers in resource-limited settings to analyze complex datasets. Beyond his technical research, he is the Co-founder and Director of the NeuroAspire Initiative, a youth-led organization democratizing neuroscience education in Nigeria.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/rcaccia.jpeg" style="max-height: 200px;" alt="Riccardo Caccia" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/rcaccia.jpeg" alt="Riccardo Caccia" />
+  <div class="profile-row__bio">
 
 Riccardo Caccia is a Medical Biotechnologist currently completing a Joint Master’s degree in Bioinformatics between the University of Milan and Politecnico di Milano. Working at the intersection of life sciences and high-performance computing, he is contributing to the Laniakea project within the ELIXIR-Italy framework. His work focuses on cloud orchestration and infrastructure automation, specifically designed to make Galaxy deployments seamless and accessible for the international research community.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/leman.png" style="max-height: 200px;" alt="Leman Nur Nehri" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/leman.png" alt="Leman Nur Nehri" />
+  <div class="profile-row__bio">
 
 Leman Nur Nehri completed her BSc, MSc, and PhD degrees in Biological Sciences at Middle East Technical University (METU). During her PhD, she focused on mathematical and computational modeling of colon cancer metastasis.
 She is currently a postdoctoral researcher at the University of Applied Sciences and Arts Northwestern Switzerland (FHNW), working on pancreatic and ovarian cancer modeling and translational oncology.
 Her research focuses on how alternative splicing reshapes the tumor microenvironment and influences metastasis. She investigates these processes using simulation and analytical approaches based on Bayesian and Markov probabilistic frameworks integrated with multi-omics data.
 In addition to her academic work, she provides bioinformatics and biological modeling consultancy to European pharmaceutical companies, particularly in therapeutic target discovery in immune hot and cold tumors.
 
-<hr/>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/niklas.jpeg" alt="Niklas Mayle" />
+  <div class="profile-row__bio">
 
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/niklas.jpeg" style="max-height: 200px;" alt="Niklas Mayle" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+Niklas Mayle is studying molecular medicine and is currently pursuing his Master’s degree in the Galaxy Team at the Albert Ludwigs University in Freiburg, Germany. Within his studies, he now specializes in bioinformatics, with a particular passion for exploring pangenomes and their application in personalized medicine. In his free time, he enjoys cooking, hiking outdoors, and developing mobile apps.
 
-Niklas Mayle is studying molecular medicine and is currently pursuing his Master’s degree in the Galaxy Team at the Albert Ludwigs University in Freiburg, Germany. Within his studies, he now specializes in bioinformatics, with a particular passion for exploring pangenomes and their application in personalized medicine. In his free time, he enjoys cooking, hiking outdoors, and developing mobile apps. 
-
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/abel.jpeg" style="max-height: 200px;" alt="Abel Asghedom" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/abel.jpeg" alt="Abel Asghedom" />
+  <div class="profile-row__bio">
 
 Abel Asghedom is an MSc student in Plant Breeding at Makerere University, Uganda, with a background in plant protection and crop improvement. He previously worked at the National Agricultural Research Institute (NARI) in Eritrea from 2013 to 2022, where he gained extensive experience in agricultural research and field-based crop improvement. His current research focuses on identifying genomic regions associated with disease resistance using phenotypic and molecular data. He has strong experience in field experimentation, statistical analysis, and working with diverse germplasm. Abel is passionate about developing resilient crop varieties and applying modern breeding approaches to improve agricultural productivity and food security in sub-Saharan Africa.
 
-<hr/>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/semhar.jpeg" alt="Semhar Yohannes" />
+  <div class="profile-row__bio">
 
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/semhar.jpeg" style="max-height: 200px;" alt="Semhar Yohannes" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+Semhar Yohannes is an Eritrean plant scientist currently pursuing a Master’s degree in Plant Breeding and Seed Systems at Makerere University, Uganda. She earned a Bachelor of Science in Horticulture and worked at the National Agricultural Research Institution in Eritrea (2016–2022), focusing on horticultural crops. Her interests include plant breeding, seed systems, and improving crop productivity to support sustainable agriculture and food security. She was also selected as a virtual participant for the Galaxy Conference 2025 in France.
 
-Semhar Yohannes is an Eritrean plant scientist currently pursuing a Master’s degree in Plant Breeding and Seed Systems at Makerere University, Uganda. She earned a Bachelor of Science in Horticulture and worked at the National Agricultural Research Institution in Eritrea (2016–2022), focusing on horticultural crops. Her interests include plant breeding, seed systems, and improving crop productivity to support sustainable agriculture and food security. She was also selected as a virtual participant for the Galaxy Conference 2025 in France. 
-
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/umesh.png" style="max-height: 200px;" alt="Umesh Bhati" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/umesh.png" alt="Umesh Bhati" />
+  <div class="profile-row__bio">
 
 Umesh Bhati is a computational biologist whose research integrates systems biology and deep learning to understand molecular interactions across biological scales. His work spans DNA–DNA interactions using Hi-C based DL models, transcription factor–DNA binding, and protein–protein interactions, combining sequence, structural, and physicochemical insights. He focuses on moving beyond sequence similarity to uncover generalizable biophysical principles of molecular recognition. He has developed integrative, multi-omics frameworks that incorporate transcriptomics, structural predictions, and network biology to reconstruct condition-specific interaction networks in complex systems. His research also emphasizes explainable AI to ensure mechanistic interpretability of deep learning models. Umesh’s work has been published in reputed journals, including Plant
 Communications and Briefings in Bioinformatics. He is driven by a strong interest in applying AI to decode dynamic cellular systems and uncover hidden regulatory mechanisms.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/fabien.JPG" style="max-height: 200px;" alt="Fabien Zimbombe Vulu" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/fabien.JPG" alt="Fabien Zimbombe Vulu" />
+  <div class="profile-row__bio">
 
 Dr. Fabien Zimbombe Vulu is a medical doctor and researcher specializing in tropical medicine, medical entomology, and infectious disease. He is currently a Postdoctoral Research Associate affiliated with the University of Kinshasa and the National Institute of Biomedical Research (INRB) in the Democratic Republic of the Congo, where his work focuses on malaria genomic surveillance and the analysis of antimalarial drug resistance markers. He also completed a postdoctoral fellowship at the University of North Carolina at Chapel Hill (USA), where he further advanced his work on the genomic analysis of antimalarial drug resistance.
 
 Dr. Vulu obtained his PhD in Infection Research from Nagasaki University (Japan), where his research investigated the geographic distribution and population genetics of Aedes albopictus in the Democratic Republic of the Congo. Dr. Vulu has extensive experience in both field and laboratory research on vector-borne diseases, including malaria, dengue, and chikungunya. His work integrates molecular biology, epidemiology, and bioinformatics to better understand disease transmission and inform control strategies in resource-limited settings. He has contributed to multiple international collaborations and has authored several peer-reviewed publications on malaria and arbovirus vectors in Central Africa, including recent work on malaria cohort studies
 and the expansion and virome diversity of Aedes mosquitoes in the region.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/joe-ueda.jpeg" style="max-height: 200px;" alt="Joe Ueda" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/joe-ueda.jpeg" alt="Joe Ueda" />
+  <div class="profile-row__bio">
 
 Joe is a bioinformatician at InforBio, the bioinformatics platform of the Institut de Biologie Paris Seine at Sorbonne University. Joe has developed a particular interest in small non-coding RNAs (sncRNAs).
 
@@ -351,21 +225,18 @@ After obtaining an MSc in Bioinformatics from Université Claude Bernard Lyon 1,
 
 In this context, he is developing a ChIP-seq analysis tool suite and associated workflows on the Galaxy platform. Through this work, Joe aims to provide accessible and reproducible analysis frameworks, along with training materials for the Galaxy Training Network, to support collaborators and the broader scientific community. He looks forward to participating in GCC2026 to connect with the Galaxy community, share insights, and further develop his expertise in collaborative and reproducible research.
 
-<hr/>
-
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/Shubham_headshot.png" style="max-height: 200px;" alt="Shubham Koirala" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="profile-row">
+  <img class="profile-row__photo" src="/images/events/gcc2026/Shubham_headshot.png" alt="Shubham Koirala" />
+  <div class="profile-row__bio">
 
 Shubham Koirala is a researcher in genetics and computational biology, currently pursuing a Ph.D. in Genetics and Genome Sciences Program at Michigan State University. His work focuses on applying machine learning and data-driven approaches to understand complex diseases with an emphasis on biomarker discovery and precision medicine.
 
 Originally from Nepal, Shubham completed his undergraduate studies in biotechnology at Kathmandu University, where he developed a strong foundation in molecular biology and bioinformatics. He later expanded his expertise by integrating computational techniques with biological research, enabling him to work at the intersection of data science and life sciences.  His research interests include transcriptomics, genomics, and the use of artificial intelligence to uncover patterns in large-scale biomedical data. Through his work, he aims to contribute to more accurate diagnostics and personalized treatment strategies.
+
+  </div>
+</div>
 
 ## Questions?
 

--- a/content/events/gcc2026/index.md
+++ b/content/events/gcc2026/index.md
@@ -26,7 +26,7 @@ contributions:
 #### Plus [CoFest](/events/gcc2026/cofest/)! June 25-26, 2026
 ### Held at IUT Clermont Auvergne University in the spectacular [Clermont-Ferrand, France](https://maps.app.goo.gl/g3g3MMivnyHMxVM16)
 
-  <div class="lead">
+  <div class="text-lg text-galaxy-grey max-w-3xl mx-auto">
     The annual gathering of the Galaxy community — researchers, developers, educators, and users from around the world — to share science, build connections, and shape the future of open data analysis.
   </div>
   <div class="flex flex-wrap justify-center gap-3 my-5">
@@ -37,128 +37,53 @@ contributions:
 
 ## Event highlights
 
-<div class="card-deck lead">
+<div class="gx-tile-grid">
 
-  <!-- About GCC -->
-  <div class="card" style="flex: 1 1 280px;">
-    <img src="/images/events/gcc2026/group_photo.jpg" class="card-img-top" style="height: 280px; object-fit: cover;" alt="GCC conference attendees" />
-    <div class="card-header">About GCC conference series</div>
+<a class="gx-tile gx-tile--link" href="/gcc">
+  <img class="gx-tile__media" src="/images/events/gcc2026/group_photo.jpg" alt="GCC conference attendees" />
+  <div class="gx-tile__title">About the GCC conference series</div>
+  <p class="gx-tile__teaser">The Galaxy Community Conference has been the community's central gathering since 2010 — where the people who use, build, and teach Galaxy come together to share work and shape what comes next.</p>
+  <span class="gx-tile__more">Learn more →</span>
+</a>
 
-The [Galaxy Community Conference (GCC)](/gcc) has been the central gathering of the Galaxy
-community since 2010. GCC brings together everyone who uses, builds, or teaches Galaxy —
-from students running their first analyses to developers building the platform and
-researchers publishing high-impact results with it.
+<a class="gx-tile gx-tile--link" href="/events/gcc2026/highlights/">
+  <img class="gx-tile__media" src="/images/events/gcc2026/keynote.jpg" alt="GCC2026 keynote presentation" />
+  <div class="gx-tile__title">Highlighted talks</div>
+  <p class="gx-tile__teaser">Invited keynotes, community talks, and open discussion — including Galaxy Live!, a keynote from Rayan Chikhi on petabyte-scale sequencing, and the Galaxy Community Update.</p>
+  <span class="gx-tile__more">See the talks →</span>
+</a>
 
-The conference spans invited keynotes, community-submitted talks, hands-on training, and
-the informal conversations that often turn out to be just as valuable as anything on the
-schedule. **It's where new collaborations begin, ideas get pressure-tested, and the
-community collectively decides what Galaxy becomes next.**
+<a class="gx-tile gx-tile--link" href="/events/gcc2026/fellowships/">
+  <img class="gx-tile__media" src="/images/events/gcc2026/fellowship.jpg" alt="GCC2026 fellowship recipients" />
+  <div class="gx-tile__title">GCC2026 fellowships</div>
+  <p class="gx-tile__teaser">Financial support shouldn't be a barrier. Awards from the JXTX Foundation, the JJ Fund, and the Galaxy Community Fund help cover registration, travel, and accommodation.</p>
+  <span class="gx-tile__more">See fellowship details →</span>
+</a>
 
-  </div>
+<a class="gx-tile gx-tile--link" href="https://www.uca.fr/" target="_blank" rel="noopener noreferrer">
+  <img class="gx-tile__media" src="/images/events/gcc2026/cartoon-clermont-auvergne-v2.png" alt="GCC2026 host: Université Clermont Auvergne" />
+  <div class="gx-tile__title">GCC2026 host</div>
+  <p class="gx-tile__teaser">GCC2026 is hosted by the Université Clermont Auvergne — a dynamic research university of 35,000+ students and 40+ research units, and home to the AuBi bioinformatics platform.</p>
+  <span class="gx-tile__more">Visit UCA →</span>
+</a>
 
-  <!-- Highlights -->
-  <div class="card" style="flex: 1 1 280px;">
-    <img src="/images/events/gcc2026/keynote.jpg" class="card-img-top" style="height: 280px; object-fit: cover;" alt="GCC2026 keynote presentation" />
-    <div class="card-header">Highlighted Talks</div>
+<a class="gx-tile gx-tile--link" href="/events/gcc2026/cofest/">
+  <img class="gx-tile__media" src="/images/events/gcc2026/cofest.jpg" alt="GCC2026 CoFest participants" />
+  <div class="gx-tile__title">GCC2026 CoFest</div>
+  <p class="gx-tile__teaser">Two days of hands-on, community-driven work right after the conference. Contribute to tools, workflows, docs, or training — everyone's welcome, whatever your background.</p>
+  <span class="gx-tile__more">Join CoFest →</span>
+</a>
 
-GCC2026 features a program of invited keynotes, community talks, and open discussions
-covering the latest in Galaxy development, real-world research applications, and the
-future of open data analysis. This year's highlights include:
-
-  <ul>
-    <li><strong>Galaxy Live!</strong> — A live, on-stage reveal of new Galaxy features</li>
-    <li><strong>Rayan Chikhi</strong> — Keynote on assembling and exploring petabyte-scale sequencing data</li>
-    <li><strong>Galaxy Community Update</strong> — The state of the ecosystem, from the people building it</li>
-    <li><strong>Panel Discussion</strong> — An open conversation on what matters most to the community</li>
-    <li><strong>Galaxy in Research</strong> — Cutting-edge science powered by Galaxy</li>
-  </ul>
-
-**See the [highlighted talks page](/events/gcc2026/highlights/) for details.**
-
-  </div>
-
-  <!-- Fellowships -->
-  <div class="card" style="flex: 1 1 280px;">
-    <img src="/images/events/gcc2026/fellowship.jpg" class="card-img-top" style="height: 280px; object-fit: cover;" alt="GCC2026 fellowship recipients" />
-    <div class="card-header">GCC2026 Fellowships</div>
-
-Financial support should not be a barrier to participating in the Galaxy community.
-Several fellowship opportunities are available to assist attendees who need support
-to attend GCC2026.
-
-Awards from the **JXTX Foundation**, the **JJ Fund**, and the **Galaxy Community Fund**
-cover registration, travel, and accommodation for graduate students, postdoctoral
-researchers, and early-career scientists — with particular consideration for applicants
-from underrepresented backgrounds and lower-resourced institutions.
-
-**Eligible researchers are encouraged to apply.** See the [fellowships page](/events/gcc2026/fellowships/)
-for full details on eligibility and application deadlines.
-  </div>
-
-  <!-- Host -->
-  <div class="card" style="flex: 1 1 280px;">
-    <img src="/images/events/gcc2026/cartoon-clermont-auvergne-v2.png" class="card-img-top" style="height: 280px; object-fit: cover;" alt="GCC2026 host" />
-    <div class="card-header">GCC2026 Host</div>
-
-**GCC2026 is hosted by the [Université Clermont Auvergne](https://www.uca.fr/)
-(UCA)**. UCA is a modern, dynamic research university born from the merger of two
-prominent institutions in 2017, now unifying diverse strengths across science,
-engineering, health, and humanities. With over 35,000 students and more than 40
-research units, UCA is deeply integrated into local and international research
-networks, committed to fostering interdisciplinary exchange and scientific
-excellence.
-
-Among other initiatives, UCA also supports the [AuBi bioinformatics
-platform](https://www.france-genomique.org/platforms-and-equipments/plateforme-de-bio-informatique-de-clermont-ferrand-aubi/?lang=en),
-which administers a local Galaxy instance.
-
-The Galaxy project is thrilled to be hosted by UCA!
-
-  </div>
-
-  <!-- Cofest -->
-  <div class="card" style="flex: 1 1 280px;">
-    <img src="/images/events/gcc2026/cofest.jpg" class="card-img-top" style="height: 280px; object-fit: cover;" alt="GCC2026 CoFest participants" />
-    <div class="card-header">GCC2026 CoFest</div>
-
-CoFest is two days of hands-on, community-driven work immediately following the main
-conference. Participants self-organize into groups and spend the time contributing
-to whatever they care about most — new tools and workflows, platform improvements,
-documentation, training materials, or helping new contributors find their footing.
-
-**Anyone is welcome, regardless of technical background.** Some groups write code;
-others work on tutorials, use cases, or community infrastructure. CoFest is one of
-the most direct ways to shape what Galaxy looks like next year.
-
-Join us at **[CoFest](/events/gcc2026/cofest/)**
-
-  </div>
-
-  <!-- Destination -->
-  <div class="card" style="flex: 1 1 280px;">
-    <img src="/images/events/gcc2026/clermont.jpg" class="card-img-top" style="height: 280px; object-fit: cover;" alt="Clermont-Ferrand, France" />
-    <div class="card-header">Clermont-Ferrand, France</div>
-
-**Nestled in the heart of central France**, Clermont-Ferrand is a city framed by
-dramatic volcanic landscapes and rich history. Dominated by the striking black
-lava-stone cathedral and surrounded by the [Chaîne des
-Puys](https://volcan.puy-de-dome.fr/volcans/chaine-des-puys.html) — a UNESCO
-World Heritage site of ancient volcanoes — the city offers an inspiring mix of
-natural beauty and architectural wonder.
-
-Conference participants can look forward to vibrant cultural experiences, from
-strolling through charming medieval streets to enjoying lively cafés and local
-gastronomy. With its dynamic university atmosphere and welcoming spirit,
-Clermont-Ferrand provides the perfect setting for stimulating academic exchange
-and memorable discoveries.
-
-The **[travel page](/events/gcc2026/travel/) has more details.**
-
-  </div>
+<a class="gx-tile gx-tile--link" href="/events/gcc2026/travel/">
+  <img class="gx-tile__media" src="/images/events/gcc2026/clermont.jpg" alt="Clermont-Ferrand, France" />
+  <div class="gx-tile__title">Clermont-Ferrand, France</div>
+  <p class="gx-tile__teaser">A walkable medieval city framed by the volcanic Chaîne des Puys, a UNESCO World Heritage site — an inspiring setting for the conference.</p>
+  <span class="gx-tile__more">Plan your trip →</span>
+</a>
 
 </div>
 
-# Stay informed
+## Stay informed
 
 Sign up for the GCC2026 announcement list to receive updates on registration,
 abstract submission deadlines, program announcements, and fellowship opportunities.
@@ -167,14 +92,6 @@ Low volume — only what matters.
   <a target="_blank" href="https://gaggle.email/join/gcc2026-announce@gaggle.email" class="inline-flex items-center justify-center rounded px-8 py-2 text-sm font-semibold text-white bg-galaxy-primary hover:bg-galaxy-dark no-underline hover:no-underline">Join GCC2026 Announce mailing list</a>
 </div>
 
-# Conference logo
+## Conference logo
 
-<table style="width: 100%">
-  <tbody>
-    <tr class="lead text-left" style="background-color: white">
-      <td style="border: 0; width: 20%;">
-        <img src="/images/events/gcc2026/gcc2026-logo.png" style="max-height: 200px;" alt="Conference Logo" />
-      </td>
-    </tr>
-  </tbody>
-</table>
+<img src="/images/events/gcc2026/gcc2026-logo.png" alt="GCC2026 Conference Logo" style="max-height: 200px;" />

--- a/content/events/gcc2026/training/index.md
+++ b/content/events/gcc2026/training/index.md
@@ -9,7 +9,7 @@ learn new concepts, get some practical, hands-on training, interact with others
 working in the similar space, and get answers for any questions you have by the
 top experts on the topic.
 
-<div class="alert alert-info text-center" style="font-size: 1.1rem; margin: 2rem 0;">
+<div class="callout text-center" style="font-size: 1.1rem;">
   <strong>Training takes place on June 25–26</strong>, immediately following the main conference days (June 22–24).
   These sessions run in parallel with <a href="/events/gcc2026/cofest/">CoFest</a> — you can attend training on one or both days,
   and switch between training and CoFest activities as your interests dictate.
@@ -20,45 +20,53 @@ top experts on the topic.
 
 <!-- Day 1 -->
 <div style="margin-bottom: 40px;">
-<h2 style="text-align: center; background-color: #ddeeff; padding: 20px; border-radius: 10px;"><b>Day 1</b> — Thursday, June 25</h2>
-<h3 style="text-align: center; margin-left: 5%; width: 90%; background-color: #d0e6ff; padding: 10px; border-radius: 10px;">Session 1 (9:00 am – 12:00 pm)</h3>
-<p style="text-align: center; color: #555;">Four parallel tracks — choose the one that fits your interests.</p>
+<h2 style="text-align: center; background-color: var(--color-bay-of-many-100); padding: 20px; border-radius: 0.5rem;"><b>Day 1</b> — Thursday, June 25</h2>
+<h3 style="text-align: center; margin-left: 5%; width: 90%; background-color: var(--color-bay-of-many-200); padding: 10px; border-radius: 0.5rem;">Session 1 (9:00 am – 12:00 pm)</h3>
+<p style="text-align: center; color: var(--color-galaxy-grey);">Four parallel tracks — choose the one that fits your interests.</p>
 
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.25rem;">
+<div class="gx-tile-grid">
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">Earth Science & Ecology</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">Earth Science & Ecology</div>
+<div class="gx-tile__body">
 
 A hands-on introduction to Galaxy for environmental and ecological research,
 covering tools and workflows for biodiversity analysis, earth observation, and
 ecological modeling. More details coming soon.
 
 </div>
+</div>
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">Tool Wrapping</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">Tool Wrapping</div>
+<div class="gx-tile__body">
 
 Learn how to bring your own command-line tools into Galaxy, from writing the
 wrapper to testing and publishing. More details coming soon.
 
 </div>
+</div>
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">Galaxy in Practice: Two Perspectives</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">Galaxy in Practice: Two Perspectives</div>
+<div class="gx-tile__body">
 
 An experienced Galaxy user and a newcomer work through the same analysis
 side by side, narrating their thinking in real time. A practical look at how
 Galaxy feels at different stages of familiarity. More details coming soon.
 
 </div>
+</div>
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">Machine Learning for Genomics</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">Machine Learning for Genomics</div>
+<div class="gx-tile__body">
 
 An introduction to building Galaxy workflows for NGS data analysis, with a focus
 on integrating machine learning models for tasks like disease classification and
 variant prioritization. More details coming soon.
 
+</div>
 </div>
 
 </div>
@@ -66,46 +74,54 @@ variant prioritization. More details coming soon.
 
 <!-- Day 2 -->
 <div style="margin-bottom: 40px;">
-<h2 style="text-align: center; background-color: #ddeeff; padding: 20px; border-radius: 10px;"><b>Day 2</b> — Friday, June 26</h2>
-<h3 style="text-align: center; margin-left: 5%; width: 90%; background-color: #d0e6ff; padding: 10px; border-radius: 10px;">Session 2 (9:00 am – 12:00 pm)</h3>
-<p style="text-align: center; color: #555;">Four parallel tracks — choose the one that fits your interests.</p>
+<h2 style="text-align: center; background-color: var(--color-bay-of-many-100); padding: 20px; border-radius: 0.5rem;"><b>Day 2</b> — Friday, June 26</h2>
+<h3 style="text-align: center; margin-left: 5%; width: 90%; background-color: var(--color-bay-of-many-200); padding: 10px; border-radius: 0.5rem;">Session 2 (9:00 am – 12:00 pm)</h3>
+<p style="text-align: center; color: var(--color-galaxy-grey);">Four parallel tracks — choose the one that fits your interests.</p>
 
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.25rem;">
+<div class="gx-tile-grid">
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">Developers Do Bioinformatics</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">Developers Do Bioinformatics</div>
+<div class="gx-tile__body">
 
 Core Galaxy developers work through a complete bioinformatics analysis from
 scratch, narrating their experience live. An honest look at Galaxy from the
 perspective of the people who build it. More details coming soon.
 
 </div>
+</div>
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">ChIP-seq, CUT&RUN & RNA-seq Analysis</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">ChIP-seq, CUT&RUN & RNA-seq Analysis</div>
+<div class="gx-tile__body">
 
 End-to-end processing of ChIP-seq, CUT&RUN, CUT&Tag, and RNA-seq data in
 Galaxy — from raw FASTQ files through alignment, peak calling, visualization,
 and differential analysis. More details coming soon.
 
 </div>
+</div>
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">Mass Spectrometry & Advanced Tool Development</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">Mass Spectrometry & Advanced Tool Development</div>
+<div class="gx-tile__body">
 
 A session covering mass spectrometry data analysis alongside advanced Galaxy
 tool development topics including expression tools, parameter sweeps, custom
 visualizations, and interactive tools. More details coming soon.
 
 </div>
+</div>
 
-<div class="card" style="box-shadow: 0 4px 12px rgba(0,0,0,0.1); border-left: 4px solid #25537b;">
-<div class="card-header" style="font-size: 1.1rem;">Multi-Omics: Single-Cell, Spatial & Beyond</div>
+<div class="gx-tile gx-tile--feature">
+<div class="gx-tile__title">Multi-Omics: Single-Cell, Spatial & Beyond</div>
+<div class="gx-tile__body">
 
 Reproducible multi-omics analysis in Galaxy, spanning single-cell and spatial
 omics, genome alignment and annotation, and proteomics and metabolomics workflows.
 More details coming soon.
 
+</div>
 </div>
 
 </div>

--- a/content/events/gcc2026/travel/index.md
+++ b/content/events/gcc2026/travel/index.md
@@ -69,12 +69,12 @@ If you are searching for accommodations independently, you may wish to look near
 
 # Local Attractions
 
-<div class="card-deck lead">
+<div class="gx-tile-grid">
 
-  <div class="card" style="flex: 1 1 340px;">
-    <img src="/images/events/gcc2026/clermont_ferrand.jpg" class="card-img-top" alt="Clermont-Ferrand, France" />
-    <div class="card-header">Historic City Center</div>
-    <div style="font-size: 0.9rem;">
+  <div class="gx-tile">
+    <img src="/images/events/gcc2026/clermont_ferrand.jpg" class="gx-tile__media" alt="Clermont-Ferrand, France" />
+    <div class="gx-tile__title">Historic City Center</div>
+    <div class="gx-tile__body">
 
 Clermont-Ferrand blends **medieval charm, volcanic stone architecture, and lush green spaces**. The city's skyline is dominated by the **Cathedral of Our Lady of the Assumption**, an extraordinary Gothic masterpiece built entirely from dark volcanic lava, its lace-like spires rising above the rooftops. Not far away, the **Romanesque Basilica of Notre-Dame du Port** showcases warm blond arkose stone, intricate carved capitals, and its famous Black Madonna.
 
@@ -82,14 +82,14 @@ The city is home to two medieval hearts — **Clermont and Montferrand** — eac
 
 For a breath of fresh air, the **Lecoq Garden** provides a serene 19th-century oasis in the city center, while the nearby **Henri Lecoq Museum** houses vast natural science collections. For sweeping views of the city and the surrounding volcanoes, the hilltop **Montjuzet Park** offers cypress-lined paths, wide lawns, and a perfect picnic spot overlooking the **Auvergne landscape**.
 
-<small>[Photo Flickr](https://flic.kr/p/2o9YVCc) by [Bérénice Batut](https://www.flickr.com/photos/134305289@N03) (CC BY SA 2.0)</small>
+<small class="gx-tile__credit">[Photo Flickr](https://flic.kr/p/2o9YVCc) by [Bérénice Batut](https://www.flickr.com/photos/134305289@N03) (CC BY SA 2.0)</small>
     </div>
   </div>
 
-  <div class="card" style="flex: 1 1 340px;">
-    <img src="/images/events/gcc2026/michelin.jpg" class="card-img-top" alt="Clermont-Ferrand, France" />
-    <div class="card-header">Aventure Michelin</div>
-    <div style="font-size: 0.9rem;">
+  <div class="gx-tile">
+    <img src="/images/events/gcc2026/michelin.jpg" class="gx-tile__media" alt="Clermont-Ferrand, France" />
+    <div class="gx-tile__title">Aventure Michelin</div>
+    <div class="gx-tile__body">
 
 Founded in **1889** in Clermont-Ferrand by Édouard and André Michelin, the company revolutionized mobility with inventions like the **detachable bicycle tire** and the **radial tire**, reshaping the automotive industry.
 
@@ -97,14 +97,14 @@ At **[L'Aventure Michelin](https://laventure.michelin.com/en/)**, discover the b
 
 A must-visit for history buffs, car enthusiasts, and anyone curious about innovation, **L'Aventure Michelin** brings to life the story of a brand that keeps the world moving forward.
 
-<small>[Photo Wikimedia](https://commons.wikimedia.org/wiki/File:Fourgonnette_Citro%C3%ABn_type_H_Michelin.jpg) (CC0 1.0)</small>
+<small class="gx-tile__credit">[Photo Wikimedia](https://commons.wikimedia.org/wiki/File:Fourgonnette_Citro%C3%ABn_type_H_Michelin.jpg) (CC0 1.0)</small>
     </div>
   </div>
 
-  <div class="card" style="flex: 1 1 340px;">
-    <img src="/images/events/gcc2026/pariou.jpg" class="card-img-top" alt="Clermont-Ferrand, France" />
-    <div class="card-header">The Puy de Dôme</div>
-    <div style="font-size: 0.9rem;">
+  <div class="gx-tile">
+    <img src="/images/events/gcc2026/pariou.jpg" class="gx-tile__media" alt="Clermont-Ferrand, France" />
+    <div class="gx-tile__title">The Puy de Dôme</div>
+    <div class="gx-tile__body">
 
 The iconic **Puy de Dôme** volcano dominates the skyline **just 15 km west of the city** and is an absolute must-see. At **1,465 meters**, this dormant volcano offers **spectacular panoramic views** of the entire **Chaîne des Puys volcanic range** and the surrounding countryside. You can reach the summit effortlessly aboard the **Panoramique des Dômes train** — a scenic **15-minute ride** — or hike up one of several trails.
 
@@ -112,14 +112,14 @@ The Puy de Dôme is a **UNESCO World Heritage site** and home to ancient **Roman
 
 To reach the Puy de Dôme it's around 25min from the city center or there's shuttle bus called ["La navette du Panoramique des Dômes"](https://www.panoramiquedesdomes.fr/comment-venir/) (free on weekends) for a convenient and eco-friendly option.
 
-<small>[Photo Flickr](https://flic.kr/p/KkbRKp) by [Bérénice Batut](https://www.flickr.com/photos/134305289@N03) (CC BY SA 2.0)</small>
+<small class="gx-tile__credit">[Photo Flickr](https://flic.kr/p/KkbRKp) by [Bérénice Batut](https://www.flickr.com/photos/134305289@N03) (CC BY SA 2.0)</small>
     </div>
   </div>
 
-  <div class="card" style="flex: 1 1 340px;">
-    <img src="/images/events/gcc2026/lemptegy.jpg" class="card-img-top" alt="Clermont-Ferrand, France" />
-    <div class="card-header">Vulcania & Volcan de Lemptegy</div>
-    <div style="font-size: 0.9rem;">
+  <div class="gx-tile">
+    <img src="/images/events/gcc2026/lemptegy.jpg" class="gx-tile__media" alt="Clermont-Ferrand, France" />
+    <div class="gx-tile__title">Vulcania & Volcan de Lemptegy</div>
+    <div class="gx-tile__body">
 
 Just **15 kilometers from Clermont-Ferrand**, the Auvergne region unveils two of its most captivating volcanic treasures, offering a blend of education, adventure, and natural wonder.
 
@@ -129,7 +129,7 @@ For those seeking a more **hands-on encounter** with Auvergne's volcanic legacy,
 
 Together, these two sites provide a **fascinating exploration** of the Auvergne's volcanic landscape, where the Earth's power and beauty are on full display.
 
-<small>[Photo Flickr](https://flic.kr/p/2oXM342) by [Bérénice Batut](https://www.flickr.com/photos/134305289@N03) (CC BY SA 2.0)</small>
+<small class="gx-tile__credit">[Photo Flickr](https://flic.kr/p/2oXM342) by [Bérénice Batut](https://www.flickr.com/photos/134305289@N03) (CC BY SA 2.0)</small>
     </div>
   </div>
 </div>
@@ -148,34 +148,34 @@ Must-try specialties include:
 
 No visit is complete without sampling **Puy lentils**, a prized local delicacy renowned for their **nutty flavor and firm texture**. Whether you're indulging in a rustic meal or exploring gourmet creations, Auvergne's cuisine promises an unforgettable taste of its volcanic terroir.
 
-<div class="card-deck lead">
-  <div class="card" style="flex: 1 1 200px;">
-    <img src="/images/events/gcc2026/saint_nectaire.jpg" class="card-img-top" alt="Saint-Nectaire" />
-    <div style="font-size: 0.9rem;">
+<div class="gx-tile-grid">
+  <div class="gx-tile">
+    <img src="/images/events/gcc2026/saint_nectaire.jpg" class="gx-tile__media" alt="Saint-Nectaire" />
+    <div class="gx-tile__body">
     
 Saint-Nectaire
 
-<small>[Photo Flickr](https://flic.kr/p/KdVUDV) by [Julien Four](https://www.flickr.com/photos/julienfour/)</small>
+<small class="gx-tile__credit">[Photo Flickr](https://flic.kr/p/KdVUDV) by [Julien Four](https://www.flickr.com/photos/julienfour/)</small>
     </div>
   </div>
   
-  <div class="card" style="flex: 1 1 200px;">
-    <img src="/images/events/gcc2026/aligot.jpg" class="card-img-top" alt="Saint-Nectaire" />
-    <div style="font-size: 0.9rem;">
+  <div class="gx-tile">
+    <img src="/images/events/gcc2026/aligot.jpg" class="gx-tile__media" alt="Saint-Nectaire" />
+    <div class="gx-tile__body">
 
 Aligot
 
-<small>Photo by Bérénice Batut</small>
+<small class="gx-tile__credit">Photo by Bérénice Batut</small>
     </div>
   </div>
   
-  <div class="card" style="flex: 1 1 200px;">
-    <img src="/images/events/gcc2026/lentilles.jpg" class="card-img-top" alt="Saint-Nectaire" />
-    <div style="font-size: 0.9rem;">
+  <div class="gx-tile">
+    <img src="/images/events/gcc2026/lentilles.jpg" class="gx-tile__media" alt="Saint-Nectaire" />
+    <div class="gx-tile__body">
 
 Lentilles verte du Puy
 
-<small>[Photo Wikimedia](https://commons.wikimedia.org/wiki/File:Lentille_verte_du_Puy.jpg)</small>
+<small class="gx-tile__credit">[Photo Wikimedia](https://commons.wikimedia.org/wiki/File:Lentille_verte_du_Puy.jpg)</small>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

The GCC2026 pages were leaning on the legacy Bootstrap (`.bs-compat`) card/alert/table classes, and the landing page's "Event highlights" was six very tall content-dump cards. This refreshes all six GCC2026 pages and removes their Bootstrap usage entirely.

- **Landing page:** the highlights are now compact teaser tiles (image + title + a one-line hook + a link to the relevant subpage), so the section fits about one screen instead of a long scroll. The full content still lives on the subpages.
- **Reusable styles** added to `global.css`: a `gx-tile` card/grid system (with a link variant that gets the signature gold hover bar, and a feature variant), a `callout` box (replaces `alert-*`), and a `profile-row` (photo + bio, used for the fellowship awardees). They're named `gx-tile` rather than `card` because the content preprocessor marks any `card`/`alert`/`lead`/`table` class as `.bs-compat` -- the new names keep this content out of the compat layer.
- **All six pages converted:** index (teaser tiles), cofest (callout + tiles), training (callout + feature tiles + brand-token headers in place of hardcoded hex), travel (attraction + culinary tiles), fellowships (22 awardee layout-tables -> profile rows), conduct (lead paragraph). None carry `.bs-compat` anymore.
- **DESIGN.md** documents the new patterns so they're the sanctioned, reusable path for future conferences.

Card images and all existing prose/bios are unchanged; the landing-page teaser copy is new (trimmed hooks that link out).

## Screenshots

Landing page, before / after:

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/dannon/galaxy-hub/pr-assets-gcc-refresh/index-before.png" width="380"> | <img src="https://raw.githubusercontent.com/dannon/galaxy-hub/pr-assets-gcc-refresh/index-after.png" width="380"> |

Fellowships -- awardee tables are now profile rows (stack on mobile):

<img src="https://raw.githubusercontent.com/dannon/galaxy-hub/pr-assets-gcc-refresh/fellowships-after.png" width="420">

Callout + content tiles (cofest):

<img src="https://raw.githubusercontent.com/dannon/galaxy-hub/pr-assets-gcc-refresh/cofest-after.png" width="420">

## Test plan

- [x] `npm run build` passes (5366 pages)
- [x] `npm run test:unit` passes (174 tests)
- [x] `npm run lint` + `prettier --check` clean
- [x] No `.bs-compat` on any GCC2026 page artifact; new classes don't leak to other content
- [x] Visual check at desktop + mobile (teaser grid, callouts, feature tiles, profile rows stack on mobile)