### PR TITLE
Fix content padding overlap below navbar on small screens

### DIFF
--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -48,7 +48,7 @@ const navbar = await getSubsiteNavbar(currentSubsite);
       </div>
 
       <!-- Main content area -->
-      <main class="flex-1 flex flex-col min-h-screen lg:ml-64 pt-16 lg:pt-0 min-w-0 overflow-x-hidden">
+      <main class="flex-1 flex flex-col min-h-screen lg:ml-64 pt-22 lg:pt-0 min-w-0 overflow-x-hidden">
         <div class="flex-1 p-4 sm:p-6 lg:p-8 bg-light-bg bg-grid">
           <slot />
         </div>


### PR DESCRIPTION
## Summary

Increases the top padding on the main content area from `pt-16` to `pt-22` in `BaseLayout.astro` to prevent content from being cut off or overlapping with the navbar on small screens.

|Before|After|
|---|---|
|<img width="804" height="1890" alt="before" src="https://github.com/user-attachments/assets/f01933bb-f071-48ec-bfbb-672f96aa5591" />|<img width="804" height="1890" alt="after" src="https://github.com/user-attachments/assets/778a3575-69b3-427c-bed0-13d0d4f6b348" />|