### PR TITLE
fix: remove stray training-material gitlink breaking checkout cleanup

### DIFF
--- a/.github/workflows/sync-training-material-metadata.yml
+++ b/.github/workflows/sync-training-material-metadata.yml
@@ -52,6 +52,9 @@ jobs:
           cp training-material/bin/schema-grants.yaml content/schema-grants.yaml
           cp training-material/bin/schema-organisations.yaml content/schema-organisations.yaml
 
+      - name: Remove training-material checkout
+        run: rm -rf training-material
+
       - name: Check for changes
         id: check-changes
         run: |


### PR DESCRIPTION
## Problem

Every `actions/checkout` post-job cleanup fails with:

fatal: No url found for submodule path 'training-material' in .gitmodules
##[error]The process '/usr/bin/git' failed with exit code 128

This fails the `Compress images` workflow on `main` (scheduled run, 2026-07-19) and on any PR that touches images, e.g. #4141 — where the failure is unrelated to the PR's own changes.

## Cause

557c32d63 (from #4135) accidentally committed the `training-material` checkout directory as a gitlink:

160000 dd6808777ed19e56dc0cf2347e8ab7453c023ba3 0     training-material

There is no matching entry in `.gitmodules`, so `git submodule foreach` — which `actions/checkout` runs during cleanup — aborts.

The gitlink appears because `.github/workflows/sync-training-material-metadata.yml` checks out `galaxyproject/training-material` into `training-material/` *inside* the workspace. `peter-evans/create-pull-request` then stages that nested repo along with the synced YAML files.

## Fix

1. Remove the stray gitlink from the index (`git rm --cached training-material`).
2. Delete the `training-material/` checkout in the sync workflow once the files are copied, so `create-pull-request` can never stage it again.

## Verification

- `git ls-files -s | grep '^160000'` now lists only `utils/utillib`, which has a valid `.gitmodules` entry.
- Next `Compress images` run on `main` should pass.
