### PR TITLE
Add print stylesheet

### DIFF
--- a/astro/src/components/layout/ContentWithToc.astro
+++ b/astro/src/components/layout/ContentWithToc.astro
@@ -40,7 +40,7 @@ const showToc = autotoc && filteredHeadings.length >= 2;
 }
 
 {/* Content with optional TOC sidebar */}
-<div class:list={['px-6 sm:px-8 pt-6', showToc && 'lg:flex lg:gap-8']}>
+<div class:list={['content-with-toc px-6 sm:px-8 pt-6', showToc && 'lg:flex lg:gap-8']}>
   {/* Main Content */}
   <div class:list={['prose prose-lg prose-galaxy max-w-none', showToc && 'lg:flex-1 lg:min-w-0']}>
     <slot />

--- a/astro/src/components/layout/Sidebar.astro
+++ b/astro/src/components/layout/Sidebar.astro
@@ -14,7 +14,9 @@ interface Props {
 const { navbar, initialSubsite } = Astro.props as Props;
 ---
 
-<aside class="hidden lg:flex flex-col w-64 bg-galaxy-dark text-white fixed left-0 top-0 h-screen overflow-y-auto z-40">
+<aside
+  class="site-sidebar hidden lg:flex flex-col w-64 bg-galaxy-dark text-white fixed left-0 top-0 h-screen overflow-y-auto z-40"
+>
   <!-- Logo Section -->
   <div class="p-4 pr-6 border-b border-medium-bg flex justify-center">
     <a href="/" class="sidebar-logo block">

--- a/astro/src/layouts/ArticleLayout.astro
+++ b/astro/src/layouts/ArticleLayout.astro
@@ -93,7 +93,7 @@ const hasMetadata =
       }
       {
         (backLink || editUrl) && (
-          <div class="flex justify-between items-center pt-4 border-t border-ebony-clay-100">
+          <div class="article-footer-actions flex justify-between items-center pt-4 border-t border-ebony-clay-100">
             {backLink ? (
               <a
                 href={backLink.href}

--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -35,12 +35,14 @@ const navbar = await getSubsiteNavbar(currentSubsite);
     <ClientRouter />
   </head>
   <body class="min-h-screen bg-background text-foreground">
-    <div class="flex min-h-screen overflow-hidden">
+    <div class="site-shell flex min-h-screen overflow-hidden">
       <!-- Sidebar (desktop only) -->
       <Sidebar transition:persist navbar={navbar} initialSubsite={currentSubsite} />
 
       <!-- Mobile header with Vue-powered menu -->
-      <div class="lg:hidden fixed top-0 left-0 right-0 z-50 bg-galaxy-dark p-4 flex items-center justify-between">
+      <div
+        class="site-mobile-header lg:hidden fixed top-0 left-0 right-0 z-50 bg-galaxy-dark p-4 flex items-center justify-between"
+      >
         <a href="/" class="block">
           <img src="/images/galaxy_logo_hub_white.svg" alt="Galaxy Community Hub" class="h-8 w-auto" />
         </a>
@@ -48,13 +50,13 @@ const navbar = await getSubsiteNavbar(currentSubsite);
       </div>
 
       <!-- Main content area -->
-      <main class="flex-1 flex flex-col min-h-screen lg:ml-64 pt-22 lg:pt-0 min-w-0 overflow-x-hidden">
-        <div class="flex-1 p-4 sm:p-6 lg:p-8 bg-light-bg bg-grid">
+      <main class="site-main flex-1 flex flex-col min-h-screen lg:ml-64 pt-22 lg:pt-0 min-w-0 overflow-x-hidden">
+        <div class="site-content flex-1 p-4 sm:p-6 lg:p-8 bg-light-bg bg-grid">
           <slot />
         </div>
 
         <!-- Footer -->
-        <footer class="bg-galaxy-dark text-white py-8 px-4 sm:px-6 lg:px-8">
+        <footer class="site-footer bg-galaxy-dark text-white py-8 px-4 sm:px-6 lg:px-8">
           <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-4 gap-8">
             <div>
               <h3 class="text-lg font-semibold text-galaxy-gold mb-4">Galaxy Project</h3>

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -4,6 +4,7 @@
 @import '@fontsource/atkinson-hyperlegible/400.css';
 @import '@fontsource/atkinson-hyperlegible/700.css';
 @import '@galaxyproject/brand-tokens/theme.css';
+@import './print.css';
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));

--- a/astro/src/styles/print.css
+++ b/astro/src/styles/print.css
@@ -1,0 +1,396 @@
+/* ==========================================================================
+   Print stylesheet
+   ==========================================================================
+
+   Two jobs here, in order of importance:
+
+   1. Make articles print at all. The screen layout nests flex containers
+      (`.site-shell` > `.site-main` > `.site-content`) and clips them with
+      `overflow: hidden`. Chrome fragments flex containers across printed
+      pages very poorly -- paragraphs get truncated mid-sentence and headings
+      vanish leaving only their bottom border. On top of that the mobile
+      header is `position: fixed`, which Chrome repeats on *every* page,
+      painting over whatever content sits under it. Unwinding those three
+      things back to plain block flow is what actually fixes printing.
+
+   2. Survive "Background graphics: off", which is the browser default in the
+      print dialog. Anything that relies on a dark background for contrast --
+      the page header, table headers, code blocks -- renders as white-on-white
+      and disappears. Those all get borders and dark text instead of
+      backgrounds, so they read the same either way.
+
+   Kept in its own file rather than appended to global.css so the print rules
+   stay greppable; global.css imports it last. These rules live outside any
+   cascade layer, so they beat Tailwind's layered utilities.
+   ========================================================================== */
+
+@media print {
+  /* --------------------------------------------------------------------
+     Page setup
+     -------------------------------------------------------------------- */
+  @page {
+    margin: 0.6in 0.55in;
+  }
+
+  /* --------------------------------------------------------------------
+     Hide non-content chrome: navigation, search, interactive controls.
+     -------------------------------------------------------------------- */
+  .site-sidebar,
+  .site-mobile-header,
+  .site-footer,
+  .toc-mobile,
+  .toc-sidebar,
+  .article-footer-actions,
+  .heading-anchor,
+  astro-dev-toolbar,
+  [data-print='hide'] {
+    display: none !important;
+  }
+
+  /* Any stray interactive control that isn't inside the chrome above. */
+  button,
+  input[type='search'],
+  form[action='/search/'],
+  dialog,
+  [role='dialog'] {
+    display: none !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Layout reset -- the actual bug fix.
+
+     `overflow-x: hidden` on the root computes `overflow-y` to `auto`
+     (per spec, a non-visible value on one axis forces the other off
+     `visible`), which makes the root a scroll container and clips printed
+     content past page one.
+     -------------------------------------------------------------------- */
+  html,
+  body {
+    overflow: visible !important;
+    width: auto !important;
+    height: auto !important;
+    min-height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: none !important;
+  }
+
+  /* Unwind the nested flex shells to block flow so content fragments
+     across pages normally. `min-height: 0` drops the min-h-screen floor
+     that would otherwise pad out the last page. */
+  .site-shell,
+  .site-main,
+  .site-content,
+  .content-with-toc {
+    display: block !important;
+    overflow: visible !important;
+    min-height: 0 !important;
+    max-width: none !important;
+    width: auto !important;
+    /* The sidebar is fixed-position on screen, so `main` carries a 16rem
+       left margin to clear it, and top padding to clear the mobile bar.
+       Both leave dead space once the chrome is hidden. */
+    margin: 0 !important;
+    padding: 0 !important;
+    background: none !important;
+  }
+
+  /* Decorative page-background patterns waste ink and hurt text contrast. */
+  .bg-grid,
+  .bg-grid-dark {
+    background-image: none !important;
+  }
+
+  article {
+    display: block !important;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: none !important;
+    box-shadow: none !important;
+  }
+
+  /* Sticky positioning pins an element to the viewport; in print that
+     parks it on page one. */
+  .sticky,
+  [class*='sticky'] {
+    position: static !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Typography
+     -------------------------------------------------------------------- */
+  body {
+    font-size: 10.5pt;
+    line-height: 1.45;
+    color: #000;
+  }
+
+  .prose,
+  .prose-lg,
+  .prose-galaxy {
+    max-width: none !important;
+    font-size: 10.5pt !important;
+    line-height: 1.45 !important;
+    color: #000 !important;
+  }
+
+  .prose p,
+  .prose li {
+    color: #000 !important;
+    orphans: 3;
+    widows: 3;
+  }
+
+  .prose h1,
+  .prose h2,
+  .prose h3,
+  .prose h4,
+  .prose h5,
+  .prose h6 {
+    color: #000 !important;
+    break-after: avoid;
+    break-inside: avoid;
+    page-break-after: avoid;
+  }
+
+  .prose h1 {
+    font-size: 18pt !important;
+  }
+  .prose h2 {
+    font-size: 14pt !important;
+    border-bottom: 1px solid #999 !important;
+  }
+  .prose h3 {
+    font-size: 12pt !important;
+    margin-top: 1.4em !important;
+  }
+  .prose h4 {
+    font-size: 11pt !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Page header -- white text on a dark gradient on screen, which is
+     invisible when background graphics are disabled.
+     -------------------------------------------------------------------- */
+  .page-header {
+    background: none !important;
+    color: #000 !important;
+    padding: 0 0 0.6rem !important;
+    border-bottom: 2px solid #000 !important;
+    border-radius: 0 !important;
+    break-inside: avoid;
+  }
+
+  .page-header::before {
+    display: none !important;
+  }
+
+  .page-header *,
+  .page-header a {
+    color: #000 !important;
+    text-decoration: none !important;
+  }
+
+  /* The gold accent bar beside the title has no text to carry it. */
+  .page-header .bg-galaxy-gold {
+    display: none !important;
+  }
+
+  /* Tag pills: keep the outline readable without a background. */
+  .page-header [class*='border-white'] {
+    border-color: #666 !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Links -- show the target, since a printed link is otherwise a dead end.
+     Scoped to article prose so navigation chrome and badges stay clean.
+     -------------------------------------------------------------------- */
+  .prose a {
+    color: #000 !important;
+    text-decoration: underline !important;
+  }
+
+  .prose a[href^='http']::after {
+    content: ' (' attr(href) ')';
+  }
+
+  /* Root-relative internal links: expand to an absolute URL a reader can type. */
+  .prose a[href^='/']::after {
+    content: ' (https://galaxyproject.org' attr(href) ')';
+  }
+
+  .prose a[href^='http']::after,
+  .prose a[href^='/']::after {
+    font-size: 0.8em;
+    font-weight: normal;
+    color: #444;
+    word-break: break-all;
+  }
+
+  /* Suppress the URL where it would be noise: in-page anchors, image links,
+     and link-styled badges. Table cells are excluded too -- the release notes
+     are full of link-dense tables, and an inline URL in every cell squeezes
+     the columns until ordinary content starts wrapping mid-word. */
+  .prose a[href^='#']::after,
+  .prose a[href^='mailto:']::after,
+  .prose a:has(> img)::after,
+  .prose table a::after,
+  .tool-list a::after,
+  .toc a::after,
+  .heading-anchor::after {
+    content: '' !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Images and figures
+     -------------------------------------------------------------------- */
+  img,
+  figure,
+  svg {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+    /* Cap height so a tall image can't push a mostly-blank page. */
+    max-height: 7in !important;
+    height: auto !important;
+    object-fit: contain;
+  }
+
+  figure {
+    margin: 0.8rem 0 !important;
+    padding: 0 !important;
+  }
+
+  .inline-div {
+    break-inside: avoid;
+  }
+
+  /* --------------------------------------------------------------------
+     Tables -- header cells are white-on-blue on screen, so they vanish
+     without background graphics. Give them a rule instead.
+     -------------------------------------------------------------------- */
+  .prose table {
+    width: 100% !important;
+    font-size: 9pt !important;
+    table-layout: auto;
+    break-inside: auto;
+  }
+
+  .prose th,
+  .prose td {
+    border: 1px solid #999 !important;
+    padding: 0.3rem 0.4rem !important;
+    /* break-word only splits a word that would otherwise overflow; `anywhere`
+       also feeds into min-content sizing and hyphenates ordinary words like
+       "October" in narrow columns. */
+    overflow-wrap: break-word;
+  }
+
+  .prose th {
+    background: none !important;
+    color: #000 !important;
+    border-bottom: 2px solid #000 !important;
+  }
+
+  /* Repeat header rows when a long table spans pages. */
+  thead {
+    display: table-header-group;
+  }
+
+  tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Wrappers that scroll a wide table on screen must not clip it on paper. */
+  .table-wrapper,
+  .overflow-x-auto,
+  .overflow-auto {
+    overflow: visible !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Code -- dark background with light text on screen; unreadable when
+     backgrounds are dropped, so invert to dark-on-light with a border.
+     -------------------------------------------------------------------- */
+  .prose pre {
+    background: none !important;
+    color: #000 !important;
+    border: 1px solid #999 !important;
+    border-radius: 3px !important;
+    padding: 0.5rem 0.65rem !important;
+    font-size: 9pt !important;
+    /* Long lines scroll on screen; on paper they must wrap or be lost. */
+    white-space: pre-wrap !important;
+    overflow-wrap: anywhere;
+    overflow: visible !important;
+    break-inside: avoid;
+  }
+
+  .prose pre code {
+    background: none !important;
+    color: #000 !important;
+  }
+
+  .prose code:not(pre code) {
+    background: none !important;
+    color: #000 !important;
+    border: 1px solid #bbb !important;
+    padding: 0 0.2em !important;
+    font-size: 0.9em !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Content components
+     -------------------------------------------------------------------- */
+  .callout,
+  .gx-tile,
+  .linkbox,
+  .profile-row,
+  blockquote {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .gx-tile,
+  .callout,
+  .linkbox {
+    background: none !important;
+    border: 1px solid #999 !important;
+    box-shadow: none !important;
+  }
+
+  .gx-tile-grid {
+    display: block !important;
+  }
+
+  .gx-tile {
+    margin-bottom: 0.8rem;
+  }
+
+  a.gx-tile--link::before {
+    display: none !important;
+  }
+
+  .prose blockquote {
+    background: none !important;
+    border-left: 3px solid #666 !important;
+    color: #000 !important;
+  }
+
+  /* --------------------------------------------------------------------
+     Belt and braces: nothing should carry an animation or transition into
+     a static medium, and no element should stay transparent on paper.
+     -------------------------------------------------------------------- */
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+    text-shadow: none !important;
+  }
+}

--- a/astro/tests/print.spec.ts
+++ b/astro/tests/print.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Print stylesheet regression tests.
+ *
+ * Background (issue #3544): articles printed with paragraphs truncated
+ * mid-sentence and headings reduced to a bare underline. Three causes --
+ * nested flex containers fragmenting across printed pages, `overflow: hidden`
+ * clipping anything past page one, and a `position: fixed` header that Chrome
+ * repeats on every page and paints over the content beneath it.
+ *
+ * A second class of bug only shows up with "Background graphics" disabled,
+ * which is the default in Chrome's print dialog: anything that relies on a
+ * dark background for contrast (page header, table headers, code blocks)
+ * renders white-on-white and disappears.
+ *
+ * These tests assert against computed styles under `media: 'print'` rather
+ * than pixels, so they stay stable as content changes.
+ */
+
+const ARTICLE = '/news/2026-07-06-gcc2026-recap/';
+const TABLE_PAGE = '/galaxy-updates/2017-10/';
+const CODE_PAGE = '/galaxy-updates/2016-10/';
+
+/** Parsed rgb()/rgba() -> perceived luminance (0 = black, 255 = white). */
+function luminance(color: string): number {
+  const m = color.match(/rgba?\(([^)]+)\)/);
+  if (!m) return NaN;
+  const [r, g, b] = m[1].split(',').map((v) => parseFloat(v));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+test.describe('Print stylesheet', () => {
+  test.describe('site chrome is hidden', () => {
+    test('navigation, footer and TOC do not print', async ({ page }) => {
+      await page.goto(ARTICLE);
+      await page.emulateMedia({ media: 'print' });
+
+      await expect(page.locator('.site-sidebar')).toBeHidden();
+      await expect(page.locator('.site-mobile-header')).toBeHidden();
+      await expect(page.locator('.site-footer')).toBeHidden();
+
+      // The article itself must still be there.
+      await expect(page.locator('article')).toBeVisible();
+      await expect(page.locator('h1').first()).toBeVisible();
+    });
+
+    test('heading anchor links do not print', async ({ page }) => {
+      await page.goto(ARTICLE);
+      await page.emulateMedia({ media: 'print' });
+
+      const anchors = page.locator('.heading-anchor');
+      if ((await anchors.count()) > 0) {
+        await expect(anchors.first()).toBeHidden();
+      }
+    });
+  });
+
+  test.describe('layout is not clipped', () => {
+    test('no print container establishes a scroll/clip context', async ({ page }) => {
+      await page.goto(ARTICLE);
+      await page.emulateMedia({ media: 'print' });
+
+      // `overflow-x: hidden` computes overflow-y to `auto` per spec, which makes
+      // the element a scroll container and drops everything past page one.
+      const selectors = ['html', 'body', '.site-shell', '.site-main', '.site-content'];
+      for (const selector of selectors) {
+        const overflow = await page
+          .locator(selector)
+          .first()
+          .evaluate((el) => {
+            const s = getComputedStyle(el);
+            return { x: s.overflowX, y: s.overflowY };
+          });
+        expect(overflow.x, `${selector} overflow-x`).toBe('visible');
+        expect(overflow.y, `${selector} overflow-y`).toBe('visible');
+      }
+    });
+
+    test('flex shells unwind to block flow so content fragments across pages', async ({ page }) => {
+      await page.goto(ARTICLE);
+      await page.emulateMedia({ media: 'print' });
+
+      for (const selector of ['.site-shell', '.site-main', '.site-content']) {
+        const display = await page
+          .locator(selector)
+          .first()
+          .evaluate((el) => getComputedStyle(el).display);
+        expect(display, `${selector} display`).toBe('block');
+      }
+    });
+
+    test('no element stays fixed or sticky in print', async ({ page }) => {
+      await page.goto(ARTICLE);
+      await page.emulateMedia({ media: 'print' });
+
+      // A fixed element is painted onto every printed page, over the content.
+      const stuck = await page.evaluate(() =>
+        [...document.querySelectorAll('body *')]
+          .filter((el) => {
+            const s = getComputedStyle(el);
+            if (s.display === 'none' || s.visibility === 'hidden') return false;
+            return s.position === 'fixed' || s.position === 'sticky';
+          })
+          .map((el) => `${el.tagName.toLowerCase()}.${el.className}`)
+          .slice(0, 10)
+      );
+      expect(stuck).toEqual([]);
+    });
+  });
+
+  test.describe('readable without background graphics', () => {
+    test('page header text is dark, not white-on-dark', async ({ page }) => {
+      await page.goto(ARTICLE);
+      await page.emulateMedia({ media: 'print' });
+
+      const color = await page
+        .locator('.page-header h1')
+        .first()
+        .evaluate((el) => getComputedStyle(el).color);
+      expect(luminance(color)).toBeLessThan(100);
+    });
+
+    test('table headers are dark text, not white on blue', async ({ page }) => {
+      await page.goto(TABLE_PAGE);
+      await page.emulateMedia({ media: 'print' });
+
+      const th = page.locator('.prose table th').first();
+      await expect(th).toBeVisible();
+      const color = await th.evaluate((el) => getComputedStyle(el).color);
+      expect(luminance(color)).toBeLessThan(100);
+    });
+
+    test('code blocks are dark text and wrap instead of scrolling', async ({ page }) => {
+      await page.goto(CODE_PAGE);
+      await page.emulateMedia({ media: 'print' });
+
+      const pre = page.locator('.prose pre').first();
+      await expect(pre).toBeVisible();
+      const style = await pre.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return { color: s.color, whiteSpace: s.whiteSpace, overflowX: s.overflowX };
+      });
+      expect(luminance(style.color)).toBeLessThan(100);
+      // Long lines scroll on screen; on paper they must wrap or be lost.
+      expect(style.whiteSpace).toBe('pre-wrap');
+      expect(style.overflowX).toBe('visible');
+    });
+  });
+
+  test.describe('link URLs', () => {
+    test('external links print their target', async ({ page }) => {
+      await page.goto(ARTICLE);
+      await page.emulateMedia({ media: 'print' });
+
+      const link = page.locator('.prose a[href^="http"]').first();
+      const href = await link.getAttribute('href');
+      const after = await link.evaluate((el) => getComputedStyle(el, '::after').content);
+      expect(after).toContain(href!);
+    });
+
+    test('internal links print an absolute URL', async ({ page }) => {
+      // Release notes link internally far more than news articles do.
+      await page.goto(CODE_PAGE);
+      await page.emulateMedia({ media: 'print' });
+
+      // Skip the cases the stylesheet deliberately leaves bare: image links,
+      // badge lists and table cells.
+      const result = await page.evaluate(() => {
+        const links = [...document.querySelectorAll('.prose a[href^="/"]')].filter(
+          (el) => !el.querySelector('img') && !el.closest('table') && !el.closest('.tool-list')
+        );
+        const el = links[0];
+        if (!el) return null;
+        return { href: el.getAttribute('href'), after: getComputedStyle(el, '::after').content };
+      });
+
+      expect(result, 'expected at least one plain internal prose link').not.toBeNull();
+      expect(result!.after).toContain(`https://galaxyproject.org${result!.href}`);
+    });
+
+    test('in-page anchors and table links stay clean', async ({ page }) => {
+      await page.goto(TABLE_PAGE);
+      await page.emulateMedia({ media: 'print' });
+
+      // A URL in every cell squeezes columns until real content wraps mid-word.
+      const cellLink = page.locator('.prose table a[href^="http"]').first();
+      if ((await cellLink.count()) > 0) {
+        const after = await cellLink.evaluate((el) => getComputedStyle(el, '::after').content);
+        expect(['none', '""', 'normal']).toContain(after);
+      }
+    });
+  });
+
+  test('print media hides chrome without dropping body copy', async ({ page }) => {
+    await page.goto(ARTICLE);
+    await page.waitForLoadState('networkidle');
+
+    const countParagraphs = () =>
+      page.evaluate(
+        () =>
+          [...document.querySelectorAll('.prose p')].filter((el) => {
+            const s = getComputedStyle(el);
+            return s.display !== 'none' && s.visibility !== 'hidden' && el.textContent!.trim().length > 0;
+          }).length
+      );
+
+    const onScreen = await countParagraphs();
+    await page.emulateMedia({ media: 'print' });
+    const onPaper = await countParagraphs();
+
+    // Hiding navigation is the point; hiding article prose is the regression
+    // this guards against.
+    expect(onScreen).toBeGreaterThan(0);
+    expect(onPaper).toBe(onScreen);
+  });
+
+  test('a real PDF render produces multiple pages of content', async ({ page }) => {
+    await page.goto(ARTICLE);
+    await page.waitForLoadState('networkidle');
+
+    // printBackground:false mirrors the browser dialog default, which is where
+    // the original bug was worst.
+    const pdf = await page.pdf({ format: 'Letter', printBackground: false });
+    expect(pdf.byteLength).toBeGreaterThan(1000);
+
+    // A long article must not collapse to a single clipped page.
+    const pageCount = (pdf.toString('latin1').match(/\/Type\s*\/Page[^s]/g) || []).length;
+    expect(pageCount).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
Closes #3544.

Marten's comment on the issue is the real starting point here -- articles don't just print unstyled, they print *wrong*. Repro'd it on the GCC2026 recap page and the print output was dropping content: paragraphs cut off mid-sentence, one heading rendered as nothing but its gold underline, and the "Photo Credit / CC BY-SA" block was missing from the PDF text layer entirely.

Three things were causing it:

- The nested flex shells in `BaseLayout` (`.site-shell` > `.site-main` > `.site-content`) fragment badly across printed pages in Chrome.
- `overflow: hidden` on the outer wrapper clips everything past page one. `overflow-x: hidden` on `html`/`body` does the same thing indirectly, since a non-visible value on one axis computes the other to `auto` and makes the root a scroll container.
- The mobile header is `position: fixed`, and Chrome repaints fixed elements on *every* printed page, over whatever is underneath. Print renders at ~816px, below the `lg:` breakpoint, so it's the mobile layout that prints -- which is why nobody noticed the header was involved.

`print.css` unwinds all three back to plain block flow and hides the nav, sidebar, footer, TOC and other interactive bits.

There's a second class of bug worth calling out, because it only shows up with **Background graphics off** -- which is the default in Chrome's print dialog, and is how Marten's screenshot was taken. The page header, table header cells and code blocks are all light-text-on-dark-background, so with backgrounds suppressed they render white-on-white and disappear. Article titles were literally invisible. Those now use borders and dark text rather than depending on a background, so they read the same either way.

Also in here, from the issue's task list: link targets print after the link text (relative ones expanded to absolute), images and tables get `break-inside: avoid`, long code lines wrap instead of scrolling off the page, and `thead` repeats when a table spans pages. URLs are deliberately suppressed inside table cells -- the release notes are full of link-dense tables and a URL in every cell squeezed the columns until dates were wrapping as "Octob er 3rd".

## On the diff

The changes to existing files are only class-name hooks (`site-shell`, `site-mobile-header`, `site-footer`, `site-sidebar`, etc.) plus one `@import`. Everything else is new. All rules live inside `@media print`, so screen rendering is untouched.

## Testing

`tests/print.spec.ts` asserts computed styles under print media emulation rather than comparing pixels, so it shouldn't churn as content changes. 13 tests; 9 of them fail with the stylesheet reverted, so they're actually holding the fix down.

Verified end-to-end against the production build (not just dev): the recap page goes 16 pages -> 11, and the content that was being dropped is back. Existing suite is green (191 unit tests, lint, prettier).

Worth a look at the rendered before/after if you're reviewing -- the difference on the `#training` section Marten linked is pretty stark.
