### PR TITLE
Add live updating GCC2026 Cofest Site

### DIFF
--- a/astro/src/build/normalize-content.mjs
+++ b/astro/src/build/normalize-content.mjs
@@ -455,6 +455,7 @@ const KNOWN_COMPONENTS = [
   'ReleaseGuardiansSection',
   'ReleaseGuardiansLabelPill',
   'ReleaseGuardiansCoordination',
+  'CofestBoard',
 ];
 
 function bodyHasComponents(body) {

--- a/astro/src/components/CofestBoard.astro
+++ b/astro/src/components/CofestBoard.astro
@@ -1,21 +1,14 @@
 ---
 /**
- * CofestBoard — Live project board for GCC2026 CoFest.
+ * CofestBoard — Live project board for GCC2026 CoFest (inline view).
  *
  * Data is fetched client-side from a published Google Sheet CSV so organizers
- * can edit the sheet live during the event without a redeploy.
- *
- * HOW TO GET THE CSV URL:
- *   1. Open your Google Sheet
- *   2. File > Share > Publish to web
- *   3. Choose the sheet tab, select "Comma-separated values (.csv)"
- *   4. Click "Publish" and copy the URL
- *   5. Paste it below as CSV_URL (also update the kiosk page board.astro)
+ * can edit the sheet live during the event without a redeploy. The sheet URL
+ * and event details live in src/data/cofest.ts, shared with the kiosk page
+ * (pages/events/gcc2026/cofest/board.astro).
  */
 import CofestBoardVue from './CofestBoard.vue';
-
-const CSV_URL =
-  'https://docs.google.com/spreadsheets/d/e/2PACX-1vQLur85FWBMU7Kq9hAnH5sbNJOZ51LlUrYKDatOtSsugu0F-k9w-uqD0Lh15QJR9IhJA8_Wx9IMByIC/pub?gid=1847317213&single=true&output=csv';
+import { COFEST_CSV_URL, COFEST_DATE, COFEST_LOCATION } from '@/data/cofest';
 ---
 
-<CofestBoardVue client:load csvUrl={CSV_URL} dateString="June 25–26, 2026" locationString="Clermont-Ferrand, France" />
+<CofestBoardVue client:load csvUrl={COFEST_CSV_URL} dateString={COFEST_DATE} locationString={COFEST_LOCATION} />

--- a/astro/src/components/CofestBoard.astro
+++ b/astro/src/components/CofestBoard.astro
@@ -1,0 +1,21 @@
+---
+/**
+ * CofestBoard — Live project board for GCC2026 CoFest.
+ *
+ * Data is fetched client-side from a published Google Sheet CSV so organizers
+ * can edit the sheet live during the event without a redeploy.
+ *
+ * HOW TO GET THE CSV URL:
+ *   1. Open your Google Sheet
+ *   2. File > Share > Publish to web
+ *   3. Choose the sheet tab, select "Comma-separated values (.csv)"
+ *   4. Click "Publish" and copy the URL
+ *   5. Paste it below as CSV_URL (also update the kiosk page board.astro)
+ */
+import CofestBoardVue from './CofestBoard.vue';
+
+const CSV_URL =
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vQLur85FWBMU7Kq9hAnH5sbNJOZ51LlUrYKDatOtSsugu0F-k9w-uqD0Lh15QJR9IhJA8_Wx9IMByIC/pub?gid=1847317213&single=true&output=csv';
+---
+
+<CofestBoardVue client:load csvUrl={CSV_URL} dateString="June 25–26, 2026" locationString="Clermont-Ferrand, France" />

--- a/astro/src/components/CofestBoard.vue
+++ b/astro/src/components/CofestBoard.vue
@@ -26,6 +26,7 @@ const props = withDefaults(
     cardsPerSlide: 6,
     eventName: 'GCC',
     slideIntervalMs: 12000,
+    refreshIntervalMs: 30000,
   }
 );
 

--- a/astro/src/components/CofestBoard.vue
+++ b/astro/src/components/CofestBoard.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import CofestBoardInline from './CofestBoardInline.vue';
+import CofestBoardPresenter from './CofestBoardPresenter.vue';
+
+export interface Project {
+  project: string;
+  description: string;
+  lead: string;
+  assignees: string[];
+}
+
+const props = withDefaults(
+  defineProps<{
+    csvUrl: string;
+    dateString: string;
+    locationString: string;
+    presenterView?: boolean;
+    refreshIntervalMs?: number;
+    cardsPerSlide?: number;
+    eventName?: string;
+    footerText?: string;
+    slideIntervalMs?: number;
+  }>(),
+  {
+    cardsPerSlide: 6,
+    eventName: 'GCC',
+    slideIntervalMs: 12000,
+  }
+);
+
+const projects = ref<Project[]>([]);
+const isLoading = ref(true);
+const error = ref<string | null>(null);
+const lastUpdated = ref<Date | null>(null);
+
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+function parseCsvRow(line: string): string[] {
+  const cols: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      cols.push(current.trim());
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  cols.push(current.trim());
+  return cols;
+}
+
+function parseCsv(text: string): Project[] {
+  const rows = text.trim().split('\n');
+  return rows
+    .slice(1)
+    .map((line) => {
+      const cols = parseCsvRow(line);
+      return {
+        project: cols[0] || '',
+        description: cols[1] || '',
+        lead: cols[2] || '',
+        assignees: (cols[3] || '')
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      };
+    })
+    .filter((p) => p.project);
+}
+
+async function loadProjects() {
+  try {
+    const res = await fetch(props.csvUrl);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const text = await res.text();
+    const parsed = parseCsv(text);
+    if (parsed.length > 0) projects.value = parsed;
+    error.value = null;
+    lastUpdated.value = new Date();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+onMounted(() => {
+  loadProjects();
+  refreshTimer = setInterval(loadProjects, props.refreshIntervalMs);
+});
+
+onUnmounted(() => {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+  }
+});
+</script>
+
+<template>
+  <CofestBoardPresenter
+    v-if="presenterView"
+    :projects="projects"
+    :is-loading="isLoading"
+    :error="error"
+    :cards-per-slide="props.cardsPerSlide"
+    :date-string="props.dateString"
+    :footer-text="props.footerText"
+    :event-name="props.eventName"
+    :last-updated="lastUpdated"
+    :location-string="props.locationString"
+    :slide-interval-ms="props.slideIntervalMs"
+  />
+
+  <CofestBoardInline v-else :projects="projects" :is-loading="isLoading" :error="error" />
+</template>

--- a/astro/src/components/CofestBoard.vue
+++ b/astro/src/components/CofestBoard.vue
@@ -2,13 +2,7 @@
 import { ref, onMounted, onUnmounted } from 'vue';
 import CofestBoardInline from './CofestBoardInline.vue';
 import CofestBoardPresenter from './CofestBoardPresenter.vue';
-
-export interface Project {
-  project: string;
-  description: string;
-  lead: string;
-  assignees: string[];
-}
+import { parseCsv, type Project } from '@/utils/cofest-csv';
 
 const props = withDefaults(
   defineProps<{
@@ -36,47 +30,6 @@ const error = ref<string | null>(null);
 const lastUpdated = ref<Date | null>(null);
 
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
-
-function parseCsvRow(line: string): string[] {
-  const cols: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (ch === '"') {
-      if (inQuotes && line[i + 1] === '"') {
-        current += '"';
-        i++;
-      } else inQuotes = !inQuotes;
-    } else if (ch === ',' && !inQuotes) {
-      cols.push(current.trim());
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  cols.push(current.trim());
-  return cols;
-}
-
-function parseCsv(text: string): Project[] {
-  const rows = text.trim().split('\n');
-  return rows
-    .slice(1)
-    .map((line) => {
-      const cols = parseCsvRow(line);
-      return {
-        project: cols[0] || '',
-        description: cols[1] || '',
-        lead: cols[2] || '',
-        assignees: (cols[3] || '')
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean),
-      };
-    })
-    .filter((p) => p.project);
-}
 
 async function loadProjects() {
   try {

--- a/astro/src/components/CofestBoardInline.vue
+++ b/astro/src/components/CofestBoardInline.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Project } from './CofestBoard.vue';
+import type { Project } from '@/utils/cofest-csv';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 

--- a/astro/src/components/CofestBoardInline.vue
+++ b/astro/src/components/CofestBoardInline.vue
@@ -19,24 +19,45 @@ defineProps<{
     <div v-else-if="projects.length === 0" class="py-8 text-center text-galaxy-grey">
       No projects found yet — check back soon!
     </div>
-    <div v-else class="gx-tile-grid">
-      <Card v-for="p in projects" :key="p.project" class="gx-tile border-galaxy-primary/10">
-        <CardHeader class="pb-2">
-          <CardTitle class="text-galaxy-dark text-base leading-snug">{{ p.project }}</CardTitle>
+    <div v-else class="gx-tile-grid not-prose">
+      <Card v-for="p in projects" :key="p.project" class="gx-tile h-full border-galaxy-primary/10 py-0 gap-0">
+        <CardHeader class="pt-4 pb-1">
+          <CardTitle class="m-0 text-galaxy-dark text-base leading-tight">{{ p.project }}</CardTitle>
         </CardHeader>
-        <CardContent class="flex flex-col gap-3 pt-0">
+        <CardContent class="flex flex-1 flex-col gap-2.5 pt-1 pb-4">
           <p v-if="p.description" class="text-sm text-galaxy-grey leading-relaxed">{{ p.description }}</p>
           <div v-if="p.lead" class="text-sm">
             <span class="text-galaxy-grey">Lead: </span>
             <span class="font-semibold text-galaxy-primary">{{ p.lead }}</span>
           </div>
-          <div v-if="p.assignees.length > 0" class="flex flex-wrap gap-1.5">
-            <Badge v-for="name in p.assignees" :key="name" variant="secondary" class="text-xs">
-              {{ name }}
-            </Badge>
+          <div v-if="p.assignees.length > 0" class="team-section">
+            <span class="team-label">TEAM</span>
+            <div class="flex flex-wrap gap-1.5">
+              <Badge v-for="name in p.assignees" :key="name" variant="default" class="text-xs font-normal">
+                {{ name }}
+              </Badge>
+            </div>
           </div>
         </CardContent>
       </Card>
     </div>
   </div>
 </template>
+
+<style scoped>
+.team-section {
+  margin-top: auto;
+  padding-top: 0.45rem;
+  border-top: 1px solid color-mix(in srgb, var(--color-galaxy-primary, #25537b) 12%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.team-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--color-galaxy-grey, #6b7280);
+}
+</style>

--- a/astro/src/components/CofestBoardInline.vue
+++ b/astro/src/components/CofestBoardInline.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { Project } from './CofestBoard.vue';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+defineProps<{
+  projects: Project[];
+  isLoading: boolean;
+  error: string | null;
+}>();
+</script>
+
+<template>
+  <div>
+    <div v-if="isLoading" class="py-8 text-center text-galaxy-grey">Loading projects…</div>
+    <div v-else-if="error" class="py-8 text-center text-galaxy-grey">
+      Could not load projects: {{ error }}. Will retry shortly.
+    </div>
+    <div v-else-if="projects.length === 0" class="py-8 text-center text-galaxy-grey">
+      No projects found yet — check back soon!
+    </div>
+    <div v-else class="gx-tile-grid">
+      <Card v-for="p in projects" :key="p.project" class="gx-tile border-galaxy-primary/10">
+        <CardHeader class="pb-2">
+          <CardTitle class="text-galaxy-dark text-base leading-snug">{{ p.project }}</CardTitle>
+        </CardHeader>
+        <CardContent class="flex flex-col gap-3 pt-0">
+          <p v-if="p.description" class="text-sm text-galaxy-grey leading-relaxed">{{ p.description }}</p>
+          <div v-if="p.lead" class="text-sm">
+            <span class="text-galaxy-grey">Lead: </span>
+            <span class="font-semibold text-galaxy-primary">{{ p.lead }}</span>
+          </div>
+          <div v-if="p.assignees.length > 0" class="flex flex-wrap gap-1.5">
+            <Badge v-for="name in p.assignees" :key="name" variant="secondary" class="text-xs">
+              {{ name }}
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  </div>
+</template>

--- a/astro/src/components/CofestBoardInline.vue
+++ b/astro/src/components/CofestBoardInline.vue
@@ -30,13 +30,14 @@ defineProps<{
             <span class="text-galaxy-grey">Lead: </span>
             <span class="font-semibold text-galaxy-primary">{{ p.lead }}</span>
           </div>
-          <div v-if="p.assignees.length > 0" class="team-section">
+          <div class="team-section">
             <span class="team-label">TEAM</span>
-            <div class="flex flex-wrap gap-1.5">
+            <div v-if="p.assignees.length > 0" class="flex flex-wrap gap-1.5">
               <Badge v-for="name in p.assignees" :key="name" variant="default" class="text-xs font-normal">
                 {{ name }}
               </Badge>
             </div>
+            <p v-else class="text-xs text-galaxy-primary italic">✨ Open spot — come join this project!</p>
           </div>
         </CardContent>
       </Card>

--- a/astro/src/components/CofestBoardPresenter.vue
+++ b/astro/src/components/CofestBoardPresenter.vue
@@ -1,0 +1,265 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import type { Project } from './CofestBoard.vue';
+
+const props = withDefaults(
+  defineProps<{
+    dateString: string;
+    error: string | null;
+    isLoading: boolean;
+    lastUpdated: Date | null;
+    locationString: string;
+    projects: Project[];
+    cardsPerSlide?: number;
+    eventName?: string;
+    slideIntervalMs?: number;
+    footerText?: string;
+  }>(),
+  {
+    cardsPerSlide: 6,
+    eventName: 'GCC',
+    slideIntervalMs: 12000,
+  }
+);
+
+const currentSlide = ref(0);
+let slideTimer: ReturnType<typeof setInterval> | null = null;
+
+const totalSlides = computed(() => Math.max(1, Math.ceil(props.projects.length / props.cardsPerSlide)));
+
+const visibleProjects = computed(() => {
+  const perSlide = props.cardsPerSlide;
+  const start = currentSlide.value * perSlide;
+  return props.projects.slice(start, start + perSlide);
+});
+
+function advance() {
+  currentSlide.value = (currentSlide.value + 1) % totalSlides.value;
+}
+
+onMounted(() => {
+  slideTimer = setInterval(advance, props.slideIntervalMs);
+});
+
+onUnmounted(() => {
+  if (slideTimer) clearInterval(slideTimer);
+});
+
+const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLocaleTimeString() : ''));
+</script>
+
+<template>
+  <div class="presenter-body">
+    <header class="presenter-header">
+      <div class="presenter-header-inner">
+        <img src="/images/galaxy_logo_hub_white.svg" alt="Galaxy" class="presenter-logo" />
+        <div class="presenter-title-group">
+          <h1 class="presenter-title">{{ props.eventName }} CoFest Projects</h1>
+          <p class="presenter-subtitle">{{ props.dateString }} &middot; {{ props.locationString }}</p>
+        </div>
+        <div class="presenter-meta">
+          <span v-if="props.projects.length > 0" class="presenter-counter">
+            Slide {{ currentSlide + 1 }} / {{ totalSlides }}
+          </span>
+          <span v-if="props.lastUpdated" class="presenter-updated">Updated {{ formattedTime }}</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="presenter-main">
+      <div v-if="props.isLoading" class="presenter-status">Loading projects…</div>
+      <div v-else-if="props.error" class="presenter-status">Could not load projects: {{ props.error }}</div>
+      <div v-else-if="props.projects.length === 0" class="presenter-status">No projects found yet.</div>
+      <Transition v-else name="slide-fade" mode="out-in">
+        <div :key="currentSlide" class="presenter-grid">
+          <div v-for="p in visibleProjects" :key="p.project" class="presenter-card">
+            <div class="presenter-card-title">{{ p.project }}</div>
+            <div v-if="p.description" class="presenter-card-desc">{{ p.description }}</div>
+            <div v-if="p.lead" class="presenter-card-lead">
+              <span class="presenter-card-lead-label">Lead: </span>{{ p.lead }}
+            </div>
+            <div v-if="p.assignees.length > 0" class="presenter-card-assignees">
+              <span v-for="name in p.assignees" :key="name" class="presenter-tag">{{ name }}</span>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </main>
+
+    <footer class="presenter-footer">
+      <span v-if="props.footerText">{{ props.footerText }}</span>
+      <span v-else>Served at Galaxy Project (<a href="/">galaxyproject.org</a>)</span>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.presenter-body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: #0f1b2d;
+  color: #f0f4f8;
+  font-family: system-ui, sans-serif;
+}
+
+.presenter-header {
+  background: linear-gradient(135deg, #1a2e4a 0%, #0f1b2d 100%);
+  border-bottom: 2px solid #ffd700;
+  padding: 0.75rem 2rem;
+  flex-shrink: 0;
+}
+
+.presenter-header-inner {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.presenter-logo {
+  height: 2.5rem;
+  width: auto;
+  flex-shrink: 0;
+}
+
+.presenter-title-group {
+  flex: 1;
+}
+
+.presenter-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.2;
+}
+
+.presenter-subtitle {
+  font-size: 0.9rem;
+  color: #ffd700;
+  margin-top: 0.15rem;
+}
+
+.presenter-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.presenter-counter {
+  font-size: 0.95rem;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}
+
+.presenter-updated {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.presenter-main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 2rem;
+  overflow: hidden;
+}
+
+.presenter-status {
+  font-size: 1.25rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.presenter-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 1600px;
+}
+
+.presenter-card {
+  background: #1e2d42;
+  border: 1px solid #2d4a6e;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.presenter-card:hover {
+  border-color: #ffd700;
+}
+
+.presenter-card-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.3;
+}
+
+.presenter-card-desc {
+  font-size: 0.88rem;
+  color: #94a3b8;
+  line-height: 1.55;
+  flex: 1;
+}
+
+.presenter-card-lead {
+  font-size: 0.85rem;
+  color: #ffd700;
+  font-weight: 600;
+}
+
+.presenter-card-lead-label {
+  color: #64748b;
+  font-weight: 400;
+}
+
+.presenter-card-assignees {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.presenter-tag {
+  background: rgba(255, 215, 0, 0.1);
+  color: #cbd5e1;
+  border-radius: 9999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  border: 1px solid rgba(255, 215, 0, 0.2);
+}
+
+.presenter-footer {
+  text-align: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  color: #475569;
+  border-top: 1px solid #1e2d42;
+  flex-shrink: 0;
+}
+
+/* Slide transition */
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition:
+    opacity 0.4s ease,
+    transform 0.4s ease;
+}
+.slide-fade-enter-from {
+  opacity: 0;
+  transform: translateY(10px);
+}
+.slide-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+</style>

--- a/astro/src/components/CofestBoardPresenter.vue
+++ b/astro/src/components/CofestBoardPresenter.vue
@@ -28,11 +28,25 @@ const currentSlide = ref(0);
 const paused = ref(false);
 let slideTimer: ReturnType<typeof setInterval> | null = null;
 
-const totalSlides = computed(() => Math.max(1, Math.ceil(props.projects.length / props.cardsPerSlide)));
+const localCardsPerSlide = ref(props.cardsPerSlide);
+function decreaseCards() {
+  if (localCardsPerSlide.value > 4) {
+    localCardsPerSlide.value--;
+    currentSlide.value = 0;
+  }
+}
+function increaseCards() {
+  if (localCardsPerSlide.value < 8) {
+    localCardsPerSlide.value++;
+    currentSlide.value = 0;
+  }
+}
+
+const totalSlides = computed(() => Math.max(1, Math.ceil(props.projects.length / localCardsPerSlide.value)));
 
 const visibleProjects = computed(() => {
-  const start = currentSlide.value * props.cardsPerSlide;
-  return props.projects.slice(start, start + props.cardsPerSlide);
+  const start = currentSlide.value * localCardsPerSlide.value;
+  return props.projects.slice(start, start + localCardsPerSlide.value);
 });
 
 function advance() {
@@ -78,10 +92,35 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
           <p class="presenter-subtitle">{{ props.dateString }} &middot; {{ props.locationString }}</p>
         </div>
         <div class="presenter-meta">
-          <span v-if="props.projects.length > 0" class="presenter-counter">
-            Slide {{ currentSlide + 1 }} / {{ totalSlides }}
-          </span>
-          <span v-if="props.lastUpdated" class="presenter-updated">Updated {{ formattedTime }}</span>
+          <div class="presenter-meta-row">
+            <div class="cards-control">
+              <Button
+                variant="outline"
+                size="icon-sm"
+                class="presenter-nav-btn"
+                :disabled="localCardsPerSlide <= 4"
+                aria-label="Fewer cards"
+                @click="decreaseCards"
+              >
+                −
+              </Button>
+              <span class="cards-label">{{ localCardsPerSlide }} / slide</span>
+              <Button
+                variant="outline"
+                size="icon-sm"
+                class="presenter-nav-btn"
+                :disabled="localCardsPerSlide >= 8"
+                aria-label="More cards"
+                @click="increaseCards"
+              >
+                +
+              </Button>
+            </div>
+            <span v-if="props.projects.length > 0" class="presenter-counter"
+              >Slide {{ currentSlide + 1 }} / {{ totalSlides }}</span
+            >
+            <span v-if="props.lastUpdated" class="presenter-updated">Updated {{ formattedTime }}</span>
+          </div>
         </div>
       </div>
     </header>
@@ -91,7 +130,11 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
       <div v-else-if="props.error" class="presenter-status">Could not load projects: {{ props.error }}</div>
       <div v-else-if="props.projects.length === 0" class="presenter-status">No projects found yet.</div>
       <Transition v-else name="slide-fade" mode="out-in">
-        <div :key="currentSlide" class="presenter-grid">
+        <div
+          :key="currentSlide"
+          class="presenter-grid"
+          :style="{ gridTemplateColumns: `repeat(${Math.ceil(localCardsPerSlide / 2)}, 1fr)` }"
+        >
           <div v-for="p in visibleProjects" :key="p.project" class="presenter-card">
             <div class="presenter-card-title">{{ p.project }}</div>
             <div v-if="p.description" class="presenter-card-desc">{{ p.description }}</div>
@@ -177,11 +220,31 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
 }
 
 .presenter-meta {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.25rem;
   flex-shrink: 0;
+}
+
+.presenter-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cards-control {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.2rem 0.4rem;
+}
+
+.cards-label {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+  min-width: 3.5rem;
+  text-align: center;
 }
 
 .presenter-counter {
@@ -212,7 +275,6 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
 
 .presenter-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
   gap: 1.25rem;
   width: 100%;
   max-width: 1600px;

--- a/astro/src/components/CofestBoardPresenter.vue
+++ b/astro/src/components/CofestBoardPresenter.vue
@@ -26,6 +26,7 @@ const props = withDefaults(
 
 const currentSlide = ref(0);
 const paused = ref(false);
+const isLight = ref(false);
 let slideTimer: ReturnType<typeof setInterval> | null = null;
 
 const localCardsPerSlide = ref(props.cardsPerSlide);
@@ -83,7 +84,7 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
 </script>
 
 <template>
-  <div class="presenter-body">
+  <div class="presenter-body" :class="{ 'presenter-light': isLight }">
     <header class="presenter-header">
       <div class="presenter-header-inner">
         <img src="/images/galaxy_logo_hub_white.svg" alt="Galaxy" class="presenter-logo" />
@@ -93,6 +94,45 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
         </div>
         <div class="presenter-meta">
           <div class="presenter-meta-row">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              class="presenter-nav-btn"
+              :aria-label="isLight ? 'Switch to dark mode' : 'Switch to light mode'"
+              @click="isLight = !isLight"
+            >
+              <svg
+                v-if="isLight"
+                xmlns="http://www.w3.org/2000/svg"
+                class="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M12 5a7 7 0 100 14A7 7 0 0012 5z"
+                />
+              </svg>
+
+              <svg
+                v-else
+                xmlns="http://www.w3.org/2000/svg"
+                class="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+                />
+              </svg>
+            </Button>
             <div class="cards-control">
               <Button
                 variant="outline"
@@ -370,6 +410,80 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
 
 .footer-text a:hover {
   color: #94a3b8;
+}
+
+/* ── Light mode overrides ── */
+.presenter-light {
+  background: #f8fafc;
+  color: #1e293b;
+}
+
+.presenter-light .presenter-header {
+  background: linear-gradient(135deg, #25537b 0%, #1a3a54 100%);
+}
+
+.presenter-light .presenter-card {
+  background: #ffffff;
+  border-color: color-mix(in srgb, #25537b 15%, transparent);
+}
+
+.presenter-light .presenter-card:hover {
+  border-color: #25537b;
+}
+
+.presenter-light .presenter-card-title {
+  color: #1e293b;
+}
+
+.presenter-light .presenter-card-desc {
+  color: #475569;
+}
+
+.presenter-light .presenter-footer {
+  border-top-color: #e2e8f0;
+  background: #f1f5f9;
+}
+
+.presenter-light .presenter-tag {
+  background: color-mix(in srgb, #25537b 8%, transparent) !important;
+  color: #25537b !important;
+  border-color: color-mix(in srgb, #25537b 25%, transparent) !important;
+}
+
+.presenter-light .presenter-card-lead {
+  color: #25537b;
+}
+
+.presenter-light .presenter-card-lead-label {
+  color: #94a3b8;
+}
+
+.presenter-light .presenter-footer .presenter-nav-btn {
+  background: rgba(0, 0, 0, 0.04) !important;
+  border-color: rgba(0, 0, 0, 0.15) !important;
+  color: #475569 !important;
+}
+
+.presenter-light .presenter-footer .presenter-nav-btn:hover {
+  background: color-mix(in srgb, #25537b 10%, transparent) !important;
+  border-color: #25537b !important;
+  color: #25537b !important;
+}
+
+.presenter-light .cards-control {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.presenter-light .presenter-counter,
+.presenter-light .cards-label {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.presenter-light .presenter-updated,
+.presenter-light .footer-text,
+.presenter-light .footer-text a {
+  color: rgba(255, 255, 255, 0.5);
 }
 
 /* Slide transition */

--- a/astro/src/components/CofestBoardPresenter.vue
+++ b/astro/src/components/CofestBoardPresenter.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import type { Project } from './CofestBoard.vue';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 const props = withDefaults(
   defineProps<{
@@ -23,27 +25,45 @@ const props = withDefaults(
 );
 
 const currentSlide = ref(0);
+const paused = ref(false);
 let slideTimer: ReturnType<typeof setInterval> | null = null;
 
 const totalSlides = computed(() => Math.max(1, Math.ceil(props.projects.length / props.cardsPerSlide)));
 
 const visibleProjects = computed(() => {
-  const perSlide = props.cardsPerSlide;
-  const start = currentSlide.value * perSlide;
-  return props.projects.slice(start, start + perSlide);
+  const start = currentSlide.value * props.cardsPerSlide;
+  return props.projects.slice(start, start + props.cardsPerSlide);
 });
 
 function advance() {
   currentSlide.value = (currentSlide.value + 1) % totalSlides.value;
 }
 
-onMounted(() => {
-  slideTimer = setInterval(advance, props.slideIntervalMs);
-});
+function prev() {
+  currentSlide.value = (currentSlide.value - 1 + totalSlides.value) % totalSlides.value;
+}
 
-onUnmounted(() => {
+function next() {
+  currentSlide.value = (currentSlide.value + 1) % totalSlides.value;
+}
+
+function togglePause() {
+  paused.value = !paused.value;
+}
+
+function startTimer() {
+  stopTimer();
+  slideTimer = setInterval(() => {
+    if (!paused.value) advance();
+  }, props.slideIntervalMs);
+}
+
+function stopTimer() {
   if (slideTimer) clearInterval(slideTimer);
-});
+}
+
+onMounted(startTimer);
+onUnmounted(stopTimer);
 
 const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLocaleTimeString() : ''));
 </script>
@@ -79,7 +99,7 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
               <span class="presenter-card-lead-label">Lead: </span>{{ p.lead }}
             </div>
             <div v-if="p.assignees.length > 0" class="presenter-card-assignees">
-              <span v-for="name in p.assignees" :key="name" class="presenter-tag">{{ name }}</span>
+              <Badge v-for="name in p.assignees" :key="name" variant="outline" class="presenter-tag">{{ name }}</Badge>
             </div>
           </div>
         </div>
@@ -87,8 +107,25 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
     </main>
 
     <footer class="presenter-footer">
-      <span v-if="props.footerText">{{ props.footerText }}</span>
-      <span v-else>Served at Galaxy Project (<a href="/">galaxyproject.org</a>)</span>
+      <Button variant="outline" size="icon-sm" class="presenter-nav-btn" aria-label="Previous slide" @click="prev">
+        &#8592;
+      </Button>
+      <Button
+        variant="outline"
+        size="icon-sm"
+        class="presenter-nav-btn"
+        :aria-label="paused ? 'Resume' : 'Pause'"
+        @click="togglePause"
+      >
+        {{ paused ? '▶' : '⏸' }}
+      </Button>
+      <Button variant="outline" size="icon-sm" class="presenter-nav-btn" aria-label="Next slide" @click="next">
+        &#8594;
+      </Button>
+      <span class="footer-text">
+        <span v-if="props.footerText">{{ props.footerText }}</span>
+        <a v-else href="/">galaxyproject.org</a>
+      </span>
     </footer>
   </div>
 </template>
@@ -228,23 +265,49 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
   gap: 0.3rem;
 }
 
+/* Badge override for dark background */
 .presenter-tag {
-  background: rgba(255, 215, 0, 0.1);
-  color: #cbd5e1;
-  border-radius: 9999px;
-  padding: 0.15rem 0.6rem;
-  font-size: 0.75rem;
-  white-space: nowrap;
-  border: 1px solid rgba(255, 215, 0, 0.2);
+  background: rgba(255, 215, 0, 0.08) !important;
+  color: #cbd5e1 !important;
+  border-color: rgba(255, 215, 0, 0.2) !important;
 }
 
+/* ── Footer ── */
 .presenter-footer {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
   padding: 0.5rem 1rem;
-  font-size: 0.75rem;
-  color: #475569;
   border-top: 1px solid #1e2d42;
   flex-shrink: 0;
+}
+
+.presenter-nav-btn {
+  background: rgba(255, 255, 255, 0.06) !important;
+  border-color: rgba(255, 255, 255, 0.15) !important;
+  color: #94a3b8 !important;
+}
+
+.presenter-nav-btn:hover {
+  background: rgba(255, 215, 0, 0.15) !important;
+  border-color: #ffd700 !important;
+  color: #ffd700 !important;
+}
+
+.footer-text {
+  font-size: 0.75rem;
+  color: #475569;
+  margin-left: 0.5rem;
+}
+
+.footer-text a {
+  color: #475569;
+  text-decoration: none;
+}
+
+.footer-text a:hover {
+  color: #94a3b8;
 }
 
 /* Slide transition */

--- a/astro/src/components/CofestBoardPresenter.vue
+++ b/astro/src/components/CofestBoardPresenter.vue
@@ -181,8 +181,14 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
             <div v-if="p.lead" class="presenter-card-lead">
               <span class="presenter-card-lead-label">Lead: </span>{{ p.lead }}
             </div>
-            <div v-if="p.assignees.length > 0" class="presenter-card-assignees">
-              <Badge v-for="name in p.assignees" :key="name" variant="outline" class="presenter-tag">{{ name }}</Badge>
+            <div class="presenter-card-assignees">
+              <span class="presenter-team-label">TEAM</span>
+              <div v-if="p.assignees.length > 0" class="presenter-tags">
+                <Badge v-for="name in p.assignees" :key="name" variant="outline" class="presenter-tag">
+                  {{ name }}
+                </Badge>
+              </div>
+              <div v-else class="presenter-join">✨ Open spot — come join this project!</div>
             </div>
           </div>
         </div>
@@ -362,9 +368,43 @@ const formattedTime = computed(() => (props.lastUpdated ? props.lastUpdated.toLo
 }
 
 .presenter-card-assignees {
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.presenter-team-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.presenter-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 0.3rem;
+}
+
+.presenter-light .presenter-card-assignees {
+  border-top-color: color-mix(in srgb, #25537b 15%, transparent);
+}
+
+.presenter-join {
+  font-size: 0.8rem;
+  color: #ffd700;
+  font-style: italic;
+}
+
+.presenter-light .presenter-join {
+  color: #25537b;
+}
+
+.presenter-light .presenter-team-label {
+  color: #94a3b8;
 }
 
 /* Badge override for dark background */

--- a/astro/src/components/CofestBoardPresenter.vue
+++ b/astro/src/components/CofestBoardPresenter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
-import type { Project } from './CofestBoard.vue';
+import type { Project } from '@/utils/cofest-csv';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 

--- a/astro/src/data/cofest.ts
+++ b/astro/src/data/cofest.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared config for the GCC2026 CoFest live board.
+ *
+ * Project data is fetched client-side from a published Google Sheet CSV so
+ * organizers can edit it live during the event without a redeploy. To repoint
+ * the board at a different sheet:
+ *   1. Open the Google Sheet
+ *   2. File > Share > Publish to web
+ *   3. Pick the sheet tab and choose "Comma-separated values (.csv)"
+ *   4. Publish, copy the URL, and paste it below
+ *
+ * Both the inline board (CofestBoard.astro) and the kiosk page
+ * (pages/events/gcc2026/cofest/board.astro) import from here, so the URL and
+ * event details only need to be updated in one place.
+ */
+export const COFEST_CSV_URL =
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vQLur85FWBMU7Kq9hAnH5sbNJOZ51LlUrYKDatOtSsugu0F-k9w-uqD0Lh15QJR9IhJA8_Wx9IMByIC/pub?gid=1847317213&single=true&output=csv';
+
+export const COFEST_DATE = 'June 25–26, 2026';
+export const COFEST_LOCATION = 'Clermont-Ferrand, France';
+export const COFEST_EVENT_NAME = 'GCC 2026';

--- a/astro/src/pages/events/[...slug].astro
+++ b/astro/src/pages/events/[...slug].astro
@@ -18,6 +18,7 @@ import Supporters from '../../components/mdx/Supporters.astro';
 import Contacts from '../../components/mdx/Contacts.astro';
 import MdxIcon from '../../components/mdx/Icon.astro';
 import Insert from '../../components/mdx/Insert.astro';
+import CofestBoard from '../../components/CofestBoard.astro';
 import SupporterGrid from '../../components/content/SupporterGrid.astro';
 import { resolveSupporters } from '../../utils/supporters';
 import { extractFunding, extractAuthors, resolveAuthor } from '../../utils/contributors';
@@ -232,6 +233,7 @@ const components = {
   ReleaseGuardiansSection,
   ReleaseGuardiansLabelPill,
   ReleaseGuardiansCoordination,
+  CofestBoard,
 };
 
 function toDate(d: Date | string | undefined): Date | null {

--- a/astro/src/pages/events/gcc2026/cofest/board.astro
+++ b/astro/src/pages/events/gcc2026/cofest/board.astro
@@ -1,0 +1,31 @@
+---
+import '../../../../styles/global.css';
+import CofestBoard from '../../../../components/CofestBoard.vue';
+
+const CSV_URL =
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vQLur85FWBMU7Kq9hAnH5sbNJOZ51LlUrYKDatOtSsugu0F-k9w-uqD0Lh15QJR9IhJA8_Wx9IMByIC/pub?gid=1847317213&single=true&output=csv';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>GCC2026 CoFest Projects | Live Board</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <CofestBoard
+      client:load
+      csvUrl={CSV_URL}
+      presenterView={true}
+      cardsPerSlide={6}
+      slideIntervalMs={12000}
+      refreshIntervalMs={30000}
+      dateString="June 25–26, 2026"
+      locationString="Clermont-Ferrand, France"
+      eventName="GCC 2026"
+    />
+  </body>
+</html>

--- a/astro/src/pages/events/gcc2026/cofest/board.astro
+++ b/astro/src/pages/events/gcc2026/cofest/board.astro
@@ -1,9 +1,7 @@
 ---
 import '../../../../styles/global.css';
 import CofestBoard from '../../../../components/CofestBoard.vue';
-
-const CSV_URL =
-  'https://docs.google.com/spreadsheets/d/e/2PACX-1vQLur85FWBMU7Kq9hAnH5sbNJOZ51LlUrYKDatOtSsugu0F-k9w-uqD0Lh15QJR9IhJA8_Wx9IMByIC/pub?gid=1847317213&single=true&output=csv';
+import { COFEST_CSV_URL, COFEST_DATE, COFEST_LOCATION, COFEST_EVENT_NAME } from '@/data/cofest';
 ---
 
 <!doctype html>
@@ -18,14 +16,14 @@ const CSV_URL =
   <body>
     <CofestBoard
       client:load
-      csvUrl={CSV_URL}
+      csvUrl={COFEST_CSV_URL}
       presenterView={true}
       cardsPerSlide={6}
       slideIntervalMs={12000}
       refreshIntervalMs={30000}
-      dateString="June 25–26, 2026"
-      locationString="Clermont-Ferrand, France"
-      eventName="GCC 2026"
+      dateString={COFEST_DATE}
+      locationString={COFEST_LOCATION}
+      eventName={COFEST_EVENT_NAME}
     />
   </body>
 </html>

--- a/astro/src/utils/cofest-csv.test.ts
+++ b/astro/src/utils/cofest-csv.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { parseCsv } from './cofest-csv';
+
+describe('parseCsv', () => {
+  it('parses a basic sheet keyed by header', () => {
+    const csv = 'Project,Description,Lead,Assignees\nFoo,Does foo,Ada,Bob';
+    expect(parseCsv(csv)).toEqual([{ project: 'Foo', description: 'Does foo', lead: 'Ada', assignees: ['Bob'] }]);
+  });
+
+  it('splits assignees on commas inside a quoted field', () => {
+    const csv = 'Project,Description,Lead,Assignees\nFoo,Desc,Ada,"Bob, Carol, Dan"';
+    expect(parseCsv(csv)[0].assignees).toEqual(['Bob', 'Carol', 'Dan']);
+  });
+
+  it('keeps commas that belong to a quoted description', () => {
+    const csv = 'Project,Description,Lead,Assignees\nFoo,"Two things: a, and b",Ada,Bob';
+    expect(parseCsv(csv)[0].description).toBe('Two things: a, and b');
+  });
+
+  it('handles newlines embedded in a quoted cell', () => {
+    const csv = 'Project,Description,Lead,Assignees\nFoo,"line one\nline two",Ada,Bob';
+    const out = parseCsv(csv);
+    expect(out).toHaveLength(1);
+    expect(out[0].description).toBe('line one\nline two');
+  });
+
+  it('handles CRLF line endings from published sheets', () => {
+    const csv = 'Project,Description,Lead,Assignees\r\nFoo,Desc,Ada,"Bob, Carol"\r\n';
+    const out = parseCsv(csv);
+    expect(out).toHaveLength(1);
+    expect(out[0].assignees).toEqual(['Bob', 'Carol']);
+  });
+
+  it('matches columns by header even when reordered', () => {
+    const csv = 'Lead,Assignees,Project,Description\nAda,"Bob, Carol",Foo,Does foo';
+    expect(parseCsv(csv)).toEqual([
+      { project: 'Foo', description: 'Does foo', lead: 'Ada', assignees: ['Bob', 'Carol'] },
+    ]);
+  });
+
+  it('treats an empty assignees cell as no team', () => {
+    const csv = 'Project,Description,Lead,Assignees\nFoo,Desc,Ada,';
+    expect(parseCsv(csv)[0].assignees).toEqual([]);
+  });
+
+  it('unescapes doubled quotes', () => {
+    const csv = 'Project,Description,Lead,Assignees\nFoo,"a ""quoted"" word",Ada,Bob';
+    expect(parseCsv(csv)[0].description).toBe('a "quoted" word');
+  });
+
+  it('drops rows without a project name', () => {
+    const csv = 'Project,Description,Lead,Assignees\nFoo,Desc,Ada,Bob\n,,,\nBar,Desc,Eve,Frank';
+    expect(parseCsv(csv).map((p) => p.project)).toEqual(['Foo', 'Bar']);
+  });
+
+  it('returns an empty array for header-only or empty input', () => {
+    expect(parseCsv('Project,Description,Lead,Assignees')).toEqual([]);
+    expect(parseCsv('')).toEqual([]);
+  });
+});

--- a/astro/src/utils/cofest-csv.ts
+++ b/astro/src/utils/cofest-csv.ts
@@ -1,0 +1,94 @@
+export interface Project {
+  project: string;
+  description: string;
+  lead: string;
+  assignees: string[];
+}
+
+/**
+ * Tokenize CSV text into rows of cells. Handles quoted fields containing
+ * commas, escaped quotes (""), and embedded newlines, plus CRLF/CR line
+ * endings. Published Google Sheets emit CRLF and will quote any cell that
+ * contains a comma or a manual line break, so we can't just split on "\n".
+ */
+function tokenize(text: string): string[][] {
+  const normalized = text.replace(/\r\n?/g, '\n');
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < normalized.length; i++) {
+    const ch = normalized[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (normalized[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      row.push(cell);
+      cell = '';
+    } else if (ch === '\n') {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = '';
+    } else {
+      cell += ch;
+    }
+  }
+
+  // Flush a trailing cell/row when the file doesn't end with a newline.
+  if (cell !== '' || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+/**
+ * Parse the CoFest project sheet. Columns are matched by header name
+ * (Project, Description, Lead, Assignees) so reordering or inserting columns
+ * in the sheet doesn't silently mismap data; falls back to positional order
+ * if the expected headers aren't found.
+ */
+export function parseCsv(text: string): Project[] {
+  const rows = tokenize(text);
+  if (rows.length < 2) return [];
+
+  const header = rows[0].map((h) => h.trim().toLowerCase());
+  const colOr = (name: string, fallback: number) => {
+    const i = header.indexOf(name);
+    return i === -1 ? fallback : i;
+  };
+  const idx = {
+    project: colOr('project', 0),
+    description: colOr('description', 1),
+    lead: colOr('lead', 2),
+    assignees: colOr('assignees', 3),
+  };
+
+  const at = (cols: string[], i: number) => (cols[i] ?? '').trim();
+
+  return rows
+    .slice(1)
+    .map((cols) => ({
+      project: at(cols, idx.project),
+      description: at(cols, idx.description),
+      lead: at(cols, idx.lead),
+      assignees: at(cols, idx.assignees)
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    }))
+    .filter((p) => p.project);
+}

--- a/content/events/gcc2026/cofest/index.md
+++ b/content/events/gcc2026/cofest/index.md
@@ -22,6 +22,17 @@ components: true
 
 </div>
 
+## CoFest 2026 Projects
+
+Below are the live projects for CoFest 2026, each with a lead and an assigned team.
+
+<div class="callout text-center">
+    <strong>Note:</strong> If you wish to join a project or if you want to change your assigned project, you can do so by filling out
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">this form</a>. <i>(same form as the one for finding your track)</i>
+</div>
+
+<CofestBoard />
+
 ## What to Expect at CoFest
 
 <div class="callout text-center">
@@ -36,17 +47,6 @@ CoFest participants will collaborate around **project tracks**, each with real, 
 - **Strengthen the platform** – Dig into the core codebase and help make Galaxy more robust.
 - **Grow the training ecosystem** – Update, improve, and create GTN tutorials that help researchers worldwide.
 - **Build community** – Contribute to governance, outreach, and the things that keep Galaxy's community thriving.
-
-## CoFest 2026 Projects
-
-Below are the live projects for CoFest 2026, each with a lead and an assigned team.
-
-<div class="callout text-center">
-    <strong>Note:</strong> If you wish to join a project or if you want to change your assigned project, you can do so by filling out
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">this form</a>. <i>(same form as the one for finding your track)</i>
-</div>
-
-<CofestBoard />
 
 ## How It Works
 

--- a/content/events/gcc2026/cofest/index.md
+++ b/content/events/gcc2026/cofest/index.md
@@ -34,8 +34,8 @@ components: true
       channel on the GCC2026 Slack and we'll place you accordingly.
     </p>
     <p>
-      Haven't filled out the form yet? Use
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">the Find Your Track</a>
+      Haven't filled out the form yet? Use the
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">Find Your Track</a>
       form and you'll be able to pick your project directly or be matched with one based on your interests and skills.
     </p>
 </div>

--- a/content/events/gcc2026/cofest/index.md
+++ b/content/events/gcc2026/cofest/index.md
@@ -24,12 +24,23 @@ components: true
 
 ## CoFest 2026 Projects
 
-Below are the live projects for CoFest 2026, each with a lead and an assigned team.
-
 <div class="callout text-center">
-    <strong>Note:</strong> If you wish to join a project or if you want to change your assigned project, you can do so by filling out
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">this form</a>. <i>(same form as the one for finding your track)</i>
+    <p>
+      <strong>Note:</strong> Already filled out the
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">Find Your Track</a>
+      form? If you'd like to change
+      your assigned project, just reach out in the
+      <a class="font-bold" href="https://gcc2026.slack.com/archives/C0B8L47SQ3A" target="_blank">#cofest</a>
+      channel on the GCC2026 Slack and we'll place you accordingly.
+    </p>
+    <p>
+      Haven't filled out the form yet? Use
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">the Find Your Track</a>
+      form and you'll be able to pick your project directly or be matched with one based on your interests and skills.
+    </p>
 </div>
+
+Below are the live projects for CoFest 2026, each with a lead and an assigned team.
 
 <CofestBoard />
 
@@ -53,14 +64,6 @@ CoFest participants will collaborate around **project tracks**, each with real, 
 CoFest is intentionally informal. We will have two days of collaborative work/brainstorming with people who care about the same things you do. There's no rigid agenda. You'll be matched with a track based on your interests and skills, and each track will have experienced contributors ready to help orient you and keep things moving.
 
 **You don't need to know anyone ahead of time**, and you don't need to come with a finished plan. Just show up, find your people, and leave having developed/planned something real together.
-
-## Find Your Track
-
-To put together the best possible teams, we would like to know your interests. Fill out the form below to share your background, the kind of work you enjoy, and what you're hoping to get out of CoFest.
-
-<div class="flex justify-center my-5">
-  <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" class="inline-flex items-center justify-center rounded px-8 py-2 text-sm font-semibold text-white bg-galaxy-primary hover:bg-galaxy-dark no-underline hover:no-underline" target="_blank">Fill out this form!</a>
-</div>
 
 ## Registration
 

--- a/content/events/gcc2026/cofest/index.md
+++ b/content/events/gcc2026/cofest/index.md
@@ -1,5 +1,6 @@
 ---
 autotoc: false
+components: true
 ---
 
 <div class="text-center my-5">
@@ -35,6 +36,17 @@ CoFest participants will collaborate around **project tracks**, each with real, 
 - **Strengthen the platform** – Dig into the core codebase and help make Galaxy more robust.
 - **Grow the training ecosystem** – Update, improve, and create GTN tutorials that help researchers worldwide.
 - **Build community** – Contribute to governance, outreach, and the things that keep Galaxy's community thriving.
+
+## CoFest 2026 Projects
+
+Below are the live projects for CoFest 2026, each with a lead and an assigned team.
+
+<div class="callout text-center">
+    <strong>Note:</strong> If you wish to join a project or if you want to change your assigned project, you can do so by filling out
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVznubQqoEZYHT0IFoG5zumoXI0oyaBxcNEgOUFnWzVLChkw/viewform?usp=sharing&ouid=117702235489827456804" target="_blank">this form</a>. <i>(same form as the one for finding your track)</i>
+</div>
+
+<CofestBoard />
 
 ## How It Works
 


### PR DESCRIPTION
Also adds a section to the existing cofest site under the event for these projects.

## Section on the Cofest page:
<img width="1228" height="898" alt="image" src="https://github.com/user-attachments/assets/0ffdb963-8cf9-400f-8c23-d47ca24579f5" />

## Presenter View (for the event):
<img width="1898" height="853" alt="image" src="https://github.com/user-attachments/assets/f53b4b9e-2883-4eb4-9adf-34fc461888ae" />

