### PR TITLE
ci: add Dependabot config for github-actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    cooldown:
+      default-days: 7
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /astro
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 7
+    groups:
+      all-npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
Commits a `dependabot.yml` so version updates are tracked in the repo rather than only in the GitHub UI.

- Tracks `github-actions` (`/.github/workflows`) and `npm` (`/astro`)
- All updates per ecosystem roll into a single PR (catch-all group)
- 7-day cooldown on freshly published versions (security updates unaffected)