### PR TITLE
fix(ci): sync training-material via authenticated sparse checkout

### DIFF
--- a/.github/workflows/sync-training-material-metadata.yml
+++ b/.github/workflows/sync-training-material-metadata.yml
@@ -27,15 +27,30 @@ jobs:
           client-id: ${{ secrets.HUB_BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.HUB_BOT_APP_PRIVATE_KEY }}
 
-      - name: Download files from training-material
+      - name: Checkout training-material repository
+        uses: actions/checkout@v4
+        with:
+          repository: galaxyproject/training-material
+          path: training-material
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+          sparse-checkout: |
+            CONTRIBUTORS.yaml
+            ORGANISATIONS.yaml
+            GRANTS.yaml
+            bin/schema-contributors.yaml
+            bin/schema-grants.yaml
+            bin/schema-organisations.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Copy files from training-material
         run: |
-          # Download the YAML files directly from GitHub's raw content
-          curl -o content/CONTRIBUTORS.yaml https://raw.githubusercontent.com/galaxyproject/training-material/main/CONTRIBUTORS.yaml
-          curl -o content/ORGANISATIONS.yaml https://raw.githubusercontent.com/galaxyproject/training-material/main/ORGANISATIONS.yaml
-          curl -o content/GRANTS.yaml https://raw.githubusercontent.com/galaxyproject/training-material/main/GRANTS.yaml
-          curl -o content/schema-contributors.yaml https://raw.githubusercontent.com/galaxyproject/training-material/main/bin/schema-contributors.yaml
-          curl -o content/schema-grants.yaml https://raw.githubusercontent.com/galaxyproject/training-material/main/bin/schema-grants.yaml
-          curl -o content/schema-organisations.yaml https://raw.githubusercontent.com/galaxyproject/training-material/main/bin/schema-organisations.yaml
+          cp training-material/CONTRIBUTORS.yaml content/CONTRIBUTORS.yaml
+          cp training-material/ORGANISATIONS.yaml content/ORGANISATIONS.yaml
+          cp training-material/GRANTS.yaml content/GRANTS.yaml
+          cp training-material/bin/schema-contributors.yaml content/schema-contributors.yaml
+          cp training-material/bin/schema-grants.yaml content/schema-grants.yaml
+          cp training-material/bin/schema-organisations.yaml content/schema-organisations.yaml
 
       - name: Check for changes
         id: check-changes


### PR DESCRIPTION
## Problem

Sync PR #4119 would have deleted real data and replaced it with a GitHub rate-limit error message (`429: Too Many Requests`), wiping out `GRANTS.yaml` and two schema files (+6 / −792).

## Root cause

The workflow fetched the six files with **unauthenticated** `curl` against `raw.githubusercontent.com`. Shared runner IPs hit the anonymous rate limit (429), and plain `curl -o` writes the error body into the file instead of failing — so the garbage got committed.

## Fix

Replace `curl` with an authenticated, shallow, sparse `actions/checkout` of `galaxyproject/training-material`, then `cp` the six files:

- **Authenticated** via the App token → high per-app rate limit, no anonymous 429.
- **`git` aborts on failure** → can't write error bodies into files.
- **Sparse checkout** → fetches only the 6 files, not the multi-GB repo.

`sparse-checkout-cone-mode: false` is required because the `bin/schema-*.yaml` are individual files.

Verified locally: exactly the 6 files fetch, all valid YAML, ~2.6 MB of git data.