### PR TITLE
Render bare-page latest news/events inline instead of same-origin iframes

### DIFF
--- a/astro/src/components/bare/LatestEventsCard.astro
+++ b/astro/src/components/bare/LatestEventsCard.astro
@@ -1,0 +1,190 @@
+---
+/**
+ * Upcoming events card for a subsite.
+ *
+ * Used twice: standalone at /bare/<subsite>/latest/events/ (embedded by third-party
+ * sites, see /eu/widgets/) and inline in the bare landing pages. Links are absolute
+ * and open in a new tab because those bare pages are themselves embedded in Galaxy
+ * server interfaces, where a same-tab relative link would navigate the host frame.
+ */
+import { getCollection } from 'astro:content';
+import { contentMatchesSubsite } from '@/utils/subsites';
+
+interface Props {
+  subsite: string;
+  siteUrl?: string;
+  limit?: number;
+}
+
+const { subsite, siteUrl = 'https://galaxyproject.org', limit = 5 } = Astro.props;
+
+const now = new Date();
+
+const allEvents = await getCollection('events', (entry) => {
+  return contentMatchesSubsite(entry.data.subsites, subsite) && !entry.data.draft;
+});
+
+// Get upcoming events
+const upcomingEvents = allEvents
+  .filter((e) => {
+    const endDate = e.data.end ? new Date(e.data.end) : e.data.date ? new Date(e.data.date) : null;
+    return endDate && endDate >= now;
+  })
+  .sort((a, b) => {
+    const dateA = a.data.date ? new Date(a.data.date) : new Date(0);
+    const dateB = b.data.date ? new Date(b.data.date) : new Date(0);
+    return dateA.getTime() - dateB.getTime();
+  })
+  .slice(0, limit);
+
+function formatDate(date: Date | string | undefined): string {
+  if (!date) return '';
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function formatDateRange(start: Date | string | undefined, end: Date | string | undefined): string {
+  if (!start) return '';
+  const startStr = formatDate(start);
+  if (!end) return startStr;
+  const startD = typeof start === 'string' ? new Date(start) : start;
+  const endD = typeof end === 'string' ? new Date(end) : end;
+  if (startD.toDateString() === endD.toDateString()) return startStr;
+  return `${startStr} - ${formatDate(end)}`;
+}
+
+const moreUrl = `${siteUrl}/bare/${subsite}/events/`;
+---
+
+<div class="home-card">
+  <div class="card-header">
+    <a href={moreUrl} target="_blank" style="color: inherit; text-decoration: none;">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 640 640"
+        style="color: #25537b; font-size: 28px; line-height:28px; height:34px;"
+        ><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+        <path
+          fill="currentColor"
+          d="M216 64C229.3 64 240 74.7 240 88L240 128L400 128L400 88C400 74.7 410.7 64 424 64C437.3 64 448 74.7 448 88L448 128L480 128C515.3 128 544 156.7 544 192L544 480C544 515.3 515.3 544 480 544L160 544C124.7 544 96 515.3 96 480L96 192C96 156.7 124.7 128 160 128L192 128L192 88C192 74.7 202.7 64 216 64zM480 496C488.8 496 496 488.8 496 480L496 416L408 416L408 496L480 496zM496 368L496 288L408 288L408 368L496 368zM360 368L360 288L280 288L280 368L360 368zM232 368L232 288L144 288L144 368L232 368zM144 416L144 480C144 488.8 151.2 496 160 496L232 496L232 416L144 416zM280 416L280 496L360 496L360 416L280 416zM216 176L160 176C151.2 176 144 183.2 144 192L144 240L496 240L496 192C496 183.2 488.8 176 480 176L216 176z"
+        >
+        </path>
+      </svg>
+    </a>
+    <a href={moreUrl} class="card-header-title" target="_blank">Events</a>
+    <a href={moreUrl} class="card-header-link more-link" target="_blank">More events</a>
+  </div>
+  <div class="card-body">
+    <ul class="events-list events-feed">
+      {
+        upcomingEvents.length > 0 ? (
+          upcomingEvents.map((event) => {
+            const slug = (event.data.slug || event.id)
+              .replace(/\.mdx?$/, '')
+              .replace(/--/g, '/')
+              .replace(/^events\//, '');
+            const location = event.data.location;
+            const locationStr = location ? (typeof location === 'string' ? location : location.name) : null;
+            return (
+              <li class="event-item">
+                <a href={`${siteUrl}/events/${slug}/`} target="_blank">
+                  {event.data.title}
+                </a>
+                <div class="event-details">
+                  {formatDateRange(event.data.date, event.data.end)}
+                  {locationStr && ` · ${locationStr}`}
+                </div>
+                {event.data.tease && <div class="event-tease">{event.data.tease}</div>}
+              </li>
+            );
+          })
+        ) : (
+          <li class="event-item">No upcoming events</li>
+        )
+      }
+    </ul>
+  </div>
+</div>
+
+<style>
+  .home-card {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  .card-header {
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    padding: 12px 15px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .card-header-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #25537b;
+    flex: 1;
+    text-decoration: none;
+  }
+
+  .card-header-title:hover {
+    text-decoration: underline;
+  }
+
+  .more-link {
+    color: #25537b;
+    text-decoration: none;
+    font-size: 14px;
+  }
+
+  .more-link:hover {
+    text-decoration: underline;
+  }
+
+  .card-body {
+    padding: 0;
+  }
+
+  .events-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .event-item {
+    padding: 12px 15px;
+    border-bottom: 1px solid #eee;
+  }
+
+  .event-item:last-child {
+    border-bottom: none;
+  }
+
+  .event-item a {
+    color: #25537b;
+    text-decoration: none;
+    font-weight: 400;
+  }
+
+  .event-item a:hover {
+    text-decoration: underline;
+  }
+
+  .event-details {
+    color: #666;
+    font-size: 13px;
+    margin-top: 4px;
+    line-height: 1.4;
+  }
+
+  .event-tease {
+    color: #666;
+    font-size: 13px;
+    margin-top: 4px;
+    line-height: 1.4;
+  }
+</style>

--- a/astro/src/components/bare/LatestNewsCard.astro
+++ b/astro/src/components/bare/LatestNewsCard.astro
@@ -1,0 +1,150 @@
+---
+/**
+ * Latest news card for a subsite.
+ *
+ * Used twice: standalone at /bare/<subsite>/latest/news/ (embedded by third-party
+ * sites, see /eu/widgets/) and inline in the bare landing pages. Links are absolute
+ * and open in a new tab because those bare pages are themselves embedded in Galaxy
+ * server interfaces, where a same-tab relative link would navigate the host frame.
+ */
+import { getCollection } from 'astro:content';
+import { contentMatchesSubsite } from '@/utils/subsites';
+
+interface Props {
+  subsite: string;
+  siteUrl?: string;
+  limit?: number;
+}
+
+const { subsite, siteUrl = 'https://galaxyproject.org', limit = 5 } = Astro.props;
+
+const allNews = await getCollection('news');
+const newsArticles = allNews
+  .filter((article) => {
+    return contentMatchesSubsite(article.data.subsites, subsite) && !article.data.draft;
+  })
+  .sort((a, b) => {
+    const dateA = a.data.date ? new Date(a.data.date) : new Date(0);
+    const dateB = b.data.date ? new Date(b.data.date) : new Date(0);
+    return dateB.getTime() - dateA.getTime();
+  })
+  .slice(0, limit);
+
+const moreUrl = `${siteUrl}/bare/${subsite}/news/`;
+---
+
+<div class="home-card">
+  <div class="card-header">
+    <a href={moreUrl} target="_blank" style="color: inherit; text-decoration: none;">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        style="color: #25537b; font-size: 25px; line-height:28px; height:25px;"
+        ><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+        <path
+          fill="currentColor"
+          d="M461.2 18.9C472.7 24 480 35.4 480 48l0 416c0 12.6-7.3 24-18.8 29.1s-24.8 3.2-34.3-5.1l-46.6-40.7c-43.6-38.1-98.7-60.3-156.4-63l0 95.7c0 17.7-14.3 32-32 32l-32 0c-17.7 0-32-14.3-32-32l0-96C57.3 384 0 326.7 0 256S57.3 128 128 128l84.5 0c61.8-.2 121.4-22.7 167.9-63.3l46.6-40.7c9.4-8.3 22.9-10.2 34.3-5.1zM224 320l0 .2c70.3 2.7 137.8 28.5 192 73.4l0-275.3c-54.2 44.9-121.7 70.7-192 73.4L224 320z"
+        >
+        </path>
+      </svg>
+    </a>
+    <a href={moreUrl} class="card-header-title" target="_blank">News</a>
+    <a href={moreUrl} class="card-header-link more-link" target="_blank">More news</a>
+  </div>
+  <div class="card-body">
+    <ul class="news-list">
+      {
+        newsArticles.map((article) => {
+          const slug = (article.data.slug || article.id)
+            .replace(/\.mdx?$/, '')
+            .replace(/--/g, '/')
+            .replace(/^news\//, '');
+          return (
+            <li class="news-item">
+              <a href={`${siteUrl}/news/${slug}/`} target="_blank">
+                {article.data.title}
+              </a>
+              {article.data.tease && <div class="news-tease">{article.data.tease}</div>}
+            </li>
+          );
+        })
+      }
+    </ul>
+  </div>
+</div>
+
+<style>
+  .home-card {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  .card-header {
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    padding: 12px 15px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .card-header-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #25537b;
+    flex: 1;
+    text-decoration: none;
+  }
+
+  .card-header-title:hover {
+    text-decoration: underline;
+  }
+
+  .card-header-link {
+    color: #25537b;
+    text-decoration: none;
+    font-size: 14px;
+  }
+
+  .card-header-link:hover {
+    text-decoration: underline;
+  }
+
+  .card-body {
+    padding: 0;
+  }
+
+  .news-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .news-item {
+    padding: 12px 15px;
+    border-bottom: 1px solid #eee;
+  }
+
+  .news-item:last-child {
+    border-bottom: none;
+  }
+
+  .news-item a {
+    color: #25537b;
+    text-decoration: none;
+    font-weight: 400;
+  }
+
+  .news-item a:hover {
+    text-decoration: underline;
+  }
+
+  .news-tease {
+    color: #666;
+    font-size: 13px;
+    margin-top: 4px;
+    line-height: 1.4;
+  }
+</style>

--- a/astro/src/components/mdx/LatestFeeds.astro
+++ b/astro/src/components/mdx/LatestFeeds.astro
@@ -1,0 +1,49 @@
+---
+/**
+ * Side-by-side "latest news" / "upcoming events" feeds for bare landing pages.
+ *
+ * Replaces the pair of same-origin iframes these pages used to carry. The iframes
+ * were a Gridsome-era workaround: back then the feed lists needed a GraphQL
+ * page-query, which only ran in .vue page components, never in markdown. Astro
+ * queries the content collections at build time, so the cards render inline.
+ *
+ * The standalone /bare/<subsite>/latest/{news,events}/ routes stay put -- they are
+ * documented embed targets for external sites (see /eu/widgets/).
+ */
+import LatestNewsCard from '@/components/bare/LatestNewsCard.astro';
+import LatestEventsCard from '@/components/bare/LatestEventsCard.astro';
+
+interface Props {
+  subsite?: string;
+}
+
+const { subsite = 'eu' } = Astro.props;
+---
+
+<div class="latest-feeds not-prose">
+  <LatestNewsCard subsite={subsite} />
+  <LatestEventsCard subsite={subsite} />
+</div>
+
+<style>
+  /* Match the type scale the feeds had while they lived in their own document,
+     so the cards keep their compact look inside the surrounding prose. */
+  .latest-feeds {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin: 0 0 3rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    color: #333;
+  }
+
+  @media (min-width: 768px) {
+    .latest-feeds {
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+  }
+</style>

--- a/astro/src/layouts/BareArticleLayout.astro
+++ b/astro/src/layouts/BareArticleLayout.astro
@@ -424,37 +424,6 @@ const { title, description } = Astro.props;
     }
   }
 
-  .prose-galaxy {
-    iframe[title='Recent Galaxy France news'],
-    iframe[title='Recent Galaxy Europe news'] {
-      display: inline-block;
-      width: calc(50% - 20px) !important;
-      margin: 0 16px 3rem 0;
-      vertical-align: top;
-    }
-
-    iframe[title*='Recent Galaxy France events'],
-    iframe[title*='Recent Galaxy Europe events'] {
-      width: calc(50% - 20px) !important;
-      display: inline-block;
-      vertical-align: top;
-      margin: 0 0 3rem;
-    }
-  }
-
-  @media (max-width: 767px) {
-    .prose-galaxy {
-      iframe[title='Recent Galaxy France news'],
-      iframe[title='Recent Galaxy Europe news'],
-      iframe[title*='Recent Galaxy France events'],
-      iframe[title*='Recent Galaxy Europe events'] {
-        display: block;
-        width: 100% !important;
-        margin: 0 0 1rem;
-      }
-    }
-  }
-
   [data-name='/ifb/main1'] {
     margin-bottom: 1.5rem;
     font-size: 0.875rem;

--- a/astro/src/pages/bare/[...slug].astro
+++ b/astro/src/pages/bare/[...slug].astro
@@ -19,6 +19,7 @@ import Supporters from '../../components/mdx/Supporters.astro';
 import Contacts from '../../components/mdx/Contacts.astro';
 import Icon from '../../components/mdx/Icon.astro';
 import Insert from '../../components/mdx/Insert.astro';
+import LatestFeeds from '../../components/mdx/LatestFeeds.astro';
 
 export async function getStaticPaths() {
   const bareArticles = await getCollection('bare-articles');
@@ -52,6 +53,7 @@ const components = {
   Contacts,
   Icon,
   Insert,
+  LatestFeeds,
 };
 ---
 

--- a/astro/src/pages/bare/eu/latest/events.astro
+++ b/astro/src/pages/bare/eu/latest/events.astro
@@ -2,45 +2,10 @@
 /**
  * Bare EU Latest Events Page
  * Shows upcoming EU events in a compact format (36.1k visits!)
- * Embedded in Galaxy EU interface - high visibility feed
+ * Standalone feed kept for external embedders (see /eu/widgets/); the Galaxy EU
+ * landing pages render the same card inline via LatestFeeds.
  */
-import { getCollection } from 'astro:content';
-import { contentMatchesSubsite } from '../../../../utils/subsites';
-
-const now = new Date();
-
-const allEvents = await getCollection('events', (entry) => {
-  return contentMatchesSubsite(entry.data.subsites, 'eu') && !entry.data.draft;
-});
-
-// Get upcoming events
-const upcomingEvents = allEvents
-  .filter((e) => {
-    const endDate = e.data.end ? new Date(e.data.end) : e.data.date ? new Date(e.data.date) : null;
-    return endDate && endDate >= now;
-  })
-  .sort((a, b) => {
-    const dateA = a.data.date ? new Date(a.data.date) : new Date(0);
-    const dateB = b.data.date ? new Date(b.data.date) : new Date(0);
-    return dateA.getTime() - dateB.getTime();
-  })
-  .slice(0, 5);
-
-function formatDate(date: Date | string | undefined): string {
-  if (!date) return '';
-  const d = typeof date === 'string' ? new Date(date) : date;
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-function formatDateRange(start: Date | string | undefined, end: Date | string | undefined): string {
-  if (!start) return '';
-  const startStr = formatDate(start);
-  if (!end) return startStr;
-  const startD = typeof start === 'string' ? new Date(start) : start;
-  const endD = typeof end === 'string' ? new Date(end) : end;
-  if (startD.toDateString() === endD.toDateString()) return startStr;
-  return `${startStr} - ${formatDate(end)}`;
-}
+import LatestEventsCard from '@/components/bare/LatestEventsCard.astro';
 ---
 
 <!doctype html>
@@ -64,151 +29,12 @@ function formatDateRange(start: Date | string | undefined, end: Date | string | 
         background: transparent;
         padding: 15px;
       }
-
-      .home-card {
-        background: #fff;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-      }
-
-      .card-header {
-        background: #f5f5f5;
-        border-bottom: 1px solid #ddd;
-        padding: 12px 15px;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-      }
-
-      .card-header-icon {
-        color: #25537b;
-        font-size: 18px;
-      }
-
-      .card-header-title {
-        font-size: 16px;
-        font-weight: 600;
-        color: #25537b;
-        flex: 1;
-        text-decoration: none;
-      }
-
-      .card-header-title:hover {
-        text-decoration: underline;
-      }
-
-      .more-link {
-        color: #25537b;
-        text-decoration: none;
-        font-size: 14px;
-      }
-
-      .more-link:hover {
-        text-decoration: underline;
-      }
-
-      .card-body {
-        padding: 0;
-      }
-
-      .events-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-      }
-
-      .event-item {
-        padding: 12px 15px;
-        border-bottom: 1px solid #eee;
-      }
-
-      .event-item:last-child {
-        border-bottom: none;
-      }
-
-      .event-item a {
-        color: #25537b;
-        text-decoration: none;
-        font-weight: 400;
-      }
-
-      .event-item a:hover {
-        text-decoration: underline;
-      }
-
-      .event-details {
-        color: #666;
-        font-size: 13px;
-        margin-top: 4px;
-        line-height: 1.4;
-      }
-
-      .event-tease {
-        color: #666;
-        font-size: 13px;
-        margin-top: 4px;
-        line-height: 1.4;
-      }
     </style>
   </head>
   <body>
-    <div class="home-card">
-      <div class="card-header">
-        <a
-          href="https://galaxyproject.org/bare/eu/events/"
-          target="_blank"
-          style="color: inherit; text-decoration: none;"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 640 640"
-            style="color: #25537b; font-size: 28px; line-height:28px; height:34px;"
-            ><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
-            <path
-              fill="currentColor"
-              d="M216 64C229.3 64 240 74.7 240 88L240 128L400 128L400 88C400 74.7 410.7 64 424 64C437.3 64 448 74.7 448 88L448 128L480 128C515.3 128 544 156.7 544 192L544 480C544 515.3 515.3 544 480 544L160 544C124.7 544 96 515.3 96 480L96 192C96 156.7 124.7 128 160 128L192 128L192 88C192 74.7 202.7 64 216 64zM480 496C488.8 496 496 488.8 496 480L496 416L408 416L408 496L480 496zM496 368L496 288L408 288L408 368L496 368zM360 368L360 288L280 288L280 368L360 368zM232 368L232 288L144 288L144 368L232 368zM144 416L144 480C144 488.8 151.2 496 160 496L232 496L232 416L144 416zM280 416L280 496L360 496L360 416L280 416zM216 176L160 176C151.2 176 144 183.2 144 192L144 240L496 240L496 192C496 183.2 488.8 176 480 176L216 176z"
-            ></path></svg
-          >
-        </a>
-        <a href="https://galaxyproject.org/bare/eu/events/" class="card-header-title" target="_blank">Events</a>
-        <a href="https://galaxyproject.org/bare/eu/events/" class="card-header-link more-link" target="_blank"
-          >More events</a
-        >
-      </div>
-      <div class="card-body">
-        <ul class="events-list events-feed">
-          {
-            upcomingEvents.length > 0 ? (
-              upcomingEvents.map((event) => {
-                const slug = (event.data.slug || event.id)
-                  .replace(/\.mdx?$/, '')
-                  .replace(/--/g, '/')
-                  .replace(/^events\//, '');
-                const location = event.data.location;
-                const locationStr = location ? (typeof location === 'string' ? location : location.name) : null;
-                return (
-                  <li class="event-item">
-                    <a href={`https://galaxyproject.org/events/${slug}/`} target="_blank">
-                      {event.data.title}
-                    </a>
-                    <div class="event-details">
-                      {formatDateRange(event.data.date, event.data.end)}
-                      {locationStr && ` · ${locationStr}`}
-                    </div>
-                    {event.data.tease && <div class="event-tease">{event.data.tease}</div>}
-                  </li>
-                );
-              })
-            ) : (
-              <li class="event-item">No upcoming events</li>
-            )
-          }
-        </ul>
-      </div>
-    </div>
+    <LatestEventsCard subsite="eu" />
     <script>
-      import { notifyParent } from '../../../../utils/iframe';
+      import { notifyParent } from '@/utils/iframe';
       notifyParent();
     </script>
   </body>

--- a/astro/src/pages/bare/eu/latest/news.astro
+++ b/astro/src/pages/bare/eu/latest/news.astro
@@ -2,22 +2,10 @@
 /**
  * Bare EU Latest News Page
  * Shows most recent EU news articles in a compact format (36.2k visits!)
- * Embedded in Galaxy EU interface - high visibility feed
+ * Standalone feed kept for external embedders (see /eu/widgets/); the Galaxy EU
+ * landing pages render the same card inline via LatestFeeds.
  */
-import { getCollection } from 'astro:content';
-import { contentMatchesSubsite } from '../../../../utils/subsites';
-
-const allNews = await getCollection('news');
-const newsArticles = allNews
-  .filter((article) => {
-    return contentMatchesSubsite(article.data.subsites, 'eu') && !article.data.draft;
-  })
-  .sort((a, b) => {
-    const dateA = a.data.date ? new Date(a.data.date) : new Date(0);
-    const dateB = b.data.date ? new Date(b.data.date) : new Date(0);
-    return dateB.getTime() - dateA.getTime();
-  })
-  .slice(0, 5);
+import LatestNewsCard from '@/components/bare/LatestNewsCard.astro';
 ---
 
 <!doctype html>
@@ -41,134 +29,12 @@ const newsArticles = allNews
         background: transparent;
         padding: 15px;
       }
-
-      .home-card {
-        background: #fff;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-      }
-
-      .card-header {
-        background: #f5f5f5;
-        border-bottom: 1px solid #ddd;
-        padding: 12px 15px;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-      }
-
-      .card-header-icon {
-        color: #25537b;
-        font-size: 18px;
-      }
-
-      .card-header-title {
-        font-size: 16px;
-        font-weight: 600;
-        color: #25537b;
-        flex: 1;
-        text-decoration: none;
-      }
-
-      .card-header-title:hover {
-        text-decoration: underline;
-      }
-
-      .card-header-link {
-        color: #25537b;
-        text-decoration: none;
-        font-size: 14px;
-      }
-
-      .card-header-link:hover {
-        text-decoration: underline;
-      }
-
-      .card-body {
-        padding: 0;
-      }
-
-      .news-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-      }
-
-      .news-item {
-        padding: 12px 15px;
-        border-bottom: 1px solid #eee;
-      }
-
-      .news-item:last-child {
-        border-bottom: none;
-      }
-
-      .news-item a {
-        color: #25537b;
-        text-decoration: none;
-        font-weight: 400;
-      }
-
-      .news-item a:hover {
-        text-decoration: underline;
-      }
-
-      .news-tease {
-        color: #666;
-        font-size: 13px;
-        margin-top: 4px;
-        line-height: 1.4;
-      }
     </style>
   </head>
   <body>
-    <div class="home-card">
-      <div class="card-header">
-        <a
-          href="https://galaxyproject.org/bare/eu/news/"
-          target="_blank"
-          style="color: inherit; text-decoration: none;"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
-            style="color: #25537b; font-size: 25px; line-height:28px; height:25px;"
-            ><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
-            <path
-              fill="currentColor"
-              d="M461.2 18.9C472.7 24 480 35.4 480 48l0 416c0 12.6-7.3 24-18.8 29.1s-24.8 3.2-34.3-5.1l-46.6-40.7c-43.6-38.1-98.7-60.3-156.4-63l0 95.7c0 17.7-14.3 32-32 32l-32 0c-17.7 0-32-14.3-32-32l0-96C57.3 384 0 326.7 0 256S57.3 128 128 128l84.5 0c61.8-.2 121.4-22.7 167.9-63.3l46.6-40.7c9.4-8.3 22.9-10.2 34.3-5.1zM224 320l0 .2c70.3 2.7 137.8 28.5 192 73.4l0-275.3c-54.2 44.9-121.7 70.7-192 73.4L224 320z"
-            ></path></svg
-          >
-        </a>
-        <a href="https://galaxyproject.org/bare/eu/news/" class="card-header-title" target="_blank">News</a>
-        <a href="https://galaxyproject.org/bare/eu/news/" class="card-header-link more-link" target="_blank"
-          >More news</a
-        >
-      </div>
-      <div class="card-body">
-        <ul class="news-list">
-          {
-            newsArticles.map((article) => {
-              const slug = (article.data.slug || article.id)
-                .replace(/\.mdx?$/, '')
-                .replace(/--/g, '/')
-                .replace(/^news\//, '');
-              return (
-                <li class="news-item">
-                  <a href={`https://galaxyproject.org/news/${slug}/`} target="_blank">
-                    {article.data.title}
-                  </a>
-                  {article.data.tease && <div class="news-tease">{article.data.tease}</div>}
-                </li>
-              );
-            })
-          }
-        </ul>
-      </div>
-    </div>
+    <LatestNewsCard subsite="eu" />
     <script>
-      import { notifyParent } from '../../../../utils/iframe';
+      import { notifyParent } from '@/utils/iframe';
       notifyParent();
     </script>
   </body>

--- a/astro/src/pages/bare/fr/latest/events.astro
+++ b/astro/src/pages/bare/fr/latest/events.astro
@@ -1,46 +1,11 @@
 ---
 /**
  * Bare FR Latest Events Page
- * Shows upcoming FR events in a compact format (36.1k visits!)
- * Embedded in Galaxy FR interface - high visibility feed
+ * Shows upcoming FR events in a compact format
+ * Standalone feed kept for external embedders; the Galaxy FR landing page can
+ * render the same card inline via LatestFeeds.
  */
-import { getCollection } from 'astro:content';
-import { contentMatchesSubsite } from '../../../../utils/subsites';
-
-const now = new Date();
-
-const allEvents = await getCollection('events', (entry) => {
-  return contentMatchesSubsite(entry.data.subsites, 'fr') && !entry.data.draft;
-});
-
-// Get upcoming events
-const upcomingEvents = allEvents
-  .filter((e) => {
-    const endDate = e.data.end ? new Date(e.data.end) : e.data.date ? new Date(e.data.date) : null;
-    return endDate && endDate >= now;
-  })
-  .sort((a, b) => {
-    const dateA = a.data.date ? new Date(a.data.date) : new Date(0);
-    const dateB = b.data.date ? new Date(b.data.date) : new Date(0);
-    return dateA.getTime() - dateB.getTime();
-  })
-  .slice(0, 5);
-
-function formatDate(date: Date | string | undefined): string {
-  if (!date) return '';
-  const d = typeof date === 'string' ? new Date(date) : date;
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-function formatDateRange(start: Date | string | undefined, end: Date | string | undefined): string {
-  if (!start) return '';
-  const startStr = formatDate(start);
-  if (!end) return startStr;
-  const startD = typeof start === 'string' ? new Date(start) : start;
-  const endD = typeof end === 'string' ? new Date(end) : end;
-  if (startD.toDateString() === endD.toDateString()) return startStr;
-  return `${startStr} - ${formatDate(end)}`;
-}
+import LatestEventsCard from '@/components/bare/LatestEventsCard.astro';
 ---
 
 <!doctype html>
@@ -64,151 +29,12 @@ function formatDateRange(start: Date | string | undefined, end: Date | string | 
         background: transparent;
         padding: 15px;
       }
-
-      .home-card {
-        background: #fff;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-      }
-
-      .card-header {
-        background: #f5f5f5;
-        border-bottom: 1px solid #ddd;
-        padding: 12px 15px;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-      }
-
-      .card-header-icon {
-        color: #25537b;
-        font-size: 18px;
-      }
-
-      .card-header-title {
-        font-size: 16px;
-        font-weight: 600;
-        color: #25537b;
-        flex: 1;
-        text-decoration: none;
-      }
-
-      .card-header-title:hover {
-        text-decoration: underline;
-      }
-
-      .more-link {
-        color: #25537b;
-        text-decoration: none;
-        font-size: 14px;
-      }
-
-      .more-link:hover {
-        text-decoration: underline;
-      }
-
-      .card-body {
-        padding: 0;
-      }
-
-      .events-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-      }
-
-      .event-item {
-        padding: 12px 15px;
-        border-bottom: 1px solid #eee;
-      }
-
-      .event-item:last-child {
-        border-bottom: none;
-      }
-
-      .event-item a {
-        color: #25537b;
-        text-decoration: none;
-        font-weight: 400;
-      }
-
-      .event-item a:hover {
-        text-decoration: underline;
-      }
-
-      .event-details {
-        color: #666;
-        font-size: 13px;
-        margin-top: 4px;
-        line-height: 1.4;
-      }
-
-      .event-tease {
-        color: #666;
-        font-size: 13px;
-        margin-top: 4px;
-        line-height: 1.4;
-      }
     </style>
   </head>
   <body>
-    <div class="home-card">
-      <div class="card-header">
-        <a
-          href="https://galaxyproject.org/bare/fr/events/"
-          target="_blank"
-          style="color: inherit; text-decoration: none;"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 640 640"
-            style="color: #25537b; font-size: 28px; line-height:28px; height:34px;"
-            ><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
-            <path
-              fill="currentColor"
-              d="M216 64C229.3 64 240 74.7 240 88L240 128L400 128L400 88C400 74.7 410.7 64 424 64C437.3 64 448 74.7 448 88L448 128L480 128C515.3 128 544 156.7 544 192L544 480C544 515.3 515.3 544 480 544L160 544C124.7 544 96 515.3 96 480L96 192C96 156.7 124.7 128 160 128L192 128L192 88C192 74.7 202.7 64 216 64zM480 496C488.8 496 496 488.8 496 480L496 416L408 416L408 496L480 496zM496 368L496 288L408 288L408 368L496 368zM360 368L360 288L280 288L280 368L360 368zM232 368L232 288L144 288L144 368L232 368zM144 416L144 480C144 488.8 151.2 496 160 496L232 496L232 416L144 416zM280 416L280 496L360 496L360 416L280 416zM216 176L160 176C151.2 176 144 183.2 144 192L144 240L496 240L496 192C496 183.2 488.8 176 480 176L216 176z"
-            ></path></svg
-          >
-        </a>
-        <a href="https://galaxyproject.org/bare/fr/events/" class="card-header-title" target="_blank">Events</a>
-        <a href="https://galaxyproject.org/bare/fr/events/" class="card-header-link more-link" target="_blank"
-          >More events</a
-        >
-      </div>
-      <div class="card-body">
-        <ul class="events-list events-feed">
-          {
-            upcomingEvents.length > 0 ? (
-              upcomingEvents.map((event) => {
-                const slug = (event.data.slug || event.id)
-                  .replace(/\.mdx?$/, '')
-                  .replace(/--/g, '/')
-                  .replace(/^events\//, '');
-                const location = event.data.location;
-                const locationStr = location ? (typeof location === 'string' ? location : location.name) : null;
-                return (
-                  <li class="event-item">
-                    <a href={`https://galaxyproject.org/events/${slug}/`} target="_blank">
-                      {event.data.title}
-                    </a>
-                    <div class="event-details">
-                      {formatDateRange(event.data.date, event.data.end)}
-                      {locationStr && ` · ${locationStr}`}
-                    </div>
-                    {event.data.tease && <div class="event-tease">{event.data.tease}</div>}
-                  </li>
-                );
-              })
-            ) : (
-              <li class="event-item">No upcoming events</li>
-            )
-          }
-        </ul>
-      </div>
-    </div>
+    <LatestEventsCard subsite="fr" />
     <script>
-      import { notifyParent } from '../../../../utils/iframe';
+      import { notifyParent } from '@/utils/iframe';
       notifyParent();
     </script>
   </body>

--- a/astro/src/pages/bare/fr/latest/news.astro
+++ b/astro/src/pages/bare/fr/latest/news.astro
@@ -1,23 +1,11 @@
 ---
 /**
  * Bare FR Latest News Page
- * Shows most recent FR news articles in a compact format (36.2k visits!)
- * Embedded in Galaxy FR interface - high visibility feed
+ * Shows most recent FR news articles in a compact format
+ * Standalone feed kept for external embedders; the Galaxy FR landing page can
+ * render the same card inline via LatestFeeds.
  */
-import { getCollection } from 'astro:content';
-import { contentMatchesSubsite } from '../../../../utils/subsites';
-
-const allNews = await getCollection('news');
-const newsArticles = allNews
-  .filter((article) => {
-    return contentMatchesSubsite(article.data.subsites, 'fr') && !article.data.draft;
-  })
-  .sort((a, b) => {
-    const dateA = a.data.date ? new Date(a.data.date) : new Date(0);
-    const dateB = b.data.date ? new Date(b.data.date) : new Date(0);
-    return dateB.getTime() - dateA.getTime();
-  })
-  .slice(0, 5);
+import LatestNewsCard from '@/components/bare/LatestNewsCard.astro';
 ---
 
 <!doctype html>
@@ -41,134 +29,12 @@ const newsArticles = allNews
         background: transparent;
         padding: 15px;
       }
-
-      .home-card {
-        background: #fff;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-      }
-
-      .card-header {
-        background: #f5f5f5;
-        border-bottom: 1px solid #ddd;
-        padding: 12px 15px;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-      }
-
-      .card-header-icon {
-        color: #25537b;
-        font-size: 18px;
-      }
-
-      a.card-header-title {
-        font-size: 16px;
-        font-weight: 600;
-        color: #25537b;
-        flex: 1;
-        text-decoration: none;
-      }
-
-      .card-header-title:hover {
-        text-decoration: underline;
-      }
-
-      .card-header-link {
-        color: #25537b;
-        text-decoration: none;
-        font-size: 14px;
-      }
-
-      .card-header-link:hover {
-        text-decoration: underline;
-      }
-
-      .card-body {
-        padding: 0;
-      }
-
-      .news-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-      }
-
-      .news-item {
-        padding: 12px 15px;
-        border-bottom: 1px solid #eee;
-      }
-
-      .news-item:last-child {
-        border-bottom: none;
-      }
-
-      .news-item a {
-        color: #25537b;
-        text-decoration: none;
-        font-weight: 400;
-      }
-
-      .news-item a:hover {
-        text-decoration: underline;
-      }
-
-      .news-tease {
-        color: #666;
-        font-size: 13px;
-        margin-top: 4px;
-        line-height: 1.4;
-      }
     </style>
   </head>
   <body>
-    <div class="home-card">
-      <div class="card-header">
-        <a
-          href="https://galaxyproject.org/bare/fr/news/"
-          target="_blank"
-          style="color: #25537b; font-size: 28px; line-height:28px; height:34px;"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
-            style="color: #25537b; font-size: 25px; line-height:28px; height:25px;"
-            ><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
-            <path
-              fill="currentColor"
-              d="M461.2 18.9C472.7 24 480 35.4 480 48l0 416c0 12.6-7.3 24-18.8 29.1s-24.8 3.2-34.3-5.1l-46.6-40.7c-43.6-38.1-98.7-60.3-156.4-63l0 95.7c0 17.7-14.3 32-32 32l-32 0c-17.7 0-32-14.3-32-32l0-96C57.3 384 0 326.7 0 256S57.3 128 128 128l84.5 0c61.8-.2 121.4-22.7 167.9-63.3l46.6-40.7c9.4-8.3 22.9-10.2 34.3-5.1zM224 320l0 .2c70.3 2.7 137.8 28.5 192 73.4l0-275.3c-54.2 44.9-121.7 70.7-192 73.4L224 320z"
-            ></path></svg
-          >
-        </a>
-        <a href="https://galaxyproject.org/bare/fr/news/" class="card-header-title" target="_blank">News</a>
-        <a href="https://galaxyproject.org/bare/fr/news/" class="card-header-link more-link" target="_blank"
-          >More news</a
-        >
-      </div>
-      <div class="card-body">
-        <ul class="news-list">
-          {
-            newsArticles.map((article) => {
-              const slug = (article.data.slug || article.id)
-                .replace(/\.mdx?$/, '')
-                .replace(/--/g, '/')
-                .replace(/^news\//, '');
-              return (
-                <li class="news-item">
-                  <a href={`https://galaxyproject.org/news/${slug}/`} target="_blank">
-                    {article.data.title}
-                  </a>
-                  {article.data.tease && <div class="news-tease">{article.data.tease}</div>}
-                </li>
-              );
-            })
-          }
-        </ul>
-      </div>
-    </div>
+    <LatestNewsCard subsite="fr" />
     <script>
-      import { notifyParent } from '../../../../utils/iframe';
+      import { notifyParent } from '@/utils/iframe';
       notifyParent();
     </script>
   </body>

--- a/astro/tests/bare-pages.spec.ts
+++ b/astro/tests/bare-pages.spec.ts
@@ -209,6 +209,7 @@ test.describe('Bare Pages', () => {
       '/bare/eu/usegalaxy/main/',
       '/bare/fr/usegalaxy/main/',
       '/bare/eu/usegalaxy/metabolomics/',
+      '/bare/eu/usegalaxy/proteomics/',
     ];
 
     for (const path of pagesWithLatestFeeds) {

--- a/astro/tests/bare-pages.spec.ts
+++ b/astro/tests/bare-pages.spec.ts
@@ -208,6 +208,7 @@ test.describe('Bare Pages', () => {
     const pagesWithLatestFeeds = [
       '/bare/eu/usegalaxy/main/',
       '/bare/fr/usegalaxy/main/',
+      '/bare/eu/usegalaxy/metabolomics/',
     ];
 
     for (const path of pagesWithLatestFeeds) {

--- a/astro/tests/bare-pages.spec.ts
+++ b/astro/tests/bare-pages.spec.ts
@@ -198,33 +198,44 @@ test.describe('Bare Pages', () => {
       const dataPolicy = page.getByText('Our Data Policy');
       await expect(dataPolicy).toBeVisible();
 
-      // Iframes for latest news/events feeds should be present
-      const iframes = page.locator('iframe.js-resize-iframe');
-      const iframeCount = await iframes.count();
-      expect(iframeCount).toBe(2);
+      // Latest news/events feeds render inline, one card each
+      const feedCards = page.locator('.latest-feeds .home-card');
+      await expect(feedCards).toHaveCount(2);
     });
 
-    test('/bare/eu/usegalaxy/main/ does not expose native iframe resize handles', async ({ page }) => {
-      await page.goto('/bare/eu/usegalaxy/main/');
+    // Every bare page that carries the feeds used to pull them from
+    // /bare/<subsite>/latest/* through same-origin iframes.
+    const pagesWithLatestFeeds = [
+      '/bare/eu/usegalaxy/main/',
+    ];
 
-      const iframes = page.locator('iframe.js-resize-iframe');
-      await expect(iframes).toHaveCount(2);
-      await expect(iframes.first()).toHaveCSS('resize', 'none');
-      await expect(iframes.nth(1)).toHaveCSS('resize', 'none');
-    });
+    for (const path of pagesWithLatestFeeds) {
+      test(`${path} renders the latest feeds without nested iframes`, async ({ page }) => {
+        const response = await page.goto(path);
+        expect(response?.status()).toBe(200);
+
+        // Nothing should embed the site in itself.
+        await expect(page.locator('iframe[src^="/bare/"]')).toHaveCount(0);
+
+        const feeds = page.locator('.latest-feeds');
+        await expect(feeds.locator('.home-card')).toHaveCount(2);
+        await expect(feeds.locator('.news-item').first()).toBeVisible();
+        await expect(feeds.locator('.event-item').first()).toBeVisible();
+      });
+    }
 
     test('/bare/eu/usegalaxy/main/ keeps lead content below latest feeds', async ({ page }) => {
       await page.goto('/bare/eu/usegalaxy/main/');
 
-      const latestFeeds = page.locator('iframe.js-resize-iframe');
-      await expect(latestFeeds).toHaveCount(2);
+      const latestFeeds = page.locator('.latest-feeds');
+      await expect(latestFeeds.locator('.home-card')).toHaveCount(2);
 
-      const lastFeedBox = await latestFeeds.nth(1).boundingBox();
+      const feedsBox = await latestFeeds.boundingBox();
       const leadBox = await page.locator('[data-name="/eu/main1"]').boundingBox();
 
-      expect(lastFeedBox).not.toBeNull();
+      expect(feedsBox).not.toBeNull();
       expect(leadBox).not.toBeNull();
-      expect(leadBox!.y).toBeGreaterThanOrEqual(lastFeedBox!.y + lastFeedBox!.height - 1);
+      expect(leadBox!.y).toBeGreaterThanOrEqual(feedsBox!.y + feedsBox!.height - 1);
     });
 
     test('/bare/eu/usegalaxy/main/ hides UseGalaxy.eu launch button', async ({ page }) => {

--- a/astro/tests/bare-pages.spec.ts
+++ b/astro/tests/bare-pages.spec.ts
@@ -210,6 +210,7 @@ test.describe('Bare Pages', () => {
       '/bare/fr/usegalaxy/main/',
       '/bare/eu/usegalaxy/metabolomics/',
       '/bare/eu/usegalaxy/proteomics/',
+      '/bare/eu/usegalaxy/eirene/',
     ];
 
     for (const path of pagesWithLatestFeeds) {

--- a/astro/tests/bare-pages.spec.ts
+++ b/astro/tests/bare-pages.spec.ts
@@ -207,6 +207,7 @@ test.describe('Bare Pages', () => {
     // /bare/<subsite>/latest/* through same-origin iframes.
     const pagesWithLatestFeeds = [
       '/bare/eu/usegalaxy/main/',
+      '/bare/fr/usegalaxy/main/',
     ];
 
     for (const path of pagesWithLatestFeeds) {

--- a/content/bare/eu/usegalaxy/eirene/index.md
+++ b/content/bare/eu/usegalaxy/eirene/index.md
@@ -42,15 +42,7 @@ Other national EIRENE Galaxy servers:
 
 <Carousel />
 
-<iframe title="Recent Galaxy Europe news" height="450"
- class="resize-y" src="/bare/eu/latest/news/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
-
-<iframe title="Recent Galaxy Europe events" height="450"
- class="resize-y" src="/bare/eu/latest/events/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
+<LatestFeeds subsite="eu" />
 
 # Contributors
 

--- a/content/bare/eu/usegalaxy/main/index.md
+++ b/content/bare/eu/usegalaxy/main/index.md
@@ -11,14 +11,7 @@ components: true
 
 "Anyone, anywhere in the world should have free, unhindered access to not just my research, but to the research of every great and enquiring mind across the spectrum of human understanding." – Prof. Stephen Hawking
 
-<iframe title="Recent Galaxy Europe news" height="450"
- class="js-resize-iframe" src="/bare/eu/latest/news/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
-<iframe title="Recent Galaxy Europe events" height="450"
- class="js-resize-iframe" src="/bare/eu/latest/events/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
+<LatestFeeds subsite="eu" />
 
 <p></p>
 

--- a/content/bare/eu/usegalaxy/metabolomics/index.md
+++ b/content/bare/eu/usegalaxy/metabolomics/index.md
@@ -94,17 +94,7 @@ Other metabolomics specialized Galaxy servers:
 
 <Carousel />
 
-<iframe 
-    title="Recent Galaxy Europe news"
-    class="js-resize-iframe" src="/bare/eu/latest/news/" scrolling="no"
-    style="width: 50%; border: none; vertical-align: top">
-</iframe>
-
-<iframe 
-    title="Recent Galaxy Europe events"
-    class="js-resize-iframe" src="/bare/eu/latest/events/" scrolling="no"
-    style="width: 50%; border: none; vertical-align: top">
-</iframe>
+<LatestFeeds subsite="eu" />
 
 # Contributors
 

--- a/content/bare/eu/usegalaxy/proteomics/index.md
+++ b/content/bare/eu/usegalaxy/proteomics/index.md
@@ -78,15 +78,7 @@ Featured Galaxy-P tools supported with manuscripts, visualization plugins, docke
 
 <Carousel />
 
-<iframe title="Recent Galaxy Europe news"
- class="js-resize-iframe" src="/bare/eu/latest/news/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
-
-<iframe title="Recent Galaxy Europe events"
- class="js-resize-iframe" src="/bare/eu/latest/events/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
+<LatestFeeds subsite="eu" />
 
 # Contributors
 

--- a/content/bare/fr/usegalaxy/main/index.md
+++ b/content/bare/fr/usegalaxy/main/index.md
@@ -12,14 +12,7 @@ components: true
 
 <br/>
 
-<iframe title="Recent Galaxy France news" height="450"
- class="js-resize-iframe" src="/bare/fr/latest/news/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
-<iframe title="Recent Galaxy France events" height="450"
- class="js-resize-iframe" src="/bare/fr/latest/events/" scrolling="no"
- style="width: 50%; border: none; vertical-align: top">
-</iframe>
+<LatestFeeds subsite="fr" />
 
 <p></p>
 <slot name="/ifb/main1" />


### PR DESCRIPTION
The bare landing pages pulled their News and Events feeds through iframes pointing at `/bare/eu/latest/news/`, `/bare/eu/latest/events/` and the FR equivalents — pages in this same repo, built by the same Astro build, served from the same origin.

That was a Gridsome-era workaround, not a design choice. In 392c2e30 (May 2022) `/bare/usegalaxy-eu/main/` became a static markdown `BareArticle`, but the feed lists needed a GraphQL `<page-query>`, which Gridsome only ran inside `.vue` page components — never in markdown. So the lists had to live at their own route (`src/pages/bare/eu/Latest.vue`) and were pulled back in through an iframe. c1048c8b later split that single frame into two. The `js-resize-iframe` class and `notifyParent()` were the accompanying auto-height hack.

The Astro port carried the markup over verbatim, but the constraint is gone: `getCollection('news' | 'events')` runs at build time in any component.

### What this changes

- Extracts the feed markup, styles and queries into subsite-aware `LatestNewsCard` / `LatestEventsCard` components, so `/bare/eu/latest/*` and `/bare/fr/latest/*` stop carrying four near-identical copies.
- Adds a `LatestFeeds` MDX component (responsive 2-up grid, `not-prose`) and uses it in place of the iframe pair on all five pages that had it:
  - `content/bare/eu/usegalaxy/main/index.md`
  - `content/bare/fr/usegalaxy/main/index.md`
  - `content/bare/eu/usegalaxy/metabolomics/index.md`
  - `content/bare/eu/usegalaxy/proteomics/index.md`
  - `content/bare/eu/usegalaxy/eirene/index.md`
- Fixes eirene on the way: its frames used `class="resize-y"` instead of `js-resize-iframe`, so they never got the auto-height treatment — they stayed pinned at `height="450"` and exposed a native resize grip.
- Removes the now-dead `iframe[title='Recent Galaxy Europe news']`-style layout rules from `BareArticleLayout`; `LatestFeeds` owns the two-column layout and the mobile stacking.

### What this deliberately does not change

- The standalone `/bare/{eu,fr}/latest/{news,events}/` routes stay exactly where they are — they are documented embed targets for external sites (`/eu/widgets/`, `/bare/`), so removing them would break third parties. They keep their standalone HTML shell and their `notifyParent()` call.
- The outer bare pages are still meant to be iframed: usegalaxy.eu embeds `/bare/eu/usegalaxy/main/` in the Galaxy welcome pane, cross-origin. Only the *nested* same-origin frames go away.
- Feed links stay absolute (`https://galaxyproject.org/...`) with `target="_blank"`, since the pages still render inside the Galaxy interface.
- `src/utils/iframe.ts` stays. `setupIframeResize()` now has no `js-resize-iframe` targets left in this repo, but it is a generic hook for authored content and the parent-side half of the handshake external embedders can still use.

### Why it's worth doing

- No nested browsing context, no third-level frame.
- No `height="450"` guesses and no cross-frame resize handshake for these pages.
- Feed content lives in each page's own document — visible to search and to assistive tech, which could not reach it through the frame.
- ~280 fewer lines overall; one source of truth for the card markup.