### PR TITLE
Move welcome video below JXTX panel, add Bluesky feed widget

### DIFF
--- a/astro/src/pages/usegalaxy/welcome.astro
+++ b/astro/src/pages/usegalaxy/welcome.astro
@@ -119,7 +119,10 @@ const carouselSlides = [
 
       <!-- Bluesky Feed -->
       <div>
-        <div class="rounded-lg shadow-md bg-white border border-ebony-clay-100 p-4 h-full flex flex-col" id="bluesky-feed">
+        <div
+          class="rounded-lg shadow-md bg-white border border-ebony-clay-100 p-4 h-full flex flex-col"
+          id="bluesky-feed"
+        >
           <div class="flex items-center gap-1.5 mb-1.5">
             <Icon name="cloud" size={14} />
             <p class="font-semibold text-galaxy-dark text-xs m-0">Latest from Bluesky</p>
@@ -444,7 +447,7 @@ const carouselSlides = [
 
         try {
           const res = await fetch(
-            'https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=galaxyproject.bsky.social&filter=posts_no_replies&limit=10',
+            'https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=galaxyproject.bsky.social&filter=posts_no_replies&limit=10'
           );
           if (!res.ok) throw new Error(`Bluesky API error: ${res.status}`);
           const data = await res.json();

--- a/astro/src/pages/usegalaxy/welcome.astro
+++ b/astro/src/pages/usegalaxy/welcome.astro
@@ -60,13 +60,16 @@ const carouselSlides = [
           <a
             href="https://galaxyproject.org/admin/tools/add-tool-from-toolshed-tutorial"
             class="text-galaxy-gold hover:text-accent-hover underline underline-offset-2">Tool Shed</a
-          >.
+          >. New to Galaxy? Watch
+          <a href="#what-is-galaxy" class="text-galaxy-gold hover:text-accent-hover underline underline-offset-2"
+            >"What is Galaxy?"</a
+          > below.
         </p>
       </div>
     </section>
 
     <!-- Media Row: Carousel + YouTube -->
-    <section class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 items-center">
       <!-- Carousel -->
       <div>
         <div class="rounded-lg overflow-hidden shadow-md bg-ebony-clay-100" id="welcome-carousel">
@@ -114,16 +117,21 @@ const carouselSlides = [
         </div>
       </div>
 
-      <!-- YouTube -->
+      <!-- Bluesky Feed -->
       <div>
-        <div class="rounded-lg overflow-hidden shadow-md">
-          <iframe
-            src="https://www.youtube-nocookie.com/embed/k6fTVIR4GME?mute=1&cc_load_policy=1&autoplay=0&loop=0&playlist=k6fTVIR4GME"
-            title="YouTube video player"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
-            class="w-full border-0 block"
-            style="aspect-ratio: 400/277;"></iframe>
+        <div class="rounded-lg shadow-md bg-white border border-ebony-clay-100 p-4 h-full flex flex-col" id="bluesky-feed">
+          <div class="flex items-center gap-1.5 mb-1.5">
+            <Icon name="cloud" size={14} />
+            <p class="font-semibold text-galaxy-dark text-xs m-0">Latest from Bluesky</p>
+          </div>
+          <div id="bluesky-feed-posts" class="space-y-1.5 overflow-y-auto text-sm flex-1" style="max-height: 220px;">
+            <p class="text-chicago-400 text-xs m-0">Loading posts&hellip;</p>
+          </div>
+          <a
+            href="https://bsky.app/profile/galaxyproject.bsky.social"
+            target="_blank"
+            class="text-galaxy-primary hover:underline text-xs mt-1.5 inline-block">View more on Bluesky &rarr;</a
+          >
         </div>
       </div>
     </section>
@@ -149,6 +157,20 @@ const carouselSlides = [
         <Icon name="heart" size={16} />
         Donate
       </a>
+    </section>
+
+    <!-- What is Galaxy Video -->
+    <section id="what-is-galaxy" class="mb-8">
+      <p class="font-semibold text-galaxy-dark mb-3">What is Galaxy?</p>
+      <div class="rounded-lg overflow-hidden shadow-md max-w-xl mx-auto">
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/k6fTVIR4GME?mute=1&cc_load_policy=1&autoplay=0&loop=0&playlist=k6fTVIR4GME"
+          title="YouTube video player"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+          class="w-full border-0 block"
+          style="aspect-ratio: 400/277;"></iframe>
+      </div>
     </section>
 
     <!-- Social Media -->
@@ -415,9 +437,79 @@ const carouselSlides = [
         startAutoPlay();
       }
 
+      async function initBlueskyFeed() {
+        const container = document.getElementById('bluesky-feed-posts');
+        if (!container || container.dataset.loaded === 'true') return;
+        container.dataset.loaded = 'true';
+
+        try {
+          const res = await fetch(
+            'https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=galaxyproject.bsky.social&filter=posts_no_replies&limit=10',
+          );
+          if (!res.ok) throw new Error(`Bluesky API error: ${res.status}`);
+          const data = await res.json();
+          const items: any[] = Array.isArray(data.feed) ? data.feed.slice(0, 10) : [];
+
+          container.textContent = '';
+
+          if (items.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'text-chicago-400 text-xs m-0';
+            empty.textContent = 'No recent posts found.';
+            container.appendChild(empty);
+            return;
+          }
+
+          const truncate = (str: string, maxLen: number) => {
+            if (str.length <= maxLen) return str;
+            const cut = str.slice(0, maxLen);
+            const lastSpace = cut.lastIndexOf(' ');
+            return `${cut.slice(0, lastSpace > 0 ? lastSpace : maxLen)}…`;
+          };
+
+          items.forEach(({ post }: any) => {
+            const rkey = post?.uri?.split('/').pop();
+            const handle = post?.author?.handle;
+            const postUrl =
+              handle && rkey
+                ? `https://bsky.app/profile/${handle}/post/${rkey}`
+                : 'https://bsky.app/profile/galaxyproject.bsky.social';
+            const text = truncate(post?.record?.text ?? '', 100);
+            const date = post?.indexedAt ? new Date(post.indexedAt) : null;
+
+            const item = document.createElement('div');
+
+            const textEl = document.createElement('p');
+            textEl.className = 'm-0 text-chicago-700 text-xs leading-snug';
+            textEl.textContent = text;
+            item.appendChild(textEl);
+
+            const link = document.createElement('a');
+            link.href = postUrl;
+            link.target = '_blank';
+            link.className = 'text-chicago-400 text-xs hover:text-galaxy-primary no-underline';
+            link.textContent = date
+              ? date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+              : 'View post';
+            item.appendChild(link);
+
+            container.appendChild(item);
+          });
+        } catch (err) {
+          container.textContent = '';
+          const errEl = document.createElement('p');
+          errEl.className = 'text-chicago-400 text-xs m-0';
+          errEl.textContent = 'Unable to load Bluesky posts right now.';
+          container.appendChild(errEl);
+          console.error('Failed to load Bluesky feed', err);
+        }
+      }
+
       // astro:page-load for ViewTransitions, DOMContentLoaded as fallback for standalone pages
       document.addEventListener('astro:page-load', initWelcomeCarousel);
       document.addEventListener('DOMContentLoaded', initWelcomeCarousel);
+      document.addEventListener('astro:page-load', initBlueskyFeed);
+      document.addEventListener('DOMContentLoaded', initBlueskyFeed);
 
       document.addEventListener('astro:before-swap', () => {
         if (welcomeCarouselInterval) {


### PR DESCRIPTION
Frees up space next to the carousel for a widget showing the 10 most recent galaxyproject Bluesky posts, fetched client-side from the public AppView API. The "Galaxy is a..." intro now links down to the relocated video.