### PR TITLE
Announce Galaxy 26.1 and update Get Galaxy

### DIFF
--- a/content/admin/get-galaxy/index.md
+++ b/content/admin/get-galaxy/index.md
@@ -19,7 +19,7 @@ If setting up or running a production Galaxy service or creating your own person
 If you do not have a Galaxy repository yet or you do not want to update the existing instance, run:
 
 ```
-$ git clone -b release_26.0 https://github.com/galaxyproject/galaxy.git
+$ git clone -b release_26.1 https://github.com/galaxyproject/galaxy.git
 ```
 
 ### Updating existing
@@ -27,7 +27,7 @@ $ git clone -b release_26.0 https://github.com/galaxyproject/galaxy.git
 If you have an existing Galaxy repository and want to update it, run:
 
 ```
-$ git fetch origin && git checkout release_26.0 && git pull --ff-only origin release_26.0
+$ git fetch origin && git checkout release_26.1 && git pull --ff-only origin release_26.1
 ```
 
 

--- a/content/news/2026/2026-08-02-galaxy-release-26-1/index.md
+++ b/content/news/2026/2026-08-02-galaxy-release-26-1/index.md
@@ -1,0 +1,11 @@
+---
+title: "Galaxy 26.1 is here!"
+date: "2026-08-02"
+tease: Galaxy 26.1 introduces Galaxy Notebooks, context-aware GalaxyAI agents, Model Context Protocol support, bulk dataset storage migration, a modern workflow extraction interface, favorite and recent tools, and clearer workflow execution monitoring. Explore the user release notes.
+hide_tease: false
+subsites: [all]
+external_url: https://docs.galaxyproject.org/en/master/releases/26.1_announce_user.html
+contributions:
+  authorship:
+    - mvdbeek
+---


### PR DESCRIPTION
Update the Get Galaxy instructions to use `release_26.1` and add a Galaxy Hub news item that links directly to the 26.1 user release notes.

This completes the Galaxy Hub and getgalaxy.org publication tasks from galaxyproject/galaxy#22750.