### PR TITLE
Lint for filename case collisions and enforce lowercase on new assets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Full history so the filename-case lint can diff added files
+          # against the PR base ref.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -71,6 +75,8 @@ jobs:
           cache-dependency-path: astro/package-lock.json
 
       - name: Lint content
+        env:
+          LINT_BASE_REF: ${{ github.event.pull_request.base.sha }}
         run: cd astro && npm ci && npm run content:lint
 
   unit-tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Full history so the filename-case lint can diff added files
-          # against the PR base ref.
-          fetch-depth: 0
+          # Depth 2 so the PR merge commit's parents are present: HEAD^1 is
+          # the current base branch tip, which the filename-case lint diffs
+          # added files against.
+          fetch-depth: 2
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -76,7 +77,9 @@ jobs:
 
       - name: Lint content
         env:
-          LINT_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          # pull_request checkouts are the PR merge commit, so HEAD^1 is the
+          # base branch tip (fresh, unlike event.pull_request.base.sha)
+          LINT_BASE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || '' }}
         run: cd astro && npm ci && npm run content:lint
 
   unit-tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ A CI lint check enforces these rules on every PR. If your directory name doesn't
 
 **Date-prefixed directories** (like `2025-10-15-my-event`) keep the date prefix unchanged; only the part after the date is normalized.
 
+**Asset file naming**: Name new images and other asset files (`.png`, `.jpg`, `.pdf`, ...) in lowercase — `keynote.jpg`, not `Keynote.jpg`. Two files whose paths differ only in case (`Keynote.jpg` and `keynote.jpg`) collide on macOS and Windows, where only one lands in the working tree and git reports a phantom modification. The content lint fails on any such case-only collision, and on newly added asset files with uppercase names. Existing uppercase files are left alone.
+
 ## Writing content
 
 ### Frontmatter

--- a/astro/package.json
+++ b/astro/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write 'src/**/*.{js,mjs,ts,vue,astro,css}'",
     "format:check": "prettier --check 'src/**/*.{js,mjs,ts,vue,astro,css}'",
     "normalize": "node src/build/normalize-content.mjs",
-    "content:lint": "node src/build/normalize-content.mjs --all --check && node src/build/check-dir-names.mjs"
+    "content:lint": "node src/build/normalize-content.mjs --all --check && node src/build/check-dir-names.mjs && node src/build/check-filename-case.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",

--- a/astro/src/build/check-filename-case.mjs
+++ b/astro/src/build/check-filename-case.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Guards against filename-case problems that break case-insensitive checkouts
+ * (macOS APFS/HFS+, Windows NTFS default).
+ *
+ * Two checks:
+ *
+ * 1. Case-collision (always runs, repo-wide). Fails if any two tracked paths
+ *    are equal when lowercased -- e.g. `Keynote.jpg` and `keynote.jpg` in the
+ *    same directory. On a case-insensitive filesystem only one of the two
+ *    actually lands in the working tree, git reports a permanent phantom
+ *    modification, and branch switches flip which file is present. This is the
+ *    exact class of bug that this lint exists to stop; it passes cleanly on a
+ *    repo with no collisions.
+ *
+ * 2. New-asset lowercase (runs when a base ref is resolvable). Fails if this
+ *    branch *adds* an asset file (image/media/doc) whose basename contains an
+ *    uppercase letter. Existing files are grandfathered -- we only look at
+ *    files added relative to the base -- so no mass rename is required. This is
+ *    forward-only pressure toward lowercase asset names, which is what keeps
+ *    collision #1 from recurring.
+ *
+ * The base ref comes from LINT_BASE_REF (set to the PR base SHA in CI) or, for
+ * local runs, is auto-detected against upstream/origin `main`. If no base can
+ * be found the new-asset check is skipped with a notice; the collision check
+ * still runs.
+ *
+ * Usage:
+ *   node src/build/check-filename-case.mjs
+ *   LINT_BASE_REF=<sha> node src/build/check-filename-case.mjs
+ */
+
+import { execFileSync } from 'child_process';
+import { join, basename } from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = join(fileURLToPath(import.meta.url), '../../../..');
+
+// Binary/media asset files where a lowercase-name convention is worth enforcing.
+// Source/content types (.md, .html, .yaml, .astro, ...) are deliberately left
+// out -- their naming is governed by the slug rules in check-dir-names.mjs.
+export const ASSET_EXTENSIONS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'svg',
+  'webp',
+  'avif',
+  'ico',
+  'bmp',
+  'tif',
+  'tiff',
+  'pdf',
+  'mp4',
+  'webm',
+  'mov',
+  'm4v',
+  'mp3',
+  'wav',
+  'key',
+  'ppt',
+  'pptx',
+  'xls',
+  'xlsx',
+  'doc',
+  'docx',
+  'zip',
+  'heic',
+]);
+
+/**
+ * Groups of tracked paths that collapse to the same lowercased path. Each group
+ * has two or more distinct real paths that cannot coexist on a case-insensitive
+ * filesystem.
+ */
+export function caseCollisions(paths) {
+  const byLower = new Map();
+  for (const p of paths) {
+    const key = p.toLowerCase();
+    let group = byLower.get(key);
+    if (!group) {
+      group = new Set();
+      byLower.set(key, group);
+    }
+    group.add(p);
+  }
+  return [...byLower.values()].filter((group) => group.size > 1).map((group) => [...group].sort());
+}
+
+export function isAssetPath(p) {
+  const name = basename(p);
+  const dot = name.lastIndexOf('.');
+  if (dot <= 0) return false; // no extension, or dotfile with no real ext
+  return ASSET_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
+}
+
+export function basenameHasUppercase(p) {
+  return /[A-Z]/.test(basename(p));
+}
+
+/** Added asset paths whose basename contains an uppercase letter. */
+export function uppercaseAssets(addedPaths) {
+  return addedPaths.filter((p) => isAssetPath(p) && basenameHasUppercase(p)).sort();
+}
+
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot, maxBuffer: 64 * 1024 * 1024 });
+}
+
+function splitNul(buf) {
+  return buf
+    .toString('utf8')
+    .split('\0')
+    .filter((s) => s.length > 0);
+}
+
+function listTrackedFiles() {
+  return splitNul(git(['ls-files', '-z']));
+}
+
+/** Resolve a base ref to diff against, or null if none is available. */
+function resolveBaseRef() {
+  const explicit = process.env.LINT_BASE_REF;
+  if (explicit && explicit.trim()) {
+    try {
+      return git(['rev-parse', '--verify', '--quiet', `${explicit.trim()}^{commit}`])
+        .toString()
+        .trim();
+    } catch {
+      // fall through to auto-detection
+    }
+  }
+  for (const ref of ['upstream/main', 'origin/main', 'main']) {
+    try {
+      return git(['merge-base', 'HEAD', ref]).toString().trim();
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+/** Files added between `base` and the working tree. */
+function listAddedFiles(base) {
+  return splitNul(git(['diff', '--diff-filter=A', '--name-only', '-z', base]));
+}
+
+function main() {
+  const problems = [];
+
+  const collisions = caseCollisions(listTrackedFiles());
+  for (const group of collisions) {
+    problems.push(`Case-only collision: ${group.join('  <=>  ')}`);
+  }
+
+  const base = resolveBaseRef();
+  if (base) {
+    const flagged = uppercaseAssets(listAddedFiles(base));
+    for (const p of flagged) {
+      problems.push(`New asset must be lowercase: ${p}`);
+    }
+  } else {
+    console.log('Note: no base ref (LINT_BASE_REF / upstream|origin|main) — skipping new-asset lowercase check.');
+  }
+
+  if (problems.length === 0) {
+    console.log('Filename case check passed. ✓');
+    process.exit(0);
+  }
+
+  console.error(`Found ${problems.length} filename-case problem(s):\n`);
+  for (const p of problems) {
+    console.error(`  ${p}`);
+  }
+  console.error(`
+Case-only collisions break on case-insensitive filesystems (macOS, Windows):
+rename one side so the paths differ by more than case, and update references.
+New asset files must use lowercase names (e.g. keynote.jpg, not Keynote.jpg).`);
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/astro/src/build/check-filename-case.mjs
+++ b/astro/src/build/check-filename-case.mjs
@@ -20,10 +20,13 @@
  *    forward-only pressure toward lowercase asset names, which is what keeps
  *    collision #1 from recurring.
  *
- * The base ref comes from LINT_BASE_REF (set to the PR base SHA in CI) or, for
- * local runs, is auto-detected against upstream/origin `main`. If no base can
- * be found the new-asset check is skipped with a notice; the collision check
- * still runs.
+ * The base comes from LINT_BASE_REF (CI sets it to HEAD^1 -- the base branch
+ * tip, since pull_request checkouts are the PR merge commit) or, for local
+ * runs, is auto-detected against upstream/origin `main`. Either way the ref is
+ * resolved through merge-base so a stale or branch-tip ref can't blame files
+ * that landed on the base after this branch diverged. If no base can be found
+ * the new-asset check is skipped with a notice; the collision check still
+ * runs.
  *
  * Usage:
  *   node src/build/check-filename-case.mjs
@@ -32,7 +35,7 @@
 
 import { execFileSync } from 'child_process';
 import { join, basename } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const repoRoot = join(fileURLToPath(import.meta.url), '../../../..');
 
@@ -96,7 +99,8 @@ export function isAssetPath(p) {
 }
 
 export function basenameHasUppercase(p) {
-  return /[A-Z]/.test(basename(p));
+  // \p{Lu} rather than [A-Z] so accented capitals (Ä.jpg) are caught too
+  return /\p{Lu}/u.test(basename(p));
 }
 
 /** Added asset paths whose basename contains an uppercase letter. */
@@ -119,20 +123,14 @@ function listTrackedFiles() {
   return splitNul(git(['ls-files', '-z']));
 }
 
-/** Resolve a base ref to diff against, or null if none is available. */
+/** Resolve a base commit to diff against, or null if none is available. */
 function resolveBaseRef() {
   const explicit = process.env.LINT_BASE_REF;
-  if (explicit && explicit.trim()) {
+  const candidates = explicit && explicit.trim() ? [explicit.trim()] : ['upstream/main', 'origin/main', 'main'];
+  for (const ref of candidates) {
     try {
-      return git(['rev-parse', '--verify', '--quiet', `${explicit.trim()}^{commit}`])
-        .toString()
-        .trim();
-    } catch {
-      // fall through to auto-detection
-    }
-  }
-  for (const ref of ['upstream/main', 'origin/main', 'main']) {
-    try {
+      // merge-base, not the ref itself: a branch tip that moved after this
+      // branch diverged would otherwise blame its new files on this branch
       return git(['merge-base', 'HEAD', ref]).toString().trim();
     } catch {
       // try next candidate
@@ -143,7 +141,9 @@ function resolveBaseRef() {
 
 /** Files added between `base` and the working tree. */
 function listAddedFiles(base) {
-  return splitNul(git(['diff', '--diff-filter=A', '--name-only', '-z', base]));
+  // --no-renames so `git mv keynote.jpg Keynote.jpg` counts as an add of the
+  // new name instead of slipping through as a rename
+  return splitNul(git(['diff', '--no-renames', '--diff-filter=A', '--name-only', '-z', base]));
 }
 
 function main() {
@@ -180,6 +180,6 @@ New asset files must use lowercase names (e.g. keynote.jpg, not Keynote.jpg).`);
   process.exit(1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/astro/src/build/check-filename-case.test.mjs
+++ b/astro/src/build/check-filename-case.test.mjs
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { caseCollisions, isAssetPath, basenameHasUppercase, uppercaseAssets } from './check-filename-case.mjs';
+
+describe('filename-case lint helpers', () => {
+  describe('caseCollisions', () => {
+    it('flags two paths that differ only in case', () => {
+      const groups = caseCollisions([
+        'content/images/events/gcc2026/Keynote.jpg',
+        'content/images/events/gcc2026/keynote.jpg',
+      ]);
+      expect(groups).toEqual([
+        ['content/images/events/gcc2026/Keynote.jpg', 'content/images/events/gcc2026/keynote.jpg'],
+      ]);
+    });
+
+    it('flags directory-case collisions, not just filenames', () => {
+      const groups = caseCollisions(['content/Foo/a.png', 'content/foo/a.png']);
+      expect(groups).toEqual([['content/Foo/a.png', 'content/foo/a.png']]);
+    });
+
+    it('returns nothing when all paths are case-distinct', () => {
+      expect(caseCollisions(['a/one.png', 'a/two.png', 'b/one.png'])).toEqual([]);
+    });
+
+    it('does not treat a path as colliding with itself', () => {
+      expect(caseCollisions(['content/keynote.jpg', 'content/keynote.jpg'])).toEqual([]);
+    });
+  });
+
+  describe('isAssetPath', () => {
+    it('recognizes image and media extensions regardless of case', () => {
+      expect(isAssetPath('content/x/Photo.JPG')).toBe(true);
+      expect(isAssetPath('content/x/clip.mp4')).toBe(true);
+      expect(isAssetPath('content/x/slides.pptx')).toBe(true);
+    });
+
+    it('ignores source/content files', () => {
+      expect(isAssetPath('content/news/2026/post/index.md')).toBe(false);
+      expect(isAssetPath('astro/src/build/thing.mjs')).toBe(false);
+      expect(isAssetPath('content/x/data.yaml')).toBe(false);
+    });
+
+    it('ignores extensionless paths and dotfiles', () => {
+      expect(isAssetPath('content/x/Makefile')).toBe(false);
+      expect(isAssetPath('content/x/.slug-bypass')).toBe(false);
+    });
+  });
+
+  describe('basenameHasUppercase', () => {
+    it('looks only at the basename, not the directory', () => {
+      expect(basenameHasUppercase('content/Legacy/keynote.jpg')).toBe(false);
+      expect(basenameHasUppercase('content/legacy/Keynote.jpg')).toBe(true);
+    });
+  });
+
+  describe('uppercaseAssets', () => {
+    it('flags added assets with uppercase basenames and ignores the rest', () => {
+      const flagged = uppercaseAssets([
+        'content/images/events/gcc2026/Keynote.jpg', // asset, uppercase -> flagged
+        'content/images/events/gcc2026/banner.png', // asset, lowercase -> ok
+        'content/news/2026/GCC-Recap/index.md', // uppercase dir but .md, not an asset
+        'content/x/Report.PDF', // asset, uppercase -> flagged
+      ]);
+      expect(flagged).toEqual(['content/images/events/gcc2026/Keynote.jpg', 'content/x/Report.PDF']);
+    });
+  });
+});

--- a/astro/src/build/check-filename-case.test.mjs
+++ b/astro/src/build/check-filename-case.test.mjs
@@ -51,6 +51,11 @@ describe('filename-case lint helpers', () => {
       expect(basenameHasUppercase('content/Legacy/keynote.jpg')).toBe(false);
       expect(basenameHasUppercase('content/legacy/Keynote.jpg')).toBe(true);
     });
+
+    it('catches accented capitals, not just A-Z', () => {
+      expect(basenameHasUppercase('content/legacy/Ärger.jpg')).toBe(true);
+      expect(basenameHasUppercase('content/legacy/ärger.jpg')).toBe(false);
+    });
   });
 
   describe('uppercaseAssets', () => {


### PR DESCRIPTION
Follow-up to #4143. That was the second time a case-only filename collision (`Keynote.jpg` vs `keynote.jpg`) slipped in, so this adds a lint to catch the class of problem going forward.

`check-filename-case.mjs` joins the `content:lint` pipeline with two checks:

1. **Case-collision (always, repo-wide):** fails if any two tracked paths are equal when lowercased. These collide on case-insensitive filesystems (macOS, Windows) -- only one file lands in the working tree, git reports a permanent phantom modification, and branch switches flip which one is present. The repo is clean today, so this passes.
2. **New-asset lowercase (forward-only):** fails if a PR *adds* an image/media/doc asset with an uppercase basename. It only looks at files added relative to the PR base, so the ~1,600 existing uppercase files are untouched -- no mass rename. The content-lint job checks out at depth 2 and diffs against `HEAD^1` of the PR merge commit (the current base tip), so no full-history fetch is needed.

Includes unit tests and a CONTRIBUTING note. I deliberately didn't try to enforce lowercase on all existing files -- that's a much bigger change and a separate discussion if we want it.

