### PR TITLE
docs(orbit): download table, Galaxy key wording + clarity-sync fixes (follow-up to #4040)

### DIFF
--- a/content/tools/orbit/index.md
+++ b/content/tools/orbit/index.md
@@ -71,12 +71,8 @@ unpacked-app alternatives to the installers above: no system install, just extra
 
 ### macOS
 
-From the [Releases page](https://github.com/galaxyproject/loom/releases), download the `.dmg` for your chip:
-
-- **Apple Silicon** (M1/M2/M3/M4): `Orbit-<version>-arm64.dmg`
-- **Intel**: `Orbit-<version>-x64.dmg` — supported from **v0.3.1** onward
-
-Not sure which you have? Apple menu → **About This Mac**: a line reading **"Chip: Apple M…"** is Apple Silicon (use **arm64**); **"Processor: Intel…"** is Intel (use **x64**).
+Download the `.dmg` for your chip (`arm64` for Apple Silicon, `x64` for Intel — see the table above
+if you're unsure which you have):
 
 1. Double-click the DMG and drag **Orbit** to **Applications**.
 2. Eject the DMG. The app is Developer-ID signed + notarized, so it opens with a normal double-click.

--- a/content/tools/orbit/index.md
+++ b/content/tools/orbit/index.md
@@ -8,7 +8,7 @@ autotoc: true
 **Orbit** is an AI agent for biological (and not only) data analytics. It lets you have a conversation about your data, draft and approve analysis plans, route steps to Galaxy or run them locally, and watch everything accumulate in a *notebook* — the durable project record that persists across sessions.
 
 <div class="callout">
-Loom/Orbit is in <strong>early alpha</strong>. Expect rough edges and breaking changes between releases. File bugs at <a href="https://github.com/galaxyproject/loom/issues">github.com/galaxyproject/loom/issues</a>. Your reports help us make it better!
+Loom/Orbit is in <strong>beta</strong>. Expect rough edges and breaking changes between releases. The quickest way to report a bug is the in-app <strong>Feedback button</strong> (or the <code>/feedback</code> command); you can also file issues at <a href="https://github.com/galaxyproject/loom/issues">github.com/galaxyproject/loom/issues</a>. Your reports help us make it better!
 </div>
 
 **What can it do? Here's a few examples...**
@@ -49,13 +49,25 @@ Loom/Orbit is in <strong>early alpha</strong>. Expect rough edges and breaking c
 
 ## Installation
 
-All installers are on the [Releases page](https://github.com/galaxyproject/loom/releases).
+All installers are on the [Releases page](https://github.com/galaxyproject/loom/releases). Pick the
+file that matches your computer:
 
-- **macOS Apple Silicon** (M1/M2/M3/M4) — `Orbit-<version>-arm64.dmg`
-- **Linux Debian / Ubuntu / Mint / Pop!\_OS** — `orbit_<version>_amd64.deb`
-- **Linux Fedora / RHEL / CentOS / openSUSE** — `orbit-<version>-1.x86_64.rpm`
-- **Linux any distro** — `Orbit-linux-x64-<version>.zip` (extract and run `orbit`)
-- **Windows** — WSL2 + Ubuntu, then use the `.deb` (see below)
+| Your system | Download | Notes |
+|---|---|---|
+| **macOS — Apple Silicon** (M1/M2/M3/M4) | `Orbit-<version>-arm64.dmg` | Recommended installer |
+| **macOS — Intel** | `Orbit-<version>-x64.dmg` | Recommended installer (v0.3.1+) |
+| **Linux — Debian / Ubuntu / Mint / Pop!\_OS** | `orbit_<version>_amd64.deb` | `sudo dpkg -i <file>` |
+| **Linux — Fedora / RHEL / CentOS / openSUSE** | `orbit-<version>-1.x86_64.rpm` | `sudo rpm -i <file>` |
+| **Linux — any distro** | `Orbit-linux-x64-<version>.zip` | Extract and run `orbit` (no system install) |
+| **Windows** | — | WSL2 + Ubuntu, then use the `.deb` (see below) |
+
+Not sure which Mac chip you have? Apple menu → **About This Mac**: **"Chip: Apple M…"** is Apple
+Silicon (use **arm64**); **"Processor: Intel…"** is Intel (use **x64**).
+
+The `*.zip` "portable" builds — `Orbit-darwin-arm64-<version>.zip` (macOS Apple Silicon),
+`Orbit-darwin-x64-<version>.zip` (macOS Intel), and `Orbit-linux-x64-<version>.zip` (Linux) — are
+unpacked-app alternatives to the installers above: no system install, just extract and run. The
+**Source code** archives are only for building Orbit yourself.
 
 ### macOS
 
@@ -148,7 +160,7 @@ DeepSeek V4 Pro and Flash are very cost-effective — roughly 10–20× cheaper 
 
 1. Log in to your Galaxy server (e.g., [usegalaxy.org](https://usegalaxy.org)).
 2. Open **User → Preferences → Manage API Key**.
-3. Click **Create a new key** and copy the key.
+3. If you already have a key, copy it; otherwise click **Create a new key**, then copy it.
 
 ## Entering credentials in Orbit
 
@@ -191,6 +203,8 @@ If you are using Anthropic API keys, we recommend starting with **Claude Sonnet 
 | `gpt-4o` | General reasoning, plan drafting | $2.50 / $10 |
 | `gpt-4o-mini` | Fast execution, cost-sensitive sessions | $0.15 / $0.60 |
 
+_`—` = list price not yet published; check the [OpenAI pricing page](https://openai.com/api/pricing/) for current rates._
+
 **Google Gemini**
 
 | Model | Best for | Price (in/out per 1M tokens) |
@@ -229,7 +243,7 @@ Switching mid-session is intentional — start on a capable model to design the 
 
 For most providers — Anthropic, Google, DeepSeek, Mistral, and others — Orbit connects through the provider's API. You pay per token, directly to the provider. Rates are shown in the tables above.
 
-For **OpenAI**, Orbit also supports signing in with your existing ChatGPT subscription. Instead of an API key, you authenticate through a browser sign-in flow (OAuth), and the models run against your subscription rather than the pay-per-token API. This is generally cheaper if you already pay for ChatGPT Plus or Pro. The OpenAI subscription provider is listed as **OpenAI (Codex)** in Preferences; click **Sign in with OpenAI** to authenticate.
+For **OpenAI**, Orbit also supports signing in with your existing ChatGPT subscription. Instead of an API key, you authenticate through a browser sign-in flow (OAuth), and the models run against your subscription rather than the pay-per-token API. This is generally cheaper if you already pay for ChatGPT Plus or Pro. The OpenAI subscription provider is listed as **OpenAI Codex (ChatGPT subscription)** in Preferences; click **Sign in with ChatGPT** to authenticate.
 
 Direct subscription auth currently works only for OpenAI. We are exploring whether similar flows can be added for Anthropic (Claude.ai) and Google (Gemini Advanced) in a future release.
 
@@ -315,6 +329,8 @@ Type `/` to open the autocomplete popup. Tab to complete; Enter submits.
 | `/cost` | Append the session token/cost breakdown to the notebook |
 | `/decisions` | Show the decision log |
 | `/connect` | Open Galaxy connection settings or switch to an existing profile |
+| `/execute` (`/run`) | Advance the next pending plan step (polls Galaxy, updates status in place) |
+| `/feedback` | Send a bug report / feedback (with optional diagnostics) to the Orbit team |
 | `/help` | Show the full command list |
 
 ## The notebook
@@ -362,7 +378,7 @@ The `/execute` command (also `/run`) tells the agent to advance the next pending
 
 Loom can fetch operational know-how from curated GitHub repos. The default repo is [`galaxyproject/galaxy-skills`](https://github.com/galaxyproject/galaxy-skills), seeded automatically on first use. It covers collection manipulation, Galaxy MCP usage, workflow report templates, Nextflow-to-Galaxy conversion, and tool development.
 
-Add additional skill repos in **Preferences → Skills**. Each entry is a URL under `github.com/galaxyproject/` (arbitrary repos are restricted in alpha to prevent prompt-injection). Fetched skills cache locally for 24 hours to cover offline use.
+Add additional skill repos in **Preferences → Skills**. Each entry is a URL under `github.com/galaxyproject/` (arbitrary repos are restricted during the beta to prevent prompt-injection). Fetched skills cache locally for 24 hours to cover offline use.
 
 ## Known issues
 
@@ -397,11 +413,15 @@ This is a transient **rate limit**, not a billing failure or a problem with your
 
 ## Getting help
 
-Questions, bug reports, and feature requests are welcome on the **Galaxy Help forum**:
+**Report a bug — easiest:** use the **Feedback button** inside Orbit, or the `/feedback` command in
+the CLI. It sends your report (with optional diagnostics) straight to the team. **Beta testers: this
+is your primary channel** — we count on a few reports per week.
 
-**[help.galaxyproject.org/c/orbit-support/16](https://help.galaxyproject.org/c/orbit-support/16)**
+**Questions, discussion, and feature requests:** the **Galaxy Help forum** —
+**[help.galaxyproject.org/c/orbit-support/16](https://help.galaxyproject.org/c/orbit-support/16)**.
 
-For bugs and crash reports, use the [GitHub issue tracker](https://github.com/galaxyproject/loom/issues).
+**Detailed bugs or crash reports** can also go to the
+[GitHub issue tracker](https://github.com/galaxyproject/loom/issues).
 
 ## Related resources
 


### PR DESCRIPTION
Follow-up to #4040, which merged only its **first** commit (the macOS Intel/Apple-Silicon DMG fix). The remaining changes were left on the branch after the merge — this PR lands them.

## Changes
- **Download table** mapping every release asset (`.dmg` / `.deb` / `.rpm` / `.zip`, Intel vs ARM, portable zips, source) to a platform, with an "About This Mac" chip-check. (macOS section deduped to point at it.)
- **Galaxy API key** step handles the already-have-a-key case.
- **"beta"** everywhere (was "early alpha").
- OpenAI subscription: **"OpenAI Codex (ChatGPT subscription)"** / **"Sign in with ChatGPT"** (matches the real UI; was "OpenAI (Codex)" / "Sign in with OpenAI").
- **Getting help** + top callout: in-app **Feedback button** / `/feedback` as the primary tester channel (forum + GitHub kept as secondary).
- Slash-command table gains **`/execute` (`/run`)** and **`/feedback`**.
- Footnoted the blank OpenAI price cells.

## Why
Removes contradictions between this page and the beta onboarding emails (bug channel, sign-in label, maturity term) so testers reading both get one consistent story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)