### PR TITLE
docs(orbit): Intel DMG, download table, + clarity-sync fixes (beta, feedback channel, sign-in label)

### DIFF
--- a/content/tools/orbit/index.md
+++ b/content/tools/orbit/index.md
@@ -59,20 +59,15 @@ All installers are on the [Releases page](https://github.com/galaxyproject/loom/
 
 ### macOS
 
-Download `Orbit-<version>-arm64.dmg` from the [Releases page](https://github.com/galaxyproject/loom/releases).
+From the [Releases page](https://github.com/galaxyproject/loom/releases), download the `.dmg` for your chip:
+
+- **Apple Silicon** (M1/M2/M3/M4): `Orbit-<version>-arm64.dmg`
+- **Intel**: `Orbit-<version>-x64.dmg` — supported from **v0.3.1** onward
+
+Not sure which you have? Apple menu → **About This Mac**: a line reading **"Chip: Apple M…"** is Apple Silicon (use **arm64**); **"Processor: Intel…"** is Intel (use **x64**).
 
 1. Double-click the DMG and drag **Orbit** to **Applications**.
-2. Eject the DMG.
-
-<div class="callout">
-<strong>Intel Mac users:</strong> No pre-built installer is available for Intel Macs yet. Run Orbit from Terminal using either method below. Node.js 22.19+ is required (<a href="https://nodejs.org">nodejs.org</a>).<br /><br />
-<strong>Option A — Git:</strong>
-<pre>git clone --branch v0.1.1 --depth 1 https://github.com/galaxyproject/loom
-cd loom/app && npm install && npm start</pre>
-<strong>Option B — Tarball (no Git required):</strong>
-<pre>curl -L https://github.com/galaxyproject/loom/archive/refs/tags/v0.1.1.tar.gz | tar xz
-cd loom-0.1.1/app && npm install && npm start</pre>
-</div>
+2. Eject the DMG. The app is Developer-ID signed + notarized, so it opens with a normal double-click.
 
 ### Linux
 


### PR DESCRIPTION
Documentation sync for the Orbit page, prompted by the v0.3.1 release and a clarity review of the beta onboarding materials. Brings the page in line with the actual app/release and removes contradictions between the page and the testers' onboarding email.

## Changelog

**Installation**
- macOS now offers **both** an Apple Silicon (`arm64`) and an **Intel (`x64`) DMG** (Intel supported from **v0.3.1**); replaces the stale "no Intel installer — build from source (v0.1.1)" callout.
- Added a **"which download do I need?"** table mapping every release asset (`.dmg` / `.deb` / `.rpm` / `.zip`, Intel vs ARM, portable zips, source) to a platform, plus an "About This Mac" chip-check.

**Credentials**
- Galaxy API key step now handles the **already-have-a-key** case (copy existing, or create one).
- OpenAI subscription provider corrected to the real UI strings: **"OpenAI Codex (ChatGPT subscription)"** / **"Sign in with ChatGPT"** (was "OpenAI (Codex)" / "Sign in with OpenAI").

**Help & feedback**
- "Getting help" now leads with the in-app **Feedback button** / `/feedback` as the primary channel for beta testers (forum + GitHub kept as secondary).
- Slash-command table gains **`/execute` (`/run`)** and **`/feedback`**.

**Consistency / polish**
- **"beta"** everywhere (was "early alpha").
- Footnoted the blank OpenAI price cells (`—` = list price not yet published).

## Why
These fixes remove direct contradictions between the page and the beta onboarding email (bug channel, Windows install path, sign-in label, maturity term), so testers reading both get one consistent story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)