### PR TITLE
Improve location details for usegalaxy.be

### DIFF
--- a/content/use/usegalaxy-be/index.md
+++ b/content/use/usegalaxy-be/index.md
@@ -7,6 +7,14 @@ platforms:
     platform_url: "https://usegalaxy.be/"
     platform_text: "ELIXIR Belgium Galaxy Server"
     platform_location: BE
+    location:
+      city: Ghent  
+      region: Flanders
+      continent_code: EU
+      postal: "9050"
+      latitude: 51.0113
+      longitude: 3.7099
+      timezone: Europe/Brussels
 summary: "General purpose genomics Galaxy server"
 image: "/use/usegalaxy-be/usegalaxy-be-logo.png"
 comments:


### PR DESCRIPTION
Added additional location information for the Galaxy BE server. Did not immediately find the controlled vocabulary I can make use of so just looked at an example (https://github.com/galaxyproject/galaxy-hub/blob/fb982d08d20a396deb4820cc20ffabca1d873c28/content/use/shaman/domains.yml).

As discussed with @hujambo-dunia in a comment somewhere in https://github.com/galaxyproject/galaxy-hub/commit/3201f7d740f9504fa5b229fb8dff2a164371fe51#diff-39f02bc0ee415a78132b9f0f9878b838c4227a692c467471b7ea98307757633f (search on 'belgium' to find the comments, GH doesn't allow me to make a link). 