### PR TITLE
Update Galaxy citation to 2026 NAR paper

### DIFF
--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1266,7 +1266,7 @@ const pillars = [
       <div class="cite-container">
         <h2>Cite Galaxy</h2>
         <p class="cite-text">
-          The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update,
+          The Galaxy Community. Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update.
           <em>Nucleic Acids Research</em>, 2026;, gkag469,
           <a href="https://doi.org/10.1093/nar/gkag469" target="_blank" rel="noopener noreferrer">doi:10.1093/nar/gkag469</a>
         </p>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1267,7 +1267,7 @@ const pillars = [
         <h2>Cite Galaxy</h2>
         <p class="cite-text">
           The Galaxy Community. Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update.
-          <em>Nucleic Acids Research</em>, 2026;, gkag469,
+          <em>Nucleic Acids Research</em>, 2026; gkag469,
           <a href="https://doi.org/10.1093/nar/gkag469" target="_blank" rel="noopener noreferrer">doi:10.1093/nar/gkag469</a>
         </p>
         <a href="/citing-galaxy/" class="cite-guide-link">Full citation guide &rarr;</a>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1268,7 +1268,9 @@ const pillars = [
         <p class="cite-text">
           The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update,
           <em>Nucleic Acids Research</em>, 2026;, gkag469,
-          <a href="https://doi.org/10.1093/nar/gkag469" target="_blank" rel="noopener noreferrer">https://doi.org/10.1093/nar/gkag469</a>
+          <a href="https://doi.org/10.1093/nar/gkag469" target="_blank" rel="noopener noreferrer"
+            >https://doi.org/10.1093/nar/gkag469</a
+          >
         </p>
         <a href="/citing-galaxy/" class="cite-guide-link">Full citation guide &rarr;</a>
       </div>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1266,12 +1266,9 @@ const pillars = [
       <div class="cite-container">
         <h2>Cite Galaxy</h2>
         <p class="cite-text">
-          The Galaxy Community. &ldquo;The Galaxy platform for accessible, reproducible, and collaborative data
-          analyses: 2024 update.&rdquo;
-          <em>Nucleic Acids Res.</em> 2024, 52(W1):W83-W94.
-          <a href="https://doi.org/10.1093/nar/gkae410" target="_blank" rel="noopener noreferrer"
-            >doi:10.1093/nar/gkae410</a
-          >
+          The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update,
+          <em>Nucleic Acids Research</em>, 2026;, gkag469,
+          <a href="https://doi.org/10.1093/nar/gkag469" target="_blank" rel="noopener noreferrer">https://doi.org/10.1093/nar/gkag469</a>
         </p>
         <a href="/citing-galaxy/" class="cite-guide-link">Full citation guide &rarr;</a>
       </div>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1268,7 +1268,7 @@ const pillars = [
         <p class="cite-text">
           The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update,
           <em>Nucleic Acids Research</em>, 2026;, gkag469,
-          <a href="https://doi.org/10.1093/nar/gkag469" target="_blank" rel="noopener noreferrer">https://doi.org/10.1093/nar/gkag469</a>
+          <a href="https://doi.org/10.1093/nar/gkag469" target="_blank" rel="noopener noreferrer">doi:10.1093/nar/gkag469</a>
         </p>
         <a href="/citing-galaxy/" class="cite-guide-link">Full citation guide &rarr;</a>
       </div>

--- a/content/citing-galaxy/index.md
+++ b/content/citing-galaxy/index.md
@@ -9,7 +9,7 @@ components: true
 
 When you use Galaxy and want to publish your work, please cite this paper:
 
-* The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update, *Nucleic Acids Research*, 2026;, gkag469, https://doi.org/10.1093/nar/gkag469 <CopyButton text='The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update, *Nucleic Acids Research*, 2026;, gkag469, https://doi.org/10.1093/nar/gkag469' />
+* The Galaxy Community. Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update. *Nucleic Acids Research*, 2026; gkag469, https://doi.org/10.1093/nar/gkag469 <CopyButton text='The Galaxy Community. Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update. *Nucleic Acids Research*, 2026; gkag469, https://doi.org/10.1093/nar/gkag469' />
 
 This and other references are also [available in GitHub](https://github.com/galaxyproject/galaxy/blob/dev/CITATION) as a [CITATION file](http://software-carpentry.org/blog/2013/09/introducing-citation-files.html).
 

--- a/content/citing-galaxy/index.md
+++ b/content/citing-galaxy/index.md
@@ -9,7 +9,7 @@ components: true
 
 When you use Galaxy and want to publish your work, please cite this paper:
 
-* The Galaxy Community. [The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update](https://doi.org/10.1093/nar/gkae410), *Nucleic Acids Research*, 2024, 52(W1):W83-W94. doi:10.1093/nar/gkae410 <CopyButton text='The Galaxy Community. "The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update." Nucleic Acids Research, 2024, 52(W1):W83-W94. doi:10.1093/nar/gkae410' />
+* The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update, *Nucleic Acids Research*, 2026;, gkag469, https://doi.org/10.1093/nar/gkag469 <CopyButton text='The Galaxy Community, Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update, *Nucleic Acids Research*, 2026;, gkag469, https://doi.org/10.1093/nar/gkag469' />
 
 This and other references are also [available in GitHub](https://github.com/galaxyproject/galaxy/blob/dev/CITATION) as a [CITATION file](http://software-carpentry.org/blog/2013/09/introducing-citation-files.html).
 


### PR DESCRIPTION
To update the citations, I based myself on the output of the **Cite** tab at https://doi.org/10.1093/nar/gkag469.


<img width="908" height="463" alt="afbeelding" src="https://github.com/user-attachments/assets/6d596836-a608-4c71-a358-770ab02d71c8" />

This does change the style that was previously adhered to:

Old: <img width="845" height="255" alt="afbeelding" src="https://github.com/user-attachments/assets/61a209a2-3ae3-4369-9fd9-b1539d2fbe28" />


New: 
<img width="809" height="267" alt="afbeelding" src="https://github.com/user-attachments/assets/f80fb30f-2aaa-4eae-b3c9-3fa4ade314ab" />

Please change the style of the citation if there would be another preferred one for the Galaxy Project. 

Flagging that it is also out of date at https://github.com/galaxyproject/galaxy-hub/blob/acbc8c62000a1a97e5117c608686798729a38959/astro/src/pages/usegalaxy/welcome.astro#L189 but that is for the .org center panel so not sure if I could see the visible impact of the change through a local deployment through `make dev`, especially with the presence of these UTF-8 general punctuations.   


Thank you!