### PR TITLE
Make Bluesky feed post text a link to the post

### DIFF
--- a/astro/src/pages/usegalaxy/welcome.astro
+++ b/astro/src/pages/usegalaxy/welcome.astro
@@ -485,8 +485,7 @@ const carouselSlides = [
             const textEl = document.createElement('a');
             textEl.href = postUrl;
             textEl.target = '_blank';
-            textEl.className =
-              'block m-0 text-chicago-700 text-xs leading-snug hover:text-galaxy-primary no-underline';
+            textEl.className = 'block m-0 text-chicago-700 text-xs leading-snug hover:text-galaxy-primary no-underline';
             textEl.textContent = text;
             item.appendChild(textEl);
 

--- a/astro/src/pages/usegalaxy/welcome.astro
+++ b/astro/src/pages/usegalaxy/welcome.astro
@@ -482,8 +482,11 @@ const carouselSlides = [
 
             const item = document.createElement('div');
 
-            const textEl = document.createElement('p');
-            textEl.className = 'm-0 text-chicago-700 text-xs leading-snug';
+            const textEl = document.createElement('a');
+            textEl.href = postUrl;
+            textEl.target = '_blank';
+            textEl.className =
+              'block m-0 text-chicago-700 text-xs leading-snug hover:text-galaxy-primary no-underline';
             textEl.textContent = text;
             item.appendChild(textEl);
 


### PR DESCRIPTION
## Summary
- Bluesky feed post text on the usegalaxy welcome page is now a clickable link to the post itself, matching the existing date link.

## Test plan
- [x] Ran the dev server locally and confirmed post text links to the correct Bluesky post URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)