### PR TITLE
fix: reclaim the dead space at the top of bare pages

### DIFF
--- a/astro/src/build/preprocess.mjs
+++ b/astro/src/build/preprocess.mjs
@@ -434,6 +434,13 @@ function inlineInserts(content, depth = 0, contentDir = CONTENT_DIR) {
     if (resolved.hasComponents) {
       hasComponents = true;
     }
+    // Drop empty inserts entirely. An empty wrapper still counts as an element
+    // child, so it would steal `:first-child` from the real leading content and
+    // stop Tailwind Typography's `.prose > :first-child { margin-top: 0 }` from
+    // applying — leaving a phantom gap at the top of the page.
+    if (resolved.content.trim() === '') {
+      return '';
+    }
     // Wrap in a div with data-name so layout CSS selectors can target inserts
     return `<div class="insert" data-name="${slotName}">\n${resolved.content}\n</div>`;
   });

--- a/astro/src/layouts/BareArticleLayout.astro
+++ b/astro/src/layouts/BareArticleLayout.astro
@@ -28,7 +28,10 @@ const { title, description } = Astro.props;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body class="min-h-screen bg-white text-chicago-900">
-    <main class="p-4 sm:p-6 lg:p-8">
+    <!-- Tight top padding: these pages are iframed into a host that supplies its own
+         chrome, so vertical space above the content is wasted. Sides and bottom keep
+         their breathing room. -->
+    <main class="px-4 pt-2 pb-6 sm:px-6 sm:pb-8 lg:px-8 lg:pb-10">
       <article class="prose prose-lg prose-galaxy max-w-none">
         <slot />
       </article>
@@ -105,6 +108,28 @@ const { title, description } = Astro.props;
   article.prose.prose-lg.prose-galaxy.max-w-none {
     max-width: 1200px;
     margin: 0 auto !important;
+  }
+
+  /* Typography's `.prose > :first-child { margin-top: 0 }` misses the mark when a
+     page opens with a non-rendering node -- several bare articles start with a raw
+     <style> block. That node takes :first-child, so the real leading heading keeps
+     its full top margin and the page opens with a dead band of white space.
+     Reset the first *rendered* child instead: an element that no rendered sibling
+     precedes. */
+  article.prose > :not(style, script, meta, link):not(:where(:not(style, script, meta, link) ~ *)) {
+    margin-top: 0;
+  }
+
+  /* Same idea one level in: many pages open with a logo wrapped in a <p>/<center>,
+     and prose gives images their own top margin. */
+  article.prose > :not(style, script, meta, link):not(:where(:not(style, script, meta, link) ~ *)) > :first-child {
+    margin-top: 0;
+  }
+
+  /* A leading logo is usually floated or centred, so the heading that follows it
+     sits at the top of the page too -- its top margin is pure dead space. */
+  article.prose > img:not(:where(:not(style, script, meta, link) ~ *)) + * {
+    margin-top: 0;
   }
 
   /* Styling for EU lead sections */


### PR DESCRIPTION
## Problem

Every bare page opened with a band of white space; ~80px of nothing above the first heading, in an iframe where vertical space is already scarce.

<img width="1553" height="805" alt="image" src="https://github.com/user-attachments/assets/bc826e45-da24-461a-9601-3d33387a7afc" />

## Cause

Two things stacked:

1. `preprocess.mjs` inlined `<slot name="…"/>` as `<div class="insert">…</div>` even when the insert body was blank. 27 inserts are currently empty, and 40 of 41 bare articles open with the empty `notices` slot. That empty wrapper is still an element child, so it takes `:first-child` — Tailwind Typography's `.prose > :first-child { margin-top: 0 }` resets the wrapper, and the real leading `<h2>` kept its full 48–56px top margin.
2. `BareArticleLayout` used a uniform `p-4 sm:p-6 lg:p-8`, adding another 32px on top. Bare pages are iframed into a host that supplies its own chrome, so that padding is wasted.

The same `:first-child` trap also fires on pages that open with a raw `<style>` block or a floated logo.

## Changes

- `preprocess.mjs`: an insert that resolves to empty emits nothing instead of an empty wrapper. Fixes the phantom first child everywhere, not just on bare pages.
- `BareArticleLayout`: `px-4 pt-2 pb-6 sm:px-6 sm:pb-8 lg:px-8 lg:pb-10` — sides and bottom keep their breathing room, the top is tightened.
- `BareArticleLayout`: reset the top margin of the first _rendered_ child, its own first child (a leading logo `<img>` wrapped in a `<p>`/`<center>`), and the block that follows a leading `<img>`.

## Verification

Measured the top of the first visible element on all 41 bare pages with Playwright, at 1440×900:

|                     | before | after   |
| ------------------- | ------ | ------- |
| top gap, most pages | 80px   | 8px     |
| pages at 8px        | 1 / 41 | 38 / 41 |

The three exceptions are unchanged on purpose: `ghana` and `singlecell` lead with an inline `margin: 1rem 0 2rem` the author set, and `eu/usegalaxy/main` opens with the carousel island.

- 375px / 768px: 8px gap, no horizontal overflow
- Non-bare pages spot-checked unchanged: `/`, `/eu/`, `/freiburg/`, `/us/`, `/ifb/`