### PR TITLE
fix(news): remove stale EU funding metadata ids

### DIFF
--- a/content/news/2019/2019-05-20-tiaas-feedback/index.md
+++ b/content/news/2019/2019-05-20-tiaas-feedback/index.md
@@ -4,10 +4,6 @@ date: "2019-05-20"
 tags: [training, tiaas]
 subsites: [eu, pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest]
 main_subsite: eu
-contributions:
-  funding:
-    - usegalaxy-eu
-    - TIaaS
 ---
 
 Recently we ran another Galaxy workshop using UseGalaxy.eu's Training infrastructure as a Service [(TIaaS)](/eu/tiaas/). The workshop was an "Introduction to Galaxy and RNA-seq" run over two afternoons at the Peter MacCallum Cancer Centre in Melbourne, Australia. The attendees were a mix of students and postdocs and their feedback was good, they liked the hands-on, practical nature of the course. Thanks to the Galaxy EU team for enabling the course through providing the convenience of the TIaaS service.

--- a/content/news/2022/2022-06-23-reached-50000-users/index.md
+++ b/content/news/2022/2022-06-23-reached-50000-users/index.md
@@ -27,10 +27,6 @@ contributions:
     - bmbf
     - dfg
     - uni-freiburg
-    - pari
-    - neic
-    - galaxy-freiburg
-    - usegalaxy-eu
 ---
 
 ![50,000 users](./reached_50000_users.png)

--- a/content/news/2022/2022-08-05-galaxy-open-api/index.md
+++ b/content/news/2022/2022-08-05-galaxy-open-api/index.md
@@ -9,8 +9,6 @@ main_subsite: freiburg
 contributions:
   authorship:
     - davelopez
-  funding:
-    - usegalaxy-eu
 ---
 
 Since Galaxy release 22.05 it's much easier to **discover**, **explore**, **learn** and **experiment** with the _Galaxy Rest API_.


### PR DESCRIPTION
## Summary

This removes stale `contributions.funding` entries from three migrated EU news posts whose IDs no longer exist in the synced GTN vocabulary.

The affected IDs were removed from `content/GRANTS.yaml` / `content/ORGANISATIONS.yaml` by the latest `sync/training-material` update, which caused full news metadata validation to fail on otherwise unrelated PRs.

## Why

Galaxy Hub validates news frontmatter funding IDs against the synced GTN vocabulary. These migrated posts referenced legacy service/project-style IDs such as `usegalaxy-eu`, `TIaaS`, `pari`, `neic`, and `galaxy-freiburg`.

Removing the stale references is the smallest Hub-side fix because:

- it unblocks `Metadata Validation`
- it avoids adding local vocabulary entries that the next GTN sync may remove again
- it keeps the visible article content unchanged
- durable vocabulary restoration, if needed, belongs upstream in `galaxyproject/training-material`
