### PR TITLE
Add closed view to Release Guardians event pages

### DIFF
--- a/astro/src/build/normalize-content.mjs
+++ b/astro/src/build/normalize-content.mjs
@@ -455,6 +455,8 @@ const KNOWN_COMPONENTS = [
   'ReleaseGuardiansSection',
   'ReleaseGuardiansLabelPill',
   'ReleaseGuardiansCoordination',
+  'ReleaseGuardiansPhase',
+  'ReleaseGuardiansRecap',
   'CofestBoard',
   'CofestProject',
 ];

--- a/astro/src/build/release-guardians-projection.mjs
+++ b/astro/src/build/release-guardians-projection.mjs
@@ -76,3 +76,33 @@ export function snapshotFingerprint(snapshot) {
   const { needsValidation, inProgress, complete, version } = snapshot;
   return JSON.stringify({ version, needsValidation, inProgress, complete });
 }
+
+/** Aggregate the `guardian` actors on a snapshot's `complete` PRs into a
+ *  tester-recognition leaderboard. Each entry counts how many PRs that
+ *  actor marked complete (validated). PRs without a guardian are skipped.
+ *  Sorted by count descending, then login for a stable tiebreak.
+ *
+ *  Pure over the snapshot so it can be unit-tested without a DOM. The
+ *  closed-view `Recap` component is a thin render wrapper over this. */
+export function aggregateGuardians(snapshot) {
+  if (!snapshot?.complete?.length) return [];
+  const counts = new Map();
+  for (const pr of snapshot.complete) {
+    const g = pr.guardian;
+    if (!g?.login) continue;
+    const entry = counts.get(g.login);
+    if (entry) {
+      entry.validatedCount += 1;
+    } else {
+      counts.set(g.login, {
+        login: g.login,
+        url: g.url,
+        avatarUrl: g.avatarUrl,
+        validatedCount: 1,
+      });
+    }
+  }
+  return [...counts.values()].sort(
+    (a, b) => b.validatedCount - a.validatedCount || a.login.localeCompare(b.login)
+  );
+}

--- a/astro/src/build/release-guardians-projection.mjs
+++ b/astro/src/build/release-guardians-projection.mjs
@@ -102,7 +102,5 @@ export function aggregateGuardians(snapshot) {
       });
     }
   }
-  return [...counts.values()].sort(
-    (a, b) => b.validatedCount - a.validatedCount || a.login.localeCompare(b.login)
-  );
+  return [...counts.values()].sort((a, b) => b.validatedCount - a.validatedCount || a.login.localeCompare(b.login));
 }

--- a/astro/src/build/release-guardians-projection.test.mjs
+++ b/astro/src/build/release-guardians-projection.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  aggregateGuardians,
   buildSnapshot,
   findGuardian,
   partitionPrs,
@@ -8,6 +9,7 @@ import {
   snapshotFingerprint,
   withStableAvatar,
 } from './release-guardians-projection.mjs';
+import { phaseFor } from '../components/release-guardians/labels.ts';
 
 const CONFIG = {
   repo: 'galaxyproject/galaxy',
@@ -322,5 +324,75 @@ describe('buildSnapshot (end-to-end normalization)', () => {
     const a = buildSnapshot(fixturePrs, CONFIG, '2026-05-27T00:00:00Z');
     const b = buildSnapshot(fixturePrs, CONFIG, '2026-05-28T00:00:00Z');
     expect(snapshotFingerprint(a)).toBe(snapshotFingerprint(b));
+  });
+});
+
+describe('aggregateGuardians', () => {
+  const guardian = (login) => ({
+    login,
+    url: `https://github.com/${login}`,
+    avatarUrl: `https://github.com/${login}.png`,
+  });
+  const pr = (number, g) => ({ number, guardian: g });
+
+  it('returns an empty list when the snapshot is null or has no complete PRs', () => {
+    expect(aggregateGuardians(null)).toEqual([]);
+    expect(aggregateGuardians({ complete: [] })).toEqual([]);
+    expect(aggregateGuardians({ complete: [pr(1, null)] })).toEqual([]);
+  });
+
+  it('counts how many complete PRs each guardian validated', () => {
+    const snapshot = {
+      complete: [pr(1, guardian('alice')), pr(2, guardian('alice')), pr(3, guardian('bob'))],
+    };
+    expect(aggregateGuardians(snapshot)).toEqual([
+      { ...guardian('alice'), validatedCount: 2 },
+      { ...guardian('bob'), validatedCount: 1 },
+    ]);
+  });
+
+  it('sorts by count descending, then login for a stable tiebreak', () => {
+    const snapshot = {
+      complete: [pr(1, guardian('zoe')), pr(2, guardian('alice')), pr(3, guardian('alice')), pr(4, guardian('zoe'))],
+    };
+    const result = aggregateGuardians(snapshot);
+    expect(result.map((g) => g.login)).toEqual(['alice', 'zoe']);
+    expect(result.map((g) => g.validatedCount)).toEqual([2, 2]);
+  });
+
+  it('ignores guardians on in-progress PRs', () => {
+    const snapshot = {
+      needsValidation: [pr(1, guardian('alice'))],
+      inProgress: [pr(2, guardian('bob'))],
+      complete: [pr(3, guardian('carol'))],
+    };
+    const result = aggregateGuardians(snapshot);
+    expect(result.map((g) => g.login)).toEqual(['carol']);
+  });
+
+  it('skips complete PRs whose guardian is missing or has no login', () => {
+    const snapshot = {
+      complete: [pr(1, null), pr(2, { login: '', url: '', avatarUrl: '' }), pr(3, guardian('alice'))],
+    };
+    expect(aggregateGuardians(snapshot)).toEqual([{ ...guardian('alice'), validatedCount: 1 }]);
+  });
+});
+
+describe('phaseFor', () => {
+  it('stays active through the entire final day of the testing window', () => {
+    expect(phaseFor('2026-06-05', Date.parse('2026-06-05T10:00:00Z'))).toBe('active');
+    expect(phaseFor('2026-06-05', Date.parse('2026-06-05T23:59:58Z'))).toBe('active');
+  });
+
+  it('closes once the final day has fully elapsed', () => {
+    expect(phaseFor('2026-06-05', Date.parse('2026-06-06T00:00:00Z'))).toBe('closed');
+  });
+
+  it('defaults to active when endDate is missing', () => {
+    expect(phaseFor(undefined, Date.parse('2026-06-06T00:00:00Z'))).toBe('active');
+  });
+
+  it('defaults to active on an unparseable endDate', () => {
+    expect(phaseFor('not-a-date', Date.parse('2026-06-06T00:00:00Z'))).toBe('active');
   });
 });

--- a/astro/src/components/release-guardians/Phase.astro
+++ b/astro/src/components/release-guardians/Phase.astro
@@ -1,0 +1,25 @@
+---
+/**
+ * Phase gate for a Release Guardians event page. Compares the testing
+ * window's `endDate` to the build date and renders one of two branches:
+ *
+ *  - active (endDate in the future): the recruitment boilerplate — intro
+ *    paragraphs, the live coordination card, and the "Become a Guardian"
+ *    steps — via the `active` slot.
+ *  - closed (endDate passed): a short recap line, via the `closed` slot.
+ *
+ * Both branches are static markdown handed in as named slots, so the event
+ * template reads top-to-bottom and the date logic lives in one place.
+ */
+import { phaseFor } from './labels';
+
+interface Props {
+  /** ISO date (YYYY-MM-DD), the testing window's end. Missing/invalid falls back to 'active' (phaseFor). */
+  endDate?: string;
+}
+const { endDate } = Astro.props;
+
+const closed = phaseFor(endDate) === 'closed';
+---
+
+{closed ? <slot name="closed" /> : <slot name="active" />}

--- a/astro/src/components/release-guardians/Recap.astro
+++ b/astro/src/components/release-guardians/Recap.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * Closed-view recap for a Release Guardians cycle. Rendered once the testing
+ * window's `endDate` has passed: a one-line summary of when validation ran, a
+ * coverage stat (share of in-scope PRs validated), and a tester-recognition
+ * list aggregated from the `guardian` already recorded on each `complete` PR.
+ *
+ * Pure render over the committed snapshot — no new fetch. Recognition covers
+ * only `complete` guardians (who marked a PR validated); PRs without a
+ * guardian are skipped, and an all-empty cycle renders no recognition block.
+ */
+import { loadSnapshot, aggregateGuardians } from './data';
+import { TONES } from './tones';
+import Icon from '../mdx/Icon.astro';
+import { formatDate } from '@/utils/dateUtils';
+
+interface Props {
+  version: string;
+  /** ISO date (YYYY-MM-DD), the testing window's end. */
+  endDate: string;
+}
+const { version, endDate } = Astro.props;
+const data = loadSnapshot(version);
+
+const validated = data?.complete.length ?? 0;
+const attempted = data?.inProgress.length ?? 0;
+const notTested = data?.needsValidation.length ?? 0;
+const total = validated + attempted + notTested;
+const coverage = total > 0 ? Math.round((validated / total) * 100) : 0;
+
+const guardians = data ? aggregateGuardians(data) : [];
+
+const windowLabel = formatDate(endDate, false);
+---
+
+<div class="not-prose my-6 p-5 rounded-lg border border-galaxy-primary/10 bg-white shadow-sm">
+  <p class="text-lg text-galaxy-dark font-semibold">
+    The Galaxy {version} release was validated through {windowLabel}.
+  </p>
+  {
+    total > 0 && (
+      <p class="text-sm text-chicago-700 mt-1">
+        <span class={`font-bold ${TONES.complete.text}`}>{coverage}%</span> of {total} in-scope PRs validated (
+        {validated} validated, {attempted} attempted, {notTested} not tested).
+      </p>
+    )
+  }
+
+  {
+    guardians.length > 0 && (
+      <div class="mt-4">
+        <div class="flex items-center gap-1 text-xs text-chicago-500 uppercase tracking-wide">
+          <Icon name="shield-check" size={14} />
+          Testers
+        </div>
+        <ul class="mt-2 flex flex-wrap gap-3">
+          {guardians.map((g) => (
+            <li class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border bg-light-bg border-ebony-clay-100">
+              <img src={g.avatarUrl} alt="" loading="lazy" width="20" height="20" class="w-5 h-5 rounded-full" />
+              <a
+                href={g.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm font-medium text-galaxy-dark hover:text-galaxy-primary"
+              >
+                @{g.login}
+              </a>
+              <span class="text-xs text-chicago-500">validated {g.validatedCount}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    )
+  }
+</div>

--- a/astro/src/components/release-guardians/Recap.astro
+++ b/astro/src/components/release-guardians/Recap.astro
@@ -31,6 +31,7 @@ const coverage = total > 0 ? Math.round((validated / total) * 100) : 0;
 const guardians = data ? aggregateGuardians(data) : [];
 
 const windowLabel = formatDate(endDate, false);
+const detail = `(${validated} validated, ${attempted} attempted, ${notTested} not tested).`;
 ---
 
 <div class="not-prose my-6 p-5 rounded-lg border border-galaxy-primary/10 bg-white shadow-sm">
@@ -40,8 +41,7 @@ const windowLabel = formatDate(endDate, false);
   {
     total > 0 && (
       <p class="text-sm text-chicago-700 mt-1">
-        <span class={`font-bold ${TONES.complete.text}`}>{coverage}%</span> of {total} in-scope PRs validated (
-        {validated} validated, {attempted} attempted, {notTested} not tested).
+        <span class={`font-bold ${TONES.complete.text}`}>{coverage}%</span> of {total} in-scope PRs validated {detail}
       </p>
     )
   }

--- a/astro/src/components/release-guardians/Section.astro
+++ b/astro/src/components/release-guardians/Section.astro
@@ -1,21 +1,29 @@
 ---
 import Card from './Card.astro';
 import { loadSnapshot, type GuardianPr, type SnapshotKind } from './data';
+import { LABELS, phaseFor, type Phase } from './labels';
 
 interface Props {
   version: string;
   kind: SnapshotKind;
-  emptyMessage: string;
+  /** Explicit override; otherwise derived from `phase`/`endDate`. */
+  emptyMessage?: string;
+  /** Explicit phase; otherwise derived from `endDate`. */
+  phase?: Phase;
+  /** Testing window end (YYYY-MM-DD); drives active vs. closed empty text. */
+  endDate?: string;
 }
-const { version, kind, emptyMessage } = Astro.props;
+const { version, kind, emptyMessage, phase, endDate } = Astro.props;
 const data = loadSnapshot(version);
 const prs: GuardianPr[] = data ? data[kind] : [];
+const resolvedPhase = phase ?? phaseFor(endDate);
+const resolvedEmpty = emptyMessage ?? LABELS[resolvedPhase][kind].empty;
 ---
 
 {
   prs.length === 0 ? (
     <div class="not-prose my-4 p-6 bg-light-bg bg-grid rounded-lg border border-ebony-clay-100 text-center text-chicago-500 italic">
-      {emptyMessage}
+      {resolvedEmpty}
     </div>
   ) : (
     <div class="not-prose my-4 p-4 bg-light-bg bg-grid rounded-lg border border-ebony-clay-100">

--- a/astro/src/components/release-guardians/Summary.astro
+++ b/astro/src/components/release-guardians/Summary.astro
@@ -1,13 +1,20 @@
 ---
 import { loadSnapshot } from './data';
 import { TONES } from './tones';
+import { LABELS, phaseFor, type Phase } from './labels';
 import Icon from '../mdx/Icon.astro';
 
 interface Props {
   version: string;
+  /** Testing window end (YYYY-MM-DD); drives active vs. closed labels. */
+  endDate?: string;
+  /** Explicit phase override; otherwise derived from `endDate`. */
+  phase?: Phase;
 }
-const { version } = Astro.props;
+const { version, endDate, phase } = Astro.props;
 const data = loadSnapshot(version);
+const resolvedPhase = phase ?? phaseFor(endDate);
+const labels = LABELS[resolvedPhase];
 
 const tileClass =
   'block p-4 rounded-lg border border-galaxy-primary/10 bg-white text-center shadow-sm hover:border-galaxy-primary/30 transition-all no-underline';
@@ -19,21 +26,21 @@ const labelClass = 'flex items-center justify-center gap-1 text-xs text-chicago-
     <div class={`text-3xl font-bold ${TONES.needsValidation.text}`}>{data?.needsValidation.length ?? 0}</div>
     <div class={labelClass}>
       <Icon name="circle-dashed" size={14} />
-      Needs Validation
+      {labels.needsValidation.tile}
     </div>
   </a>
   <a href="#in-progress" class={tileClass}>
     <div class={`text-3xl font-bold ${TONES.inProgress.text}`}>{data?.inProgress.length ?? 0}</div>
     <div class={labelClass}>
       <Icon name="loader" size={14} />
-      In Progress
+      {labels.inProgress.tile}
     </div>
   </a>
   <a href="#complete" class={tileClass}>
     <div class={`text-3xl font-bold ${TONES.complete.text}`}>{data?.complete.length ?? 0}</div>
     <div class={labelClass}>
       <Icon name="circle-check" size={14} />
-      Complete
+      {labels.complete.tile}
     </div>
   </a>
 </div>

--- a/astro/src/components/release-guardians/data.ts
+++ b/astro/src/components/release-guardians/data.ts
@@ -42,3 +42,18 @@ export function loadSnapshot(version: string): Snapshot | null {
   const key = `/src/data/release-guardians/${version}.json`;
   return snapshots[key]?.default ?? null;
 }
+
+/** A tester-recognition entry: a GitHub actor and how many PRs they validated. */
+export interface GuardianStat {
+  login: string;
+  url: string;
+  avatarUrl: string;
+  validatedCount: number;
+}
+
+/**
+ * Aggregate the `guardian` on each `complete` PR into a recognition list,
+ * sorted by validated count descending. Re-exports the pure helper from the
+ * build layer so components and tests share one implementation.
+ */
+export { aggregateGuardians } from '@/build/release-guardians-projection.mjs';

--- a/astro/src/components/release-guardians/labels.ts
+++ b/astro/src/components/release-guardians/labels.ts
@@ -1,0 +1,73 @@
+/**
+ * Per-phase label text for the Release Guardians UI. The active page speaks in
+ * the present tense (a to-do board); once the testing window closes the same
+ * three buckets read as a historical record. Centralised here so `Summary`
+ * (tile) and `Section` (empty-bucket message) stay in sync — edit one string,
+ * it moves everywhere.
+ *
+ * Section *headings* are NOT covered here: they carry `id` anchors and
+ * `<Icon>` children that a plain string can't express, so they're hardcoded
+ * per phase directly in the event template/content file instead.
+ */
+
+import type { SnapshotKind } from './data';
+
+export interface KindLabels {
+  /** Short label for the Summary tile. */
+  tile: string;
+  /** Empty-bucket message. */
+  empty: string;
+}
+
+export type Phase = 'active' | 'closed';
+
+/**
+ * Resolve the page phase from the testing window's end date versus the build
+ * time. Returns 'closed' once `endDate` has passed. Invalid/missing dates
+ * default to 'active' so a misconfigured cycle never silently freezes the
+ * recruitment page. Centralised so Phase, Summary, and Section agree.
+ *
+ * Deliberately NOT `isPublishedDate` (astro/src/utils/dateUtils.ts): that
+ * helper does `d <= now` against a raw instant, which would close the page
+ * at 00:00 UTC on `endDate` — cutting off testers on the window's last day.
+ * This pads to end-of-day UTC so the window stays open through all of
+ * `endDate`, matching how the testing window is actually communicated
+ * (e.g. "2026-06-01 → 2026-06-05" means testing runs through June 5).
+ */
+export function phaseFor(endDate: string | undefined, now: number = Date.now()): Phase {
+  if (!endDate) return 'active';
+  const end = new Date(`${endDate}T23:59:59Z`);
+  if (Number.isNaN(end.getTime())) return 'active';
+  return end.getTime() < now ? 'closed' : 'active';
+}
+
+export const LABELS: Record<Phase, Record<SnapshotKind, KindLabels>> = {
+  active: {
+    needsValidation: {
+      tile: 'Needs Validation',
+      empty: 'No PRs currently need validation.',
+    },
+    inProgress: {
+      tile: 'In Progress',
+      empty: 'No PRs currently in progress.',
+    },
+    complete: {
+      tile: 'Complete',
+      empty: 'No PRs marked complete yet.',
+    },
+  },
+  closed: {
+    needsValidation: {
+      tile: 'Not tested',
+      empty: 'No PRs went untested.',
+    },
+    inProgress: {
+      tile: 'Attempted',
+      empty: 'No validation was left unfinished.',
+    },
+    complete: {
+      tile: 'Validated',
+      empty: 'No PRs were validated.',
+    },
+  },
+};

--- a/astro/src/pages/events/[...slug].astro
+++ b/astro/src/pages/events/[...slug].astro
@@ -27,6 +27,8 @@ import ReleaseGuardiansSummary from '../../components/release-guardians/Summary.
 import ReleaseGuardiansSection from '../../components/release-guardians/Section.astro';
 import ReleaseGuardiansLabelPill from '../../components/release-guardians/LabelPill.astro';
 import ReleaseGuardiansCoordination from '../../components/release-guardians/Coordination.astro';
+import ReleaseGuardiansPhase from '../../components/release-guardians/Phase.astro';
+import ReleaseGuardiansRecap from '../../components/release-guardians/Recap.astro';
 
 interface ConferenceNavItem {
   slug: string;
@@ -233,6 +235,8 @@ const components = {
   ReleaseGuardiansSection,
   ReleaseGuardiansLabelPill,
   ReleaseGuardiansCoordination,
+  ReleaseGuardiansPhase,
+  ReleaseGuardiansRecap,
   CofestBoard,
 };
 

--- a/astro/src/templates/release-guardians-event.md.template
+++ b/astro/src/templates/release-guardians-event.md.template
@@ -16,6 +16,9 @@ contributions:
 components: true
 ---
 
+<ReleaseGuardiansPhase endDate="{{endDate}}">
+  <div slot="active">
+
 The Galaxy **{{version}}** release is entering community validation. Become a **Galaxy Release Guardian** and help exercise user-facing changes across real deployments, workflows, and user environments before publication.
 
 Pick a pull request from the list below, test the change on the [**Galaxy Test Server**]({{testServer}}), and capture your findings by [**opening a new issue**]({{issueLink}}) that references the PR number. Keeping the feedback in a dedicated issue keeps the PR conversation focused on code review. The PR labels are the workflow.
@@ -32,19 +35,36 @@ Pick a pull request from the list below, test the change on the [**Galaxy Test S
 4. [**Open a new issue**]({{issueLink}}) describing your findings, reference the PR number, and include screenshots, regressions, deployment notes, and any edge cases you hit.
 5. When validation is complete, replace <ReleaseGuardiansLabelPill label="{{inProgressLabel}}" kind="inProgress" /> with <ReleaseGuardiansLabelPill label="{{completeLabel}}" kind="complete" />.
 
-<ReleaseGuardiansSummary version="{{version}}" />
+  </div>
+  <div slot="closed">
 
-<h2 id="needs-validation"><Icon name="circle-dashed" /> Needs Validation</h2>
+<ReleaseGuardiansRecap version="{{version}}" endDate="{{endDate}}" />
 
-<ReleaseGuardiansSection version="{{version}}" kind="needsValidation" emptyMessage="No PRs currently need validation." />
+  </div>
+</ReleaseGuardiansPhase>
 
-<h2 id="in-progress"><Icon name="loader" /> In Progress</h2>
+<ReleaseGuardiansSummary version="{{version}}" endDate="{{endDate}}" />
 
-<ReleaseGuardiansSection version="{{version}}" kind="inProgress" emptyMessage="No PRs currently in progress." />
+<ReleaseGuardiansPhase endDate="{{endDate}}">
+  <h2 id="needs-validation" slot="active"><Icon name="circle-dashed" /> Needs Validation</h2>
+  <h2 id="needs-validation" slot="closed"><Icon name="circle-dashed" /> Not tested</h2>
+</ReleaseGuardiansPhase>
 
-<h2 id="complete"><Icon name="circle-check" /> Complete</h2>
+<ReleaseGuardiansSection version="{{version}}" kind="needsValidation" endDate="{{endDate}}" />
 
-<ReleaseGuardiansSection version="{{version}}" kind="complete" emptyMessage="No PRs marked complete yet." />
+<ReleaseGuardiansPhase endDate="{{endDate}}">
+  <h2 id="in-progress" slot="active"><Icon name="loader" /> In Progress</h2>
+  <h2 id="in-progress" slot="closed"><Icon name="loader" /> Attempted, not finished</h2>
+</ReleaseGuardiansPhase>
+
+<ReleaseGuardiansSection version="{{version}}" kind="inProgress" endDate="{{endDate}}" />
+
+<ReleaseGuardiansPhase endDate="{{endDate}}">
+  <h2 id="complete" slot="active"><Icon name="circle-check" /> Complete</h2>
+  <h2 id="complete" slot="closed"><Icon name="circle-check" /> Validated</h2>
+</ReleaseGuardiansPhase>
+
+<ReleaseGuardiansSection version="{{version}}" kind="complete" endDate="{{endDate}}" />
 
 ---
 

--- a/content/events/2026-06-01-release-guardians-26-1/index.md
+++ b/content/events/2026-06-01-release-guardians-26-1/index.md
@@ -17,6 +17,9 @@ contributions:
 components: true
 ---
 
+<ReleaseGuardiansPhase endDate="2026-06-05">
+  <div slot="active">
+
 The Galaxy **26.1** release is entering community validation. Become a **Galaxy Release Guardian** and help exercise user-facing changes across real deployments, workflows, and user environments before publication.
 
 Pick a pull request from the list below, test the change on the [**Galaxy Test Server**](https://test.galaxyproject.org/), and capture your findings by [**opening a new issue**](https://github.com/galaxyproject/galaxy/issues/new?template=bug_report.md) that references the PR number. Keeping the feedback in a dedicated issue keeps the PR conversation focused on code review. The PR labels are the workflow.
@@ -33,19 +36,36 @@ Pick a pull request from the list below, test the change on the [**Galaxy Test S
 4. [**Open a new issue**](https://github.com/galaxyproject/galaxy/issues/new?template=bug_report.md) describing your findings, reference the PR number, and include screenshots, regressions, deployment notes, and any edge cases you hit.
 5. When validation is complete, replace <ReleaseGuardiansLabelPill label="release-testing-in-progress" kind="inProgress" /> with <ReleaseGuardiansLabelPill label="release-testing-complete" kind="complete" />.
 
-<ReleaseGuardiansSummary version="26.1" />
+  </div>
+  <div slot="closed">
 
-<h2 id="needs-validation"><Icon name="circle-dashed" /> Needs Validation</h2>
+<ReleaseGuardiansRecap version="26.1" endDate="2026-06-05" />
 
-<ReleaseGuardiansSection version="26.1" kind="needsValidation" emptyMessage="No PRs currently need validation." />
+  </div>
+</ReleaseGuardiansPhase>
 
-<h2 id="in-progress"><Icon name="loader" /> In Progress</h2>
+<ReleaseGuardiansSummary version="26.1" endDate="2026-06-05" />
 
-<ReleaseGuardiansSection version="26.1" kind="inProgress" emptyMessage="No PRs currently in progress." />
+<ReleaseGuardiansPhase endDate="2026-06-05">
+  <h2 id="needs-validation" slot="active"><Icon name="circle-dashed" /> Needs Validation</h2>
+  <h2 id="needs-validation" slot="closed"><Icon name="circle-dashed" /> Not tested</h2>
+</ReleaseGuardiansPhase>
 
-<h2 id="complete"><Icon name="circle-check" /> Complete</h2>
+<ReleaseGuardiansSection version="26.1" kind="needsValidation" endDate="2026-06-05" />
 
-<ReleaseGuardiansSection version="26.1" kind="complete" emptyMessage="No PRs marked complete yet." />
+<ReleaseGuardiansPhase endDate="2026-06-05">
+  <h2 id="in-progress" slot="active"><Icon name="loader" /> In Progress</h2>
+  <h2 id="in-progress" slot="closed"><Icon name="loader" /> Attempted, not finished</h2>
+</ReleaseGuardiansPhase>
+
+<ReleaseGuardiansSection version="26.1" kind="inProgress" endDate="2026-06-05" />
+
+<ReleaseGuardiansPhase endDate="2026-06-05">
+  <h2 id="complete" slot="active"><Icon name="circle-check" /> Complete</h2>
+  <h2 id="complete" slot="closed"><Icon name="circle-check" /> Validated</h2>
+</ReleaseGuardiansPhase>
+
+<ReleaseGuardiansSection version="26.1" kind="complete" endDate="2026-06-05" />
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #4160.

As discussed in the issue, the `release-testing-*` labels aren't stale — they're a record of testing state and should stay as-is. The actual problem was presentational: after a testing window closes, the event page kept showing the active recruiting wording for a release that had already shipped.

Per the [agreed design](https://github.com/galaxyproject/galaxy-hub/issues/4160#issuecomment-5092368043):

> switch the page to a closed view once `testingEnd` passes, the same way `EventsList` tells past events from upcoming. The closed page shows a short recap: how many PRs were validated, who tested them, and the three lists kept as a record (Validated / Attempted / Not tested).

- Once a testing window's end date passes, the page switches from the active recruiting layout (intro, coordination card, "Become a Guardian" steps) to a closed recap.
- The recap shows the validation window, a coverage stat, and a tester-recognition list built from the `guardian` already recorded on each validated PR.
- The three PR buckets stay on the page as a historical record, relabeled for the closed phase: **Validated** / **Attempted, not finished** / **Not tested**.
- The phase boundary is inclusive of the whole final day of the testing window (deliberately not a raw `<` comparison against midnight UTC, so testers aren't cut off on the last day) — covered by new unit tests.

No GitHub label semantics change; this is purely how the page presents a closed cycle.

<img width="1024" height="1350" alt="closed-view-recap" src="https://github.com/user-attachments/assets/0c559b01-4e5c-42c0-a4de-ae8964017863" />


## Test plan

- [x] `npm run test:unit` — new `phaseFor` boundary tests plus existing `aggregateGuardians`/`buildSnapshot` suites pass (44/44)
- [x] `npm run lint` / `npm run format:check` — clean on touched files
- [x] `npm run build` — full site build succeeds (5424 pages)
- [x] Verified the closed 26.1 event page renders the recap sentence, coverage stats, testers list, and the three relabeled sections, with recruiting content absent
- [x] Verified a future-dated window still renders the full active/recruiting layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)