### PR TITLE
Stop Playwright tests waiting on external embeds

### DIFF
--- a/astro/tests/content-rendering.spec.ts
+++ b/astro/tests/content-rendering.spec.ts
@@ -94,7 +94,10 @@ test.describe('Content Rendering', () => {
     });
 
     test('SIG microbial page renders inlined linkbox sidebar', async ({ page }) => {
-      await page.goto('/community/sig/microbial/');
+      // waitUntil: 'domcontentloaded' -- this page embeds several external iframes
+      // (GTN, galaxy_codex, Google Calendar) and the default 'load' blocks on them,
+      // flaking in CI. We only assert on the server-rendered inlined linkbox.
+      await page.goto('/community/sig/microbial/', { waitUntil: 'domcontentloaded' });
       await expect(page.getByText('Galaxy Community Board')).toBeVisible();
     });
 

--- a/astro/tests/redirects.spec.ts
+++ b/astro/tests/redirects.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from '@playwright/test';
 
 test.describe('External URL redirects', () => {
   test('news item with external_url redirects to target', async ({ page }) => {
-    const response = await page.goto('/news/2024-12-19-community_page/');
+    // waitUntil: 'commit' so we only verify the redirect lands -- the default
+    // 'load' waits for the external GTN target to fully load, which flakes in CI.
+    const response = await page.goto('/news/2024-12-19-community_page/', { waitUntil: 'commit' });
     expect(response?.status()).toBe(200);
 
     await expect(page).toHaveURL(


### PR DESCRIPTION
Two Playwright tests -- the microbial SIG page and the `external_url` news redirect -- have been failing on basically every open PR, including ones that don't touch those pages at all (I noticed it on #4091). The failures are always a 30s `page.goto` timeout waiting until "load".

The root cause is that both pages depend on third-party content and `page.goto` defaults to `waitUntil: 'load'`, which blocks until *every* subresource finishes. The microbial page embeds a pile of external iframes (GTN, galaxy_codex, Google Calendar) plus a GitHub-hosted image; the news item does a server-side redirect out to `training.galaxyproject.org`. When those hosts are slow from the GitHub runners, the `load` event never fires and the navigation times out. Nothing in the PRs is actually broken -- it's the runner's link to those external hosts. (The sibling `/community/sig/genome-annotation/` linkbox test has no external embeds and never flakes, which is the tell.)

Neither test actually cares about the external content. The microbial test only checks that the inlined linkbox ("Galaxy Community Board") renders, and the redirect test only checks the response status and the final URL. So I switched them to `domcontentloaded` / `commit` respectively, which stop waiting on resources the assertions don't touch. Both still pass locally, and they no longer hang on third-party uptime.