### PR TITLE
Consistency in naming NFDI in Hub messages

### DIFF
--- a/content/events/2025-04-22-galaxy-imaging-hackathon/index.md
+++ b/content/events/2025-04-22-galaxy-imaging-hackathon/index.md
@@ -5,7 +5,7 @@ end: '2025-04-24'
 location:
   name: "Freiburg, Germany"
 contact: "Beatriz Serrano-Solano, Diana Chiang Jurado"
-tags: [hackathon, imaging, bioimaging, esg, esg-wp1, esg-wp5]
+tags: [hackathon, imaging, bioimaging, esg, esg-wp1, esg-wp5, nfdi]
 subsites: [all, esg, eu]
 contributions:
   organisers:
@@ -15,7 +15,6 @@ contributions:
     - eubi
   funding:
     - eu
-    - nfdi
     - oscars
     - nfdi4bioimage
 ---

--- a/content/events/2026-04-02-domps-ai-in-biology/index.md
+++ b/content/events/2026-04-02-domps-ai-in-biology/index.md
@@ -9,7 +9,7 @@ location:
   url: https://dompssymposium.wixsite.com/domps
 gtn: true
 contact: "Anup Kumar: kumara@informatik.uni-freiburg.de"
-tags: [conference, talk]
+tags: [conference, talk, nfdi]
 subsites: [all]
 contributions:
   instructors:
@@ -19,7 +19,7 @@ contributions:
     - uni-freiburg
     - elixir-europe
     - nfdi4plants
-    - nfdi
+    - nfdi4bioimage
 ---
 
 

--- a/content/news/2023/2023-09-12-cordi/index.md
+++ b/content/news/2023/2023-09-12-cordi/index.md
@@ -12,7 +12,6 @@ contributions:
     - sanjaysrikakulam
   funding:
     - eu
-    - nfdi
     - nfdi4bioimage
     - nfdi4plants
     - elixir-europe

--- a/content/news/2025/2025-06-23-rspace-integration/index.md
+++ b/content/news/2025/2025-06-23-rspace-integration/index.md
@@ -4,7 +4,7 @@ date: "2025-06-23"
 tease: "Analyze data with Galaxy, keep it under control on RSpace"
 hide_tease: false
 subsites: [all,esg]
-tags: [esg, esg-wp2, "new feature", rdm]
+tags: [esg, esg-wp2, "new feature", rdm, nfdi]
 contributions:
   authorship:
     - kysrpex
@@ -13,7 +13,6 @@ contributions:
     - eurosciencegateway
     - uni-freiburg
     - elixir-europe
-    - nfdi
 ---
 
 [RSpace](https://www.researchspace.com/) is an open-source research data management system (RDM) and electronic lab

--- a/content/news/2025/2025-11-13-eosc-symposium2025/index.md
+++ b/content/news/2025/2025-11-13-eosc-symposium2025/index.md
@@ -2,7 +2,7 @@
 title: "One framework, one workflow, many communities: Freiburg Galaxy team at EOSC Symposium 2025"
 date: "2025-11-13"
 tease: "Galaxy showed how 'one framework, one workflow, many communities' can run cross-disciplinary imaging analyses on the emerging EOSC Federation. Here is what we presented, with slides and video."
-tags: [eosc, workflow, workflowhub, imaging, fair, interoperability, pulsar, federation, reproducibility, esg, esg-wp1, esg-wp4, esg-wp2, esg-wp5, climate, esg-wp3]
+tags: [eosc, workflow, workflowhub, imaging, fair, interoperability, pulsar, federation, reproducibility, esg, esg-wp1, esg-wp4, esg-wp2, esg-wp5, climate, esg-wp3, nfdi]
 subsites: [all, esg]
 main_subsite: eu
 contributions:
@@ -17,7 +17,6 @@ contributions:
     - elixir-europe
     - deNBI
     - mwk
-    - nfdi
     - egi
     - ifremer
     - fiesta

--- a/content/news/2025/2025-11-21-eosc-symposium-berd/index.md
+++ b/content/news/2025/2025-11-21-eosc-symposium-berd/index.md
@@ -10,7 +10,6 @@ contributions:
     - dadrasarmin
   funding:
     - eu
-    - nfdi
     - eurosciencegateway
 ---
 At [EOSC Symposium 2025](https://eosc.eu/news/lets-seize-this-moment-momentum-made-visible-at-eosc-symposium-2025/), there was an interesting lightning talk about "BERD@NFDI – Galaxy Project B-Plan Use Case," presented in a compelling screencast and a dedicated Lightning Talk by Dr. Felicitas Sommer. This project tackles a difficult challenge: making the regulatory information from thousands of unstructured dataset such as land-use plans accessible for interdisciplinary research. For the [Galaxy Project](https://galaxyproject.org/), this use case is a promising story of collaboration, demonstrating how our open platform serves as a critical engine for data analysis and FAIR data-practices in new research domains.


### PR DESCRIPTION
As suggested here: https://github.com/usegalaxy-eu/issues/issues/938#issuecomment-4197196396
I removed  NFDI as a funder to only keep the specific NFDI projects that are actual funders from recent blog posts on the hub.
Instead, I added NFDI as a tag if the post did not already have it.
The idea is to differentiate between actual funding (bioimaging, dataplant, etc.) and the general use in an NFDI context, which is now available as a tag now.

