### PR TITLE
Add Tools page for US subsite as well using a weekly workflow

### DIFF
--- a/.github/workflows/release-guardians-refresh.yml
+++ b/.github/workflows/release-guardians-refresh.yml
@@ -4,7 +4,7 @@
 # the testing label, and rewrites the matching event file in content/events/
 # plus the per-cycle snapshot under astro/src/data/release-guardians/.
 # If anything changed, opens (or updates) a PR — matching the pattern used by
-# update-eu-tools, update-eu-citations, sync-training-material-metadata, etc.
+# update-tools, update-eu-citations, sync-training-material-metadata, etc.
 
 name: Release Guardians refresh
 

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -1,4 +1,4 @@
-name: Update EU Tools Report
+name: Update Tools Report
 on:
   workflow_dispatch:
   schedule:
@@ -12,6 +12,19 @@ jobs:
   update-tools:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'galaxyproject'
+    strategy:
+      matrix:
+        include:
+          - id: eu
+            label: EU
+            server: https://usegalaxy.eu
+            name: 'European Galaxy'
+            output: content/eu/tools/index.md
+          - id: us
+            label: US
+            server: https://usegalaxy.org
+            name: 'US Galaxy'
+            output: content/us/tools/index.md
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -32,14 +45,14 @@ jobs:
         run: pip install requests
 
       - name: Run update script
-        run: python scripts/update-tools.py --server https://usegalaxy.eu --name "European Galaxy" --output content/eu/tools/index.md
+        run: python scripts/update-tools.py --server ${{ matrix.server }} --name "${{ matrix.name }}" --output ${{ matrix.output }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: 'chore(eu): update tools report'
-          title: 'Update EU Tools Report'
-          body: 'Auto-generated PR with the updated inventory of tools available at [Galaxy EU](https://usegalaxy.eu).'
-          branch: update-eu-tools-report
+          commit-message: 'chore(${{ matrix.id }}): update tools report'
+          title: 'Update ${{ matrix.label }} Tools Report'
+          body: 'Auto-generated PR with the updated inventory of tools available at [Galaxy ${{ matrix.label }}](${{ matrix.server }}).'
+          branch: update-${{ matrix.id }}-tools-report
           delete-branch: true

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'galaxyproject'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - id: eu
@@ -23,7 +24,7 @@ jobs:
           - id: us
             label: US
             server: https://usegalaxy.org
-            name: 'US Galaxy'
+            name: 'Galaxy US'
             output: content/us/tools/index.md
     steps:
       - name: Checkout
@@ -45,7 +46,7 @@ jobs:
         run: pip install requests
 
       - name: Run update script
-        run: python scripts/update-tools.py --server ${{ matrix.server }} --name "${{ matrix.name }}" --output ${{ matrix.output }}
+        run: python scripts/update-tools.py --server "${{ matrix.server }}" --name "${{ matrix.name }}" --output "${{ matrix.output }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8

--- a/content/us/navbar.yml
+++ b/content/us/navbar.yml
@@ -7,3 +7,6 @@ left:
     - label: Events
       relativeTo: subsite
       target: events/
+    - label: Tools
+      relativeTo: subsite
+      target: tools/

--- a/content/us/tools/index.md
+++ b/content/us/tools/index.md
@@ -1,7 +1,7 @@
 ---
 # THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY.
-# To update, run: python3 scripts/update-tools.py --server https://usegalaxy.org --name "US Galaxy" --output content/us/tools/index.md
-title: US Galaxy Tools
+# To update, run: python3 scripts/update-tools.py --server https://usegalaxy.org --name "Galaxy US" --output content/us/tools/index.md
+title: Galaxy US Tools
 description: "2350 tools and counting"
 ---
 

--- a/content/us/tools/index.md
+++ b/content/us/tools/index.md
@@ -1,0 +1,2950 @@
+---
+# THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY.
+# To update, run: python3 scripts/update-tools.py --server https://usegalaxy.org --name "US Galaxy" --output content/us/tools/index.md
+title: US Galaxy Tools
+description: "2350 tools and counting"
+---
+
+
+### Get Data
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=sam_dump" target="_top" title="format from NCBI SRA">Download and Extract Reads in BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_dump" target="_top" title="format from NCBI SRA">Download and Extract Reads in FASTQ</a>
+<a href="https://usegalaxy.org/root?tool_id=ebi_metagenomics_run_downloader" target="_top" title="from EBI Metagenomics database">Download run data</a>
+<a href="https://usegalaxy.org/root?tool_id=ebi_sra_main" target="_top" title="ENA SRA">EBI SRA</a>
+<a href="https://usegalaxy.org/root?tool_id=ebi_search_rest_results" target="_top" title="to obtain search results on resources and services hosted at the EBI">EBI Search</a>
+<a href="https://usegalaxy.org/root?tool_id=pyega3" target="_top" title="">EGA Download Client</a>
+<a href="https://usegalaxy.org/root?tool_id=fasterq_dump" target="_top" title="format from NCBI SRA">Faster Download and Extract Reads in FASTQ</a>
+<a href="https://usegalaxy.org/root?tool_id=iedb_api" target="_top" title="MHC Binding prediction">IEDB</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_acc_download" target="_top" title="Download sequences from GenBank/RefSeq by accession through the NCBI ENTREZ API">NCBI Accession Download</a>
+<a href="https://usegalaxy.org/root?tool_id=datasets_download_gene" target="_top" title="download gene sequences and metadata">NCBI Datasets Gene</a>
+<a href="https://usegalaxy.org/root?tool_id=datasets_download_genome" target="_top" title="download genome sequence, annotation and metadata">NCBI Datasets Genomes</a>
+<a href="https://usegalaxy.org/root?tool_id=dbbuilder" target="_top" title="">Protein Database Downloader</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_table_direct1" target="_top" title="table browser">UCSC Main</a>
+<a href="https://usegalaxy.org/root?tool_id=uniprotxml_downloader" target="_top" title="download proteome as XML or fasta">UniProt</a>
+<a href="https://usegalaxy.org/root?tool_id=unipept" target="_top" title="retrieve taxonomy for peptides">Unipept</a>
+<a href="https://usegalaxy.org/root?tool_id=upload1" target="_top" title="from your computer">Upload File</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_dl" target="_top" title="Download FASTQ files from ENA">fastq-dl</a>
+<a href="https://usegalaxy.org/root?tool_id=pysradb_search" target="_top" title="sequence metadata from SRA/ENA">pysradb search</a>
+
+</div>
+
+### Send Data
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=export_remote" target="_top" title="to repositories">Export datasets</a>
+
+</div>
+
+### Collection Operations
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=__APPLY_RULES__" target="_top" title="to reorganize a collection using the rule builder">Apply rules</a>
+<a href="https://usegalaxy.org/root?tool_id=__BUILD_LIST__" target="_top" title="from individual datasets or existing collections">Build list</a>
+<a href="https://usegalaxy.org/root?tool_id=collapse_dataset" target="_top" title="into single dataset in order of the collection">Collapse Collection</a>
+<a href="https://usegalaxy.org/root?tool_id=collection_column_join" target="_top" title="on multiple datasets">Column join</a>
+<a href="https://usegalaxy.org/root?tool_id=__CONVERT_SAMPLE_SHEET__" target="_top" title="to list collection">Convert sample sheet</a>
+<a href="https://usegalaxy.org/root?tool_id=__DUPLICATE_FILE_TO_COLLECTION__" target="_top" title="by duplicating a dataset N times">Duplicate file to collection</a>
+<a href="https://usegalaxy.org/root?tool_id=__EXTRACT_DATASET__" target="_top" title="from a collection by index or identifier">Extract dataset</a>
+<a href="https://usegalaxy.org/root?tool_id=collection_element_identifiers" target="_top" title="of a list collection">Extract element identifiers</a>
+<a href="https://usegalaxy.org/root?tool_id=__FILTER_FROM_FILE__" target="_top" title="using a list of identifiers from a file">Filter collection</a>
+<a href="https://usegalaxy.org/root?tool_id=__FILTER_EMPTY_DATASETS__" target="_top" title="from a collection">Filter empty datasets</a>
+<a href="https://usegalaxy.org/root?tool_id=__FILTER_FAILED_DATASETS__" target="_top" title="from a collection">Filter failed datasets</a>
+<a href="https://usegalaxy.org/root?tool_id=__FILTER_NULL__" target="_top" title="from a collection">Filter null elements</a>
+<a href="https://usegalaxy.org/root?tool_id=__CROSS_PRODUCT_FLAT__" target="_top" title="of two collections into flat lists for all-vs-all comparison">Flat Cross Product</a>
+<a href="https://usegalaxy.org/root?tool_id=__FLATTEN__" target="_top" title="to a simple list">Flatten collection</a>
+<a href="https://usegalaxy.org/root?tool_id=__HARMONIZELISTS__" target="_top" title="to match identifiers and order">Harmonize two collections</a>
+<a href="https://usegalaxy.org/root?tool_id=__KEEP_SUCCESS_DATASETS__" target="_top" title="datasets in a collection">Keep success</a>
+<a href="https://usegalaxy.org/root?tool_id=__MERGE_COLLECTION__" target="_top" title="into a single collection">Merge collections</a>
+<a href="https://usegalaxy.org/root?tool_id=__NEST__" target="_top" title="by adding a nesting level">Nest collection</a>
+<a href="https://usegalaxy.org/root?tool_id=__CROSS_PRODUCT_NESTED__" target="_top" title="of two collections into nested lists for all-vs-all comparison">Nested Cross Product</a>
+<a href="https://usegalaxy.org/root?tool_id=__RELABEL_FROM_FILE__" target="_top" title="of collection elements from a file">Relabel identifiers</a>
+<a href="https://usegalaxy.org/root?tool_id=__SAMPLE_SHEET_TO_TABULAR__" target="_top" title="to extract sample sheet metadata as a table">Sample sheet to tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=__SORTLIST__" target="_top" title="elements alphabetically, numerically, or by a custom order">Sort collection</a>
+<a href="https://usegalaxy.org/root?tool_id=__SPLIT_PAIRED_AND_UNPAIRED__" target="_top" title="into separate paired and unpaired collections">Split Paired and Unpaired</a>
+<a href="https://usegalaxy.org/root?tool_id=split_file_to_collection" target="_top" title="to dataset collection">Split file</a>
+<a href="https://usegalaxy.org/root?tool_id=__TAG_FROM_FILE__" target="_top" title="from a tabular file of tags">Tag elements</a>
+<a href="https://usegalaxy.org/root?tool_id=__UNZIP_COLLECTION__" target="_top" title="into forward and reverse datasets">Unzip collection</a>
+<a href="https://usegalaxy.org/root?tool_id=__ZIP_COLLECTION__" target="_top" title="into a paired collection">Zip collections</a>
+
+</div>
+
+### Expression Tools
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=calculate_numeric_param" target="_top" title="from parameters">Calculate numeric parameter value</a>
+<a href="https://usegalaxy.org/root?tool_id=compose_text_param" target="_top" title="from parameters">Compose text parameter value</a>
+<a href="https://usegalaxy.org/root?tool_id=map_param_value" target="_top" title="">Map parameter value</a>
+<a href="https://usegalaxy.org/root?tool_id=param_value_from_file" target="_top" title="from dataset">Parse parameter value</a>
+<a href="https://usegalaxy.org/root?tool_id=pick_value" target="_top" title="">Pick parameter value</a>
+
+</div>
+
+---
+
+## General Text Tools
+
+
+### Text Manipulation
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=addValue" target="_top" title="to an existing dataset">Add column</a>
+<a href="https://usegalaxy.org/root?tool_id=addValue" target="_top" title="to an existing dataset">Add column</a>
+<a href="https://usegalaxy.org/root?tool_id=addName" target="_top" title="to an existing tabular file">Add input name as column</a>
+<a href="https://usegalaxy.org/root?tool_id=add_line_to_file" target="_top" title="writes a line of text at the begining or end of a text file.">Add line to file</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_cut_tool" target="_top" title="columns from a table (cut)">Advanced Cut</a>
+<a href="https://usegalaxy.org/root?tool_id=ChangeCase" target="_top" title="of selected columns">Change Case</a>
+<a href="https://usegalaxy.org/root?tool_id=regexColumn1" target="_top" title="">Column Regex Find And Replace</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_column_arrange_by_header" target="_top" title="by header name">Column arrange</a>
+<a href="https://usegalaxy.org/root?tool_id=Add_a_column1" target="_top" title="on rows">Compute</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_cat" target="_top" title="tail-to-head (cat)">Concatenate datasets</a>
+<a href="https://usegalaxy.org/root?tool_id=cat_multiple" target="_top" title="tail-to-head">Concatenate multiple datasets</a>
+<a href="https://usegalaxy.org/root?tool_id=cat_multi_datasets" target="_top" title="tail-to-head while specifying how">Concatenate multiple datasets</a>
+<a href="https://usegalaxy.org/root?tool_id=cat1" target="_top" title="">Concatenate multiple datasets or collections</a>
+<a href="https://usegalaxy.org/root?tool_id=Condense%20characters1" target="_top" title="consecutive characters">Condense</a>
+<a href="https://usegalaxy.org/root?tool_id=Convert%20characters1" target="_top" title="delimiters to TAB">Convert</a>
+<a href="https://usegalaxy.org/root?tool_id=createInterval" target="_top" title="as a new dataset">Create single interval</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_text_file_with_recurring_lines" target="_top" title="with recurring lines">Create text file</a>
+<a href="https://usegalaxy.org/root?tool_id=Cut1" target="_top" title="columns from a table">Cut</a>
+<a href="https://usegalaxy.org/root?tool_id=filter_tabular" target="_top" title="">Filter Tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_easyjoin_tool" target="_top" title="two files">Join</a>
+<a href="https://usegalaxy.org/root?tool_id=wc_gnu" target="_top" title="of a dataset">Line/Word/Character count</a>
+<a href="https://usegalaxy.org/root?tool_id=mergeCols1" target="_top" title="together">Merge Columns</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_multijoin_tool" target="_top" title="(combine multiple files)">Multi-Join</a>
+<a href="https://usegalaxy.org/root?tool_id=nl" target="_top" title="">Number lines</a>
+<a href="https://usegalaxy.org/root?tool_id=Paste1" target="_top" title="two files side by side">Paste</a>
+<a href="https://usegalaxy.org/root?tool_id=query_tabular" target="_top" title="using sqlite sql">Query Tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=gff3.rebase" target="_top" title="against parent features">Rebase GFF3 features</a>
+<a href="https://usegalaxy.org/root?tool_id=regex1" target="_top" title="">Regex Find And Replace</a>
+<a href="https://usegalaxy.org/root?tool_id=Remove%20beginning1" target="_top" title="of a file">Remove beginning</a>
+<a href="https://usegalaxy.org/root?tool_id=column_remove_by_header" target="_top" title="by heading">Remove columns</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_find_and_replace" target="_top" title="parts of text">Replace</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_replace_in_line" target="_top" title="in entire line">Replace Text</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_replace_in_column" target="_top" title="in a specific column">Replace Text</a>
+<a href="https://usegalaxy.org/root?tool_id=replace_column_with_key_value_file" target="_top" title="by values which are defined in a convert file">Replace column</a>
+<a href="https://usegalaxy.org/root?tool_id=sqlite_to_tabular" target="_top" title="for SQL query">SQLite to tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_grep_tool" target="_top" title="(grep)">Search in textfiles</a>
+<a href="https://usegalaxy.org/root?tool_id=secure_hash_message_digest" target="_top" title="on a dataset">Secure Hash / Message Digest</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_head_tool" target="_top" title="lines from a dataset (head)">Select first</a>
+<a href="https://usegalaxy.org/root?tool_id=Show%20beginning1" target="_top" title="lines from a dataset">Select first</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_tail_tool" target="_top" title="lines from a dataset (tail)">Select last</a>
+<a href="https://usegalaxy.org/root?tool_id=Show%20tail1" target="_top" title="lines from a dataset">Select last</a>
+<a href="https://usegalaxy.org/root?tool_id=random_lines1" target="_top" title="from a file">Select random lines</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_sort_header_tool" target="_top" title="data in ascending or descending order">Sort</a>
+<a href="https://usegalaxy.org/root?tool_id=column_order_header_sort" target="_top" title="by heading">Sort Column Order</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_sort_rows" target="_top" title="according to their columns">Sort a row</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_split_on_column" target="_top" title="">Split by group</a>
+<a href="https://usegalaxy.org/root?tool_id=table_compute" target="_top" title="computes operations on table data">Table Compute</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_awk_tool" target="_top" title="with awk">Text reformatting</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_sed_tool" target="_top" title="with sed">Text transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=trimmer" target="_top" title="leading or trailing characters">Trim</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_unfold_column_tool" target="_top" title="columns from a table">Unfold</a>
+<a href="https://usegalaxy.org/root?tool_id=uniprot" target="_top" title="ID mapping and retrieval">UniProt</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_sorted_uniq" target="_top" title="occurrences of each record">Unique</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_uniq" target="_top" title="occurrences of each record">Unique</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_uniq_tool" target="_top" title="assuming sorted input file">Unique lines</a>
+<a href="https://usegalaxy.org/root?tool_id=annotatemyids" target="_top" title="annotate a generic set of identifiers">annotateMyIDs</a>
+<a href="https://usegalaxy.org/root?tool_id=cast" target="_top" title="expand combinations of variables:values to columnar format">cast</a>
+<a href="https://usegalaxy.org/root?tool_id=diff" target="_top" title="analyzes two files and generates an unidiff text file with information about the differences and an optional Html report">diff</a>
+<a href="https://usegalaxy.org/root?tool_id=jq" target="_top" title="query and transform JSON documents">jq</a>
+<a href="https://usegalaxy.org/root?tool_id=melt" target="_top" title="collapse combinations of variables:values to single lines">melt</a>
+<a href="https://usegalaxy.org/root?tool_id=tp_tac" target="_top" title="reverse a file (reverse cat)">tac</a>
+
+</div>
+
+### Filter and Sort
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=bigwig_outlier_bed" target="_top" title="Writes high and low bigwig runs as features in a bed file">Bigwig outliers to bed features</a>
+<a href="https://usegalaxy.org/root?tool_id=Extract_features1" target="_top" title="from GFF data">Extract features</a>
+<a href="https://usegalaxy.org/root?tool_id=Filter1" target="_top" title="data on any column using simple expressions">Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=gff_filter_by_attribute" target="_top" title="using simple expressions">Filter GFF data by attribute</a>
+<a href="https://usegalaxy.org/root?tool_id=gff_filter_by_feature_count" target="_top" title="using simple expressions">Filter GFF data by feature count</a>
+<a href="https://usegalaxy.org/root?tool_id=gtf_filter_by_attribute_values_list" target="_top" title="">Filter GTF data by attribute values_list</a>
+<a href="https://usegalaxy.org/root?tool_id=Grep1" target="_top" title="lines that match an expression">Select</a>
+<a href="https://usegalaxy.org/root?tool_id=sample_seqs" target="_top" title="e.g. to reduce coverage">Sub-sample sequences files</a>
+
+</div>
+
+### Join, Subtract and Group
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=comp1" target="_top" title="to find common or distinct rows">Compare two Datasets</a>
+<a href="https://usegalaxy.org/root?tool_id=Grouping1" target="_top" title="data by a column and perform aggregate operation on other columns.">Group</a>
+<a href="https://usegalaxy.org/root?tool_id=join1" target="_top" title="side by side on a specified field">Join two Datasets</a>
+<a href="https://usegalaxy.org/root?tool_id=subtract_query1" target="_top" title="from another dataset">Subtract Whole Dataset</a>
+
+</div>
+
+### Datamash
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=datamash_ops" target="_top" title="(operations on tabular data)">Datamash</a>
+<a href="https://usegalaxy.org/root?tool_id=datamash_reverse" target="_top" title="columns in a tabular file">Reverse</a>
+<a href="https://usegalaxy.org/root?tool_id=datamash_transpose" target="_top" title="rows/columns in a tabular file">Transpose</a>
+
+</div>
+
+---
+
+## Genomic File Manipulation
+
+
+### FASTA/FASTQ
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_barcode_splitter" target="_top" title="">Barcode Splitter</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_clipper" target="_top" title="adapter sequences">Clip</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_collapser" target="_top" title="sequences">Collapse</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_combiner" target="_top" title="into FASTQ">Combine FASTA and QUAL</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta_compute_length" target="_top" title="">Compute sequence length</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta_concatenate0" target="_top" title="FASTA alignment by species">Concatenate</a>
+<a href="https://usegalaxy.org/root?tool_id=cutadapt" target="_top" title="Remove adapter sequences from FASTQ/FASTA">Cutadapt</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta_merge_files_and_filter_unique_sequences" target="_top" title="Concatenate FASTA database files together">FASTA Merge Files and Filter Unique Sequences</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fasta_formatter" target="_top" title="formatter">FASTA Width</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta2tab" target="_top" title="converter">FASTA-to-Tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_groomer" target="_top" title="convert between various FASTQ quality formats">FASTQ Groomer</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_masker_by_quality" target="_top" title="by quality score">FASTQ Masker</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_quality_trimmer" target="_top" title="by sliding window">FASTQ Quality Trimmer</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_trimmer" target="_top" title="by column">FASTQ Trimmer</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_paired_end_deinterlacer" target="_top" title="on paired end reads">FASTQ de-interlacer</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_paired_end_interlacer" target="_top" title="on paired end reads">FASTQ interlacer</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_paired_end_joiner" target="_top" title="on paired end reads">FASTQ joiner</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_paired_end_splitter" target="_top" title="on joined paired end reads">FASTQ splitter</a>
+<a href="https://usegalaxy.org/root?tool_id=flash" target="_top" title="adjust length of short reads">FLASH</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta-stats" target="_top" title="display summary statistics for a FASTA file">Fasta Statistics</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta_regex_finder" target="_top" title="Search in fasta for regexp match">Fasta regular expression finder</a>
+<a href="https://usegalaxy.org/root?tool_id=filter_by_fasta_ids" target="_top" title="on the headers and/or the sequences">Filter FASTA</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_filter" target="_top" title="reads by quality score and length">Filter FASTQ</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastq_quality_filter" target="_top" title="">Filter by quality</a>
+<a href="https://usegalaxy.org/root?tool_id=seq_filter_by_id" target="_top" title="from a tabular file">Filter sequences by ID</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta_filter_by_length" target="_top" title="">Filter sequences by length</a>
+<a href="https://usegalaxy.org/root?tool_id=length_and_gc_content" target="_top" title="from GTF and FASTA file">Gene length and GC content</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_manipulation" target="_top" title="reads on various attributes">Manipulate FASTQ</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_find_subsequences" target="_top" title="providing regions in BED format">Nucleotide subsequence search</a>
+<a href="https://usegalaxy.org/root?tool_id=iuc_pear" target="_top" title="Paired-End read merger">Pear</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastq_quality_converter" target="_top" title="(ASCII-Numeric)">Quality format converter</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fasta_nucleotides_changer" target="_top" title="converter">RNA/DNA</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_artifacts_filter" target="_top" title="">Remove sequencing artifacts</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_renamer" target="_top" title="">Rename sequences</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_reverse_complement" target="_top" title="">Reverse-Complement</a>
+<a href="https://usegalaxy.org/root?tool_id=trim_reads" target="_top" title="">Select high quality segments</a>
+<a href="https://usegalaxy.org/root?tool_id=seqkit_grep" target="_top" title="grep-like tools for FASTA/Q files">SeqKit grep</a>
+<a href="https://usegalaxy.org/root?tool_id=seqkit_translate" target="_top" title="nucleotid to protein sequence">SeqKit translate</a>
+<a href="https://usegalaxy.org/root?tool_id=seqkit_split2" target="_top" title="Split sequences into files by part size, number of parts, or length">Seqkit Split2</a>
+<a href="https://usegalaxy.org/root?tool_id=sickle" target="_top" title="Windowed adaptive trimming of FASTQ data">Sickle</a>
+<a href="https://usegalaxy.org/root?tool_id=rbc_splitfasta" target="_top" title="files into a collection">Split Fasta</a>
+<a href="https://usegalaxy.org/root?tool_id=tab2fasta" target="_top" title="converts tabular file to FASTA format">Tabular-to-FASTA</a>
+<a href="https://usegalaxy.org/root?tool_id=trim_galore" target="_top" title="Quality and adapter trimmer of reads">Trim Galore!</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_trimmer" target="_top" title="">Trim sequences</a>
+<a href="https://usegalaxy.org/root?tool_id=umi_tools_count" target="_top" title="performs quantification of UMIs from BAM files">UMI-tools count</a>
+<a href="https://usegalaxy.org/root?tool_id=umi_tools_dedup" target="_top" title="Extract UMI from fastq files">UMI-tools deduplicate</a>
+<a href="https://usegalaxy.org/root?tool_id=umi_tools_extract" target="_top" title="Extract UMI from fastq files">UMI-tools extract</a>
+<a href="https://usegalaxy.org/root?tool_id=umi_tools_group" target="_top" title="Extract UMI from fastq files">UMI-tools group</a>
+<a href="https://usegalaxy.org/root?tool_id=umi_tools_whitelist" target="_top" title="Extract cell barcodes from FASTQ files">UMI-tools whitelist</a>
+<a href="https://usegalaxy.org/root?tool_id=fasplit" target="_top" title="Split a FASTA file">faSplit</a>
+<a href="https://usegalaxy.org/root?tool_id=fastp" target="_top" title="fast all-in-one preprocessing for FASTQ files">fastp</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_join" target="_top" title="- Joins two paired-end reads on the overlapping ends">fastq-join</a>
+<a href="https://usegalaxy.org/root?tool_id=filtlong" target="_top" title="Filtering long reads by quality">filtlong</a>
+
+</div>
+
+### FASTQ Quality Control
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_quality_statistics" target="_top" title="">Compute quality statistics</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastx_nucleotides_distribution" target="_top" title="">Draw nucleotides distribution chart</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastq_quality_boxplot" target="_top" title="">Draw quality score boxplot</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_stats" target="_top" title="by column">FASTQ Summary Statistics</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_info" target="_top" title="validates single or paired fastq files">FASTQ info</a>
+<a href="https://usegalaxy.org/root?tool_id=fastqe" target="_top" title="visualize fastq files with emoji&#x27;s 🧬😎">FASTQE</a>
+<a href="https://usegalaxy.org/root?tool_id=falco" target="_top" title="An alternative, more performant implementation of FastQC for high throughput sequence quality control">Falco</a>
+<a href="https://usegalaxy.org/root?tool_id=fastqc" target="_top" title="Read Quality reports">FastQC</a>
+<a href="https://usegalaxy.org/root?tool_id=multiqc" target="_top" title="aggregate results from bioinformatics analyses into a single report">MultiQC</a>
+<a href="https://usegalaxy.org/root?tool_id=prinseq" target="_top" title="to process quality of sequences">PRINSEQ</a>
+<a href="https://usegalaxy.org/root?tool_id=trimmomatic" target="_top" title="flexible read trimming tool for Illumina NGS data">Trimmomatic</a>
+
+</div>
+
+### SAM/BAM
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=bam_to_sam" target="_top" title="convert BAM to SAM">BAM-to-SAM</a>
+<a href="https://usegalaxy.org/root?tool_id=bamutil_clip_overlap" target="_top" title="">BamUtil clipOverlap</a>
+<a href="https://usegalaxy.org/root?tool_id=sam2interval" target="_top" title="to interval">Convert SAM</a>
+<a href="https://usegalaxy.org/root?tool_id=bamFilter" target="_top" title="datasets on a variety of attributes">Filter BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=sam_bw_filter" target="_top" title="on bitwise flag values">Filter SAM</a>
+<a href="https://usegalaxy.org/root?tool_id=samtool_filter2" target="_top" title="files on FLAG MAPQ RG LN or by region">Filter SAM or BAM, output SAM or BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=MDtag_filter" target="_top" title="on MD tag string">Filter mapped reads</a>
+<a href="https://usegalaxy.org/root?tool_id=pileup_parser" target="_top" title="on coverage and SNPs">Filter pileup</a>
+<a href="https://usegalaxy.org/root?tool_id=sam_pileup" target="_top" title="from BAM dataset">Generate pileup</a>
+<a href="https://usegalaxy.org/root?tool_id=bamtools" target="_top" title="datasets in various ways">Operate on and transform BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=pileup_interval" target="_top" title="condenses pileup format into ranges of bases">Pileup-to-Interval</a>
+<a href="https://usegalaxy.org/root?tool_id=qualimap_bamqc" target="_top" title="">QualiMap BamQC</a>
+<a href="https://usegalaxy.org/root?tool_id=qualimap_multi_bamqc" target="_top" title="">QualiMap Multi-Sample BamQC</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_rmdup" target="_top" title="remove PCR duplicates">RmDup</a>
+<a href="https://usegalaxy.org/root?tool_id=sam_to_bam" target="_top" title="convert SAM to BAM">SAM-to-BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=sambamba_flagstat" target="_top" title="Retrieving flag statistics from BAM file">Sambamba flagstat</a>
+<a href="https://usegalaxy.org/root?tool_id=sambamba_markdup" target="_top" title="Finds and marks duplicate reads in BAM files">Sambamba markdup</a>
+<a href="https://usegalaxy.org/root?tool_id=sambamba_merge" target="_top" title="Merge several BAM files into one">Sambamba merge</a>
+<a href="https://usegalaxy.org/root?tool_id=sambamba_sort" target="_top" title="Tool to sort BAM files">Sambamba sort</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_ampliconclip" target="_top" title="clip primer bases from bam files">Samtools ampliconclip</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_bedcov" target="_top" title="calculate read depth for a set of genomic intervals">Samtools bedcov</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_calmd" target="_top" title="recalculate MD/NM tags">Samtools calmd</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_collate" target="_top" title="shuffle and group reads together by their names">Samtools collate</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_coverage" target="_top" title="Produces a histogram or table of coverage per chromosome">Samtools coverage</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_depth" target="_top" title="compute the depth at each position or region">Samtools depth</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_fastx" target="_top" title="extract FASTA or FASTQ from alignment files">Samtools fastx</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_fixmate" target="_top" title="fill mate coordinates, ISIZE and mate related flags">Samtools fixmate</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_flagstat" target="_top" title="tabulate descriptive stats for BAM datset">Samtools flagstat</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_idxstats" target="_top" title="reports stats of the BAM index file">Samtools idxstats</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_markdup" target="_top" title="marks duplicate alignments">Samtools markdup</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_merge" target="_top" title="merge multiple sorted alignment files">Samtools merge</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_mpileup" target="_top" title="multi-way pileup of variants">Samtools mpileup</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_phase" target="_top" title="call and phase heterozygous SNPs">Samtools phase</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_reheader" target="_top" title="copy SAM/BAM header between datasets or edit read groups">Samtools reheader</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_sort" target="_top" title="order of storing aligned sequences">Samtools sort</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_split" target="_top" title="BAM dataset on readgroups">Samtools split</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_stats" target="_top" title="generate statistics for BAM dataset">Samtools stats</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_view" target="_top" title="- reformat, filter, or subsample SAM, BAM or CRAM">Samtools view</a>
+<a href="https://usegalaxy.org/root?tool_id=samtools_slice_bam" target="_top" title="BAM by genomic regions">Slice</a>
+<a href="https://usegalaxy.org/root?tool_id=bamtools_split" target="_top" title="BAM datasets on variety of attributes">Split</a>
+<a href="https://usegalaxy.org/root?tool_id=bamSplit" target="_top" title="BAM datasets on variety of attributes">Split</a>
+<a href="https://usegalaxy.org/root?tool_id=bamtools_split_tag" target="_top" title="into a dataset list collection">Split BAM by read tag value</a>
+<a href="https://usegalaxy.org/root?tool_id=bamtools_split_mapped" target="_top" title="into a mapped and an unmapped dataset">Split BAM by reads mapping status</a>
+<a href="https://usegalaxy.org/root?tool_id=bamtools_split_ref" target="_top" title="into a dataset list collection">Split BAM by reference</a>
+<a href="https://usegalaxy.org/root?tool_id=bamtools_split_paired" target="_top" title="reads datasets">Split BAM into paired- and single-end</a>
+<a href="https://usegalaxy.org/root?tool_id=mosdepth" target="_top" title="- fast and flexible depth coverage calculation">mosdepth</a>
+<a href="https://usegalaxy.org/root?tool_id=revertR2orientationInBam" target="_top" title="Revert the mapped orientation of R2 mates in a bam.">revertR2orientationInBam</a>
+
+</div>
+
+### BED
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=bedops-sort-bed" target="_top" title="">bedops sort-bed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_annotatebed" target="_top" title="annotate coverage of features from multiple files">bedtools AnnotateBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_bamtobed" target="_top" title="converter">bedtools BAM to BED</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_bedtobam" target="_top" title="converter">bedtools BED to BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_bedtoigv" target="_top" title="create batch script for taking IGV screenshots">bedtools BED to IGV</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_bed12tobed6" target="_top" title="converter">bedtools BED12 to BED6</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_bedpetobam" target="_top" title="converter">bedtools BEDPE to BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_closestbed" target="_top" title="find the closest, potentially non-overlapping interval">bedtools ClosestBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_clusterbed" target="_top" title="cluster overlapping/nearby intervals">bedtools ClusterBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_complementbed" target="_top" title="Extract intervals not represented by an interval file">bedtools ComplementBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_coveragebed" target="_top" title="of features in file B on the features in file A (bedtools coverage)">bedtools Compute both the depth and breadth of coverage</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_bamtofastq" target="_top" title="">bedtools Convert from BAM to FastQ</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_expandbed" target="_top" title="replicate lines based on lists of values in columns">bedtools ExpandBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_fisher" target="_top" title="calculate Fisher statistic between two feature files">bedtools FisherBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_flankbed" target="_top" title="create new intervals from the flanks of existing intervals">bedtools FlankBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_genomecoveragebed" target="_top" title="compute the coverage over an entire genome">bedtools Genome Coverage</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_groupbybed" target="_top" title="group by common cols and summarize other cols">bedtools GroupByBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_intersectbed" target="_top" title="find overlapping intervals in various ways">bedtools Intersect intervals</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_jaccard" target="_top" title="calculate the distribution of relative distances between two files">bedtools JaccardBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_links" target="_top" title="create a HTML page of links to UCSC locations">bedtools LinksBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_makewindowsbed" target="_top" title="make interval windows across a genome">bedtools MakeWindowsBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_map" target="_top" title="apply a function to a column for each overlapping interval">bedtools MapBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_maskfastabed" target="_top" title="use intervals to mask sequences from a FASTA file">bedtools MaskFastaBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_unionbedgraph" target="_top" title="combines coverage intervals from multiple BEDGRAPH files">bedtools Merge BedGraph files</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_mergebed" target="_top" title="combine overlapping/nearby intervals into a single interval">bedtools MergeBED</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_multicovtbed" target="_top" title="counts coverage from multiple BAMs at specific intervals">bedtools MultiCovBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_multiintersectbed" target="_top" title="identifies common intervals among multiple interval files">bedtools Multiple Intersect</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_nucbed" target="_top" title="profile the nucleotide content of intervals in a FASTA file">bedtools NucBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_overlapbed" target="_top" title="computes the amount of overlap from two intervals">bedtools OverlapBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_randombed" target="_top" title="generate random intervals in a genome">bedtools RandomBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_reldistbed" target="_top" title="calculate the distribution of relative distances">bedtools ReldistBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_shufflebed" target="_top" title="randomly redistrubute intervals in a genome">bedtools ShuffleBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_slopbed" target="_top" title="adjust the size of intervals">bedtools SlopBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_sortbed" target="_top" title="order the intervals">bedtools SortBED</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_spacingbed" target="_top" title="reports the distances between features">bedtools SpacingBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_subtractbed" target="_top" title="remove intervals based on overlaps">bedtools SubtractBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_tagbed" target="_top" title="tag BAM alignments based on overlaps with interval files">bedtools TagBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_windowbed" target="_top" title="find overlapping intervals within a window around an interval">bedtools WindowBed</a>
+<a href="https://usegalaxy.org/root?tool_id=bedtools_getfastabed" target="_top" title="use intervals to extract sequences from a FASTA file">bedtools getfasta</a>
+
+</div>
+
+### VCF/BCF
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=vcftools_annotate" target="_top" title="a VCF dataset with custom filters">Annotate</a>
+<a href="https://usegalaxy.org/root?tool_id=vcftools_slice" target="_top" title="to get data from selected regions">Slice VCF</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfbedintersect" target="_top" title="Intersect VCF and BED datasets">VCF-BEDintersect:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfvcfintersect" target="_top" title="Intersect two VCF datasets">VCF-VCFintersect:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfaddinfo" target="_top" title="Adds info fields from the second dataset which are not present in the first dataset">VCFaddinfo:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfannotate" target="_top" title="Intersect VCF records with BED annotations">VCFannotate:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfannotategenotypes" target="_top" title="Annotate genotypes in a VCF dataset using genotypes from another VCF dataset">VCFannotateGenotypes:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfbreakcreatemulti" target="_top" title="Break multiple alleles into multiple records, or combine overallpoing alleles into a single record">VCFbreakCreateMulti:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfcheck" target="_top" title="Verify that the reference allele matches the reference genome">VCFcheck:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfcombine" target="_top" title="Combine multiple VCF datasets">VCFcombine:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfcommonsamples" target="_top" title="Output records belonging to samples common between two datasets">VCFcommonSamples:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfdistance" target="_top" title="Calculate distance to the nearest variant">VCFdistance:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfdistance" target="_top" title="Calculate distance to the nearest variant">VCFdistance:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcffilter2" target="_top" title="filter VCF data in a variety of attributes">VCFfilter:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcffixup" target="_top" title="Count the allele frequencies across alleles present in each record in the VCF file">VCFfixup:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfflatten2" target="_top" title="Removes multi-allelic sites by picking the most common alternate">VCFflatten:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfgeno2haplo" target="_top" title="Convert genotype-based phased alleles into haplotype alleles">VCFgenotype-to-haplotype:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfgenotypes" target="_top" title="Convert numerical representation of genotypes to allelic">VCFgenotypes:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfhethom" target="_top" title="Count the number of heterozygotes and alleles, compute het/hom ratio">VCFhetHomAlleles:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfleftalign" target="_top" title="Left-align indels and complex variants in VCF dataset">VCFleftAlign:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfprimers" target="_top" title="Extract flanking sequences for each VCF record">VCFprimers:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfrandomsample" target="_top" title="Randomly sample sites from VCF dataset">VCFrandomSample:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfselectsamples" target="_top" title="Select samples from a VCF dataset">VCFselectsamples:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfsort" target="_top" title="Sort VCF dataset by coordinate">VCFsort:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcf2tsv" target="_top" title="Convert VCF data into TAB-delimited format">VCFtoTab-delimited:</a>
+<a href="https://usegalaxy.org/root?tool_id=vcfallelicprimitives" target="_top" title="Split alleleic primitives (gaps or mismatches) into multiple VCF lines">VcfAllelicPrimitives:</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_query_list_samples" target="_top" title="in VCF/BCF file">bcftools List Samples</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_annotate" target="_top" title="Annotate and edit VCF/BCF files">bcftools annotate</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_call" target="_top" title="SNP/indel variant calling from VCF/BCF">bcftools call</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_cnv" target="_top" title="Call copy number variation from VCF B-allele frequency (BAF) and Log R Ratio intensity (LRR) values">bcftools cnv</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_concat" target="_top" title="Concatenate or combine VCF/BCF files">bcftools concat</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_consensus" target="_top" title="Create consensus sequence by applying VCF variants to a reference fasta file">bcftools consensus</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_convert_from_vcf" target="_top" title="Converts VCF/BCF to IMPUTE2/SHAPEIT formats">bcftools convert from vcf</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_convert_to_vcf" target="_top" title="Converts other formats to VCF/BCFk">bcftools convert to vcf</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_counts" target="_top" title="plugin  counts number of samples, SNPs, INDELs, MNPs and total sites">bcftools counts</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_csq" target="_top" title="Haplotype aware consequence predictor">bcftools csq</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_dosage" target="_top" title="plugin genotype dosage">bcftools dosage</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_fill_an_ac" target="_top" title="plugin Fill INFO fields AN and AC">bcftools fill-AN-AC</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_fill_tags" target="_top" title="plugin Set INFO tags AF, AN, AC, AC_Hom, AC_Het, AC_Hemi">bcftools fill-tags</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_filter" target="_top" title="Apply fixed-threshold filters">bcftools filter</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_fixploidy" target="_top" title="plugin  Fix ploidy">bcftools fixploidy</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_gtcheck" target="_top" title="Check sample identity">bcftools gtcheck</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_impute_info" target="_top" title="plugin Add imputation information metrics to the INFO field">bcftools impute-info</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_isec" target="_top" title="Create intersections, unions and complements of VCF files">bcftools isec</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_mendelian" target="_top" title="plugin Count Mendelian consistent / inconsistent genotypes">bcftools mendelian2</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_merge" target="_top" title="Merge multiple VCF/BCF files from non-overlapping sample sets to create one multi-sample file">bcftools merge</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_missing2ref" target="_top" title="plugin Set missing genotypes">bcftools missing2ref</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_mpileup" target="_top" title="Generate VCF or BCF containing genotype likelihoods for one or multiple alignment (BAM or CRAM) files">bcftools mpileup</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_norm" target="_top" title="Left-align and normalize indels; check if REF alleles match the reference; split multiallelic sites into multiple rows; recover multiallelics from multiple rows">bcftools norm</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_query" target="_top" title="Extracts fields from VCF/BCF file and prints them in user-defined format">bcftools query</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_reheader" target="_top" title="Modify header of VCF/BCF files, change sample names">bcftools reheader</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_roh" target="_top" title="HMM model for detecting runs of homo/autozygosity">bcftools roh</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_setgt" target="_top" title="plugin Sets genotypes">bcftools setGT</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_stats" target="_top" title="Parses VCF or BCF and produces stats which can be plotted using plot-vcfstats">bcftools stats</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_tag2tag" target="_top" title="plugin Convert between similar tags, such as GL and GP">bcftools tag2tag</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_view" target="_top" title="VCF/BCF conversion, view, subset and filter VCF/BCF files">bcftools view</a>
+
+</div>
+
+### Nanopore
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=clair3" target="_top" title="germline small variant caller for long-reads">Clair3</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_yield_plot" target="_top" title="of sequencing yield over time">Collector’s curve</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_tabular" target="_top" title="in tabular format from a set of FAST5 files">Extract FASTQ</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_events" target="_top" title="from a set of sequencing reads">Extract nanopore events</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_extract" target="_top" title="in FASTA or FASTQ format from nanopore files">Extract reads</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_times" target="_top" title="and channel information from a set of FAST5 files">Extract time</a>
+<a href="https://usegalaxy.org/root?tool_id=flye" target="_top" title="de novo assembler for single molecule sequencing reads">Flye</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_qualpos" target="_top" title="plot of quality score distribution over positions in nanopore reads">Generate box-whisker</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_hist" target="_top" title="of nanopore read lengths">Generate histogram</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_winner" target="_top" title="from a set of FAST5 files.">Get longest read</a>
+<a href="https://usegalaxy.org/root?tool_id=nanoplot" target="_top" title="Plotting suite for Oxford Nanopore sequencing data and alignments">NanoPlot</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_occupancy" target="_top" title="per cell in nanopore reads">Plot performance</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_squiggle" target="_top" title="for nanopore reads">Plot signals</a>
+<a href="https://usegalaxy.org/root?tool_id=porechop" target="_top" title="adapter trimmer for Oxford Nanopore reads">Porechop</a>
+<a href="https://usegalaxy.org/root?tool_id=pycoqc" target="_top" title="quality control for Nanopore sequencing data">Pycoqc</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_stats" target="_top" title="from a set of FAST5 files">Read length statistics</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_nucdist" target="_top" title="distribution in nanopore sequencing reads">Show nucleotide</a>
+<a href="https://usegalaxy.org/root?tool_id=poretools_qualdist" target="_top" title="score distribution in nanopore sequencing reads">Show quality</a>
+<a href="https://usegalaxy.org/root?tool_id=medaka_consensus_pipeline" target="_top" title="Assembly polishing via neural networks">medaka consensus pipeline</a>
+<a href="https://usegalaxy.org/root?tool_id=medaka_consensus" target="_top" title="inference from a trained model and alignments.">medaka inference tool</a>
+<a href="https://usegalaxy.org/root?tool_id=medaka_variant_pipeline" target="_top" title="via neural networks">medaka variant pipeline</a>
+<a href="https://usegalaxy.org/root?tool_id=medaka_variant" target="_top" title="decodes variant calls from medaka consensus output">medaka vcf tool</a>
+
+</div>
+
+### Convert Formats
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=bbgtobigwig" target="_top" title="">BAM BED GFF coverage bigWigs</a>
+<a href="https://usegalaxy.org/root?tool_id=bed2gff1" target="_top" title="converter">BED-to-GFF</a>
+<a href="https://usegalaxy.org/root?tool_id=bed_to_bigBed" target="_top" title="converter">BED-to-bigBed</a>
+<a href="https://usegalaxy.org/root?tool_id=compress_file" target="_top" title="">Compress file(s)</a>
+<a href="https://usegalaxy.org/root?tool_id=bioext_bam2msa" target="_top" title="to FASTA multiple sequence alignment">Convert BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=bam_to_scidx" target="_top" title="">Convert BAM to ScIdx</a>
+<a href="https://usegalaxy.org/root?tool_id=gtftobed12" target="_top" title="">Convert GTF to BED12</a>
+<a href="https://usegalaxy.org/root?tool_id=gffcompare_to_bed" target="_top" title="for StringTie results">Convert gffCompare annotated GTF to BED</a>
+<a href="https://usegalaxy.org/root?tool_id=galaxy_intermine_exchange" target="_top" title="Dataset">Create InterMine Interchange</a>
+<a href="https://usegalaxy.org/root?tool_id=crossmap_bam" target="_top" title="Convert genome coordinates or annotation files between genome assemblies">CrossMap BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=crossmap_bed" target="_top" title="Convert genome coordinates or annotation files between genome assemblies">CrossMap BED</a>
+<a href="https://usegalaxy.org/root?tool_id=crossmap_gff" target="_top" title="Convert genome coordinates or annotation files between genome assemblies">CrossMap GFF</a>
+<a href="https://usegalaxy.org/root?tool_id=crossmap_vcf" target="_top" title="Convert genome coordinates or annotation files between genome assemblies">CrossMap VCF</a>
+<a href="https://usegalaxy.org/root?tool_id=crossmap_wig" target="_top" title="Convert genome coordinates or annotation files between genome assemblies">CrossMap Wig</a>
+<a href="https://usegalaxy.org/root?tool_id=xlsx2tsv" target="_top" title="with pandas">Excel to Tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta2tab" target="_top" title="converter">FASTA-to-Tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=cshl_fastq_to_fasta" target="_top" title="converter from FASTX-toolkit">FASTQ to FASTA</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_to_fasta_python" target="_top" title="converter">FASTQ to FASTA</a>
+<a href="https://usegalaxy.org/root?tool_id=fastq_to_tabular" target="_top" title="converter">FASTQ to Tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=gfa_to_fa" target="_top" title="Convert Graphical Fragment Assembly files to FASTA format">GFA to FASTA</a>
+<a href="https://usegalaxy.org/root?tool_id=gff2bed1" target="_top" title="converter">GFF-to-BED</a>
+<a href="https://usegalaxy.org/root?tool_id=graphicsmagick_image_montage" target="_top" title="">Image Montage</a>
+<a href="https://usegalaxy.org/root?tool_id=MAF_To_BED1" target="_top" title="Converts a MAF formatted file to the BED format">MAF to BED</a>
+<a href="https://usegalaxy.org/root?tool_id=MAF_To_Fasta1" target="_top" title="Converts a MAF formatted file to FASTA format">MAF to FASTA</a>
+<a href="https://usegalaxy.org/root?tool_id=MAF_To_Interval1" target="_top" title="Converts a MAF formatted file to the Interval format">MAF to Interval</a>
+<a href="https://usegalaxy.org/root?tool_id=bam2fastx" target="_top" title="PacBio BAM to Fastx">PacBio bam2fastx</a>
+<a href="https://usegalaxy.org/root?tool_id=rds_to_tabular" target="_top" title="convert R serialized rectangular objects into tabular data">RDS to tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=Sff_extractor" target="_top" title="">SFF converter</a>
+<a href="https://usegalaxy.org/root?tool_id=tabular_to_fastq" target="_top" title="converter">Tabular to FASTQ</a>
+<a href="https://usegalaxy.org/root?tool_id=tab2fasta" target="_top" title="converts tabular file to FASTA format">Tabular-to-FASTA</a>
+<a href="https://usegalaxy.org/root?tool_id=tooldistillator" target="_top" title="Extract information from output files of specific tools and expose it as JSON files">ToolDistillator</a>
+<a href="https://usegalaxy.org/root?tool_id=tooldistillator_summarize" target="_top" title="Aggregate several JSON reports from ToolDistillator">ToolDistillator Summarize</a>
+<a href="https://usegalaxy.org/root?tool_id=unzip" target="_top" title="Unzip a file">Unzip</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_axtomaf" target="_top" title="Convert dataset from axt to MAF format">axtToMaf</a>
+<a href="https://usegalaxy.org/root?tool_id=bax2bam" target="_top" title="converts PacBio basecall format (bax.h5) into BAM">bax2bam</a>
+<a href="https://usegalaxy.org/root?tool_id=bed_to_protein_map" target="_top" title="genomic location of proteins for MVP">bed to protein map</a>
+<a href="https://usegalaxy.org/root?tool_id=fatovcf" target="_top" title="Convert a FASTA alignment file to Variant Call Format (VCF) single-nucleotide diffs">faToVcf</a>
+<a href="https://usegalaxy.org/root?tool_id=gffread" target="_top" title="Filters and/or converts GFF3/GTF2 records">gffread</a>
+<a href="https://usegalaxy.org/root?tool_id=maftoaxt" target="_top" title="Convert file from MAF to axt format">mafToAxt</a>
+<a href="https://usegalaxy.org/root?tool_id=msconvert" target="_top" title="Convert and/or filter mass spectrometry files">msconvert</a>
+<a href="https://usegalaxy.org/root?tool_id=mz_to_sqlite" target="_top" title="Extract mzIdentML and associated proteomics datasets into a SQLite DB">mz to sqlite</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_nettoaxt" target="_top" title="Convert net (and chain) to axt format">netToAxt</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc-twobittofa" target="_top" title="Convert all or part of .2bit file to FASTA">twoBitToFa</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_wigtobigwig" target="_top" title="bedGraph or Wig to bigWig converter">wigtobigwig</a>
+
+</div>
+
+### Lift-Over
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=liftOver1" target="_top" title="between assemblies and genomes">Convert genome coordinates</a>
+
+</div>
+
+---
+
+## Common Genomics Tools
+
+
+### Operate on Genomic Intervals
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=aggregate_scores_in_intervals2" target="_top" title="Appends the average, min, max of datapoints per interval">Aggregate datapoints</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_basecoverage_1" target="_top" title="of all intervals">Base Coverage</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_cluster_1" target="_top" title="the intervals of a dataset">Cluster</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_complement_1" target="_top" title="intervals of a dataset">Complement</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_concat_1" target="_top" title="two BED files">Concatenate</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_coverage_1" target="_top" title="of a set of intervals on second set of intervals">Coverage</a>
+<a href="https://usegalaxy.org/root?tool_id=flanking_features_1" target="_top" title="for every interval">Fetch closest non-overlapping feature</a>
+<a href="https://usegalaxy.org/root?tool_id=gene2exon1" target="_top" title="expander">Gene BED To Exon/Intron/Codon BED</a>
+<a href="https://usegalaxy.org/root?tool_id=get_flanks1" target="_top" title="returns flanking region/s for every gene">Get flanks</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_intersect_1" target="_top" title="the intervals of two datasets">Intersect</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_join_1" target="_top" title="the intervals of two datasets side-by-side">Join</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_merge_1" target="_top" title="the overlapping intervals of a dataset">Merge</a>
+<a href="https://usegalaxy.org/root?tool_id=gops_subtract_1" target="_top" title="the intervals of two datasets">Subtract</a>
+<a href="https://usegalaxy.org/root?tool_id=translate_bed" target="_top" title="cDNA in 3frames or CDS">Translate BED transcripts</a>
+<a href="https://usegalaxy.org/root?tool_id=wiggle2simple1" target="_top" title="converter">Wiggle-to-Interval</a>
+
+</div>
+
+### Fetch Sequences/Alignments
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=Extract%20genomic%20DNA%201" target="_top" title="using coordinates from assembled/unassembled genomes">Extract Genomic DNA</a>
+<a href="https://usegalaxy.org/root?tool_id=maf_by_block_number1" target="_top" title="given a set of block numbers and a MAF file">Extract MAF by block number</a>
+<a href="https://usegalaxy.org/root?tool_id=Interval2Maf_pairwise1" target="_top" title="given a set of genomic intervals">Extract Pairwise MAF blocks</a>
+<a href="https://usegalaxy.org/root?tool_id=MAF_filter" target="_top" title="by specified attributes">Filter MAF</a>
+<a href="https://usegalaxy.org/root?tool_id=MAF_Limit_To_Species1" target="_top" title="by Species">Filter MAF blocks</a>
+<a href="https://usegalaxy.org/root?tool_id=maf_limit_size1" target="_top" title="by Size">Filter MAF blocks</a>
+<a href="https://usegalaxy.org/root?tool_id=MAF_Thread_For_Species1" target="_top" title="by Species">Join MAF blocks</a>
+<a href="https://usegalaxy.org/root?tool_id=maf_stats1" target="_top" title="Alignment coverage information">MAF Coverage Stats</a>
+<a href="https://usegalaxy.org/root?tool_id=MAF_Reverse_Complement_1" target="_top" title="a MAF file">Reverse Complement</a>
+<a href="https://usegalaxy.org/root?tool_id=GeneBed_Maf_Fasta2" target="_top" title="given a set of coding exon intervals">Stitch Gene blocks</a>
+<a href="https://usegalaxy.org/root?tool_id=Interval_Maf_Merged_Fasta2" target="_top" title="given a set of genomic intervals">Stitch MAF blocks</a>
+
+</div>
+
+---
+
+## Genomics Analysis
+
+
+### Assembly
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=aegean_parseval" target="_top" title="compare two sets of gene annotations for the same sequence.">AEGeAn ParsEval</a>
+<a href="https://usegalaxy.org/root?tool_id=alnchain" target="_top" title="filter .1aln alignments into one-to-one global alignment">ALNchain</a>
+<a href="https://usegalaxy.org/root?tool_id=bandage_image" target="_top" title="visualize de novo assembly graphs">Bandage Image</a>
+<a href="https://usegalaxy.org/root?tool_id=bandage_info" target="_top" title="determine statistics of de novo assembly graphs">Bandage Info</a>
+<a href="https://usegalaxy.org/root?tool_id=bionano_scaffold" target="_top" title="automates the scaffolding process">Bionano Hybrid Scaffold</a>
+<a href="https://usegalaxy.org/root?tool_id=blobtoolkit" target="_top" title="Genome Assembly QC">BlobToolKit</a>
+<a href="https://usegalaxy.org/root?tool_id=unicycler" target="_top" title="pipeline for bacterial genomes">Create assemblies with Unicycler</a>
+<a href="https://usegalaxy.org/root?tool_id=disco" target="_top" title="to assemble metagenomics data using an overlap-layout-consensus (OLC) approach">DISCO</a>
+<a href="https://usegalaxy.org/root?tool_id=fastga" target="_top" title="align whole genomes">FastGA</a>
+<a href="https://usegalaxy.org/root?tool_id=fastk_fastk" target="_top" title="A k-mer counter for high-quality assembly datasets">FastK</a>
+<a href="https://usegalaxy.org/root?tool_id=fastk_histex" target="_top" title="Reads and displays a kmer histogram produced by FastK">FastK Histex</a>
+<a href="https://usegalaxy.org/root?tool_id=fastk_logex" target="_top" title="Performs binary operations on the generated Ktab files from FASTK suite">FastK Logex</a>
+<a href="https://usegalaxy.org/root?tool_id=bellerophon" target="_top" title="chimeric reads from Arima Genomics">Filter and merge</a>
+<a href="https://usegalaxy.org/root?tool_id=genomescope" target="_top" title="reference-free genome profiling">GenomeScope</a>
+<a href="https://usegalaxy.org/root?tool_id=halfdeep" target="_top" title="identifies genomic regions with half-depth coverage based on sequencing read mappings.">HalfDeep</a>
+<a href="https://usegalaxy.org/root?tool_id=hifiasm" target="_top" title="haplotype-resolved de novo assembler for PacBio Hifi reads">Hifiasm</a>
+<a href="https://usegalaxy.org/root?tool_id=idba_hybrid" target="_top" title="Iterative de Bruijn Graph Assembler for hybrid sequencing data">IDBA-HYBRID</a>
+<a href="https://usegalaxy.org/root?tool_id=idba_tran" target="_top" title="Iterative de Bruijn Graph Assembler for transcriptome data">IDBA-TRAN</a>
+<a href="https://usegalaxy.org/root?tool_id=idba_ud" target="_top" title="Iterative de Bruijn Graph Assembler for data with highly uneven depth">IDBA-UD</a>
+<a href="https://usegalaxy.org/root?tool_id=lexicmap_index" target="_top" title="Builds LexicMap index">LexicMap Index</a>
+<a href="https://usegalaxy.org/root?tool_id=lexicmap_search" target="_top" title="nucleotide sequence tool for querying genomes">LexicMap Search</a>
+<a href="https://usegalaxy.org/root?tool_id=megahit" target="_top" title="for metagenomics assembly">MEGAHIT</a>
+<a href="https://usegalaxy.org/root?tool_id=merqury" target="_top" title="evaluate the assembly quality">Merqury</a>
+<a href="https://usegalaxy.org/root?tool_id=merquryplot" target="_top" title="evaluate the assembly quality">Merqury histogram plot</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl" target="_top" title="a genomic k-mer counter and sequence utility">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl_arithmetic_kmers" target="_top" title="apply arithmetic operations to k-mer counts">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl_count_kmers" target="_top" title="count k-mers">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl_filter_kmers" target="_top" title="filter k-mers">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl_groups_kmers" target="_top" title="apply operations on k-mer databases">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl_histogram_kmers" target="_top" title="get k-mer frequency histogram">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl_print" target="_top" title="get k-mer counts">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=meryl_trio_mode" target="_top" title="build hap-mers databases for trios">Meryl</a>
+<a href="https://usegalaxy.org/root?tool_id=mitohifi" target="_top" title="Assemble mitogenomes from Pacbio HiFi reads">MitoHiFi</a>
+<a href="https://usegalaxy.org/root?tool_id=nextdenovo" target="_top" title="string graph-based de novo assembler for long reads">NextDenovo</a>
+<a href="https://usegalaxy.org/root?tool_id=pairtools_stats" target="_top" title="Calculates pairs statistics for input pairs and pairsam files.">Pairtools Stats</a>
+<a href="https://usegalaxy.org/root?tool_id=pairtools_dedup" target="_top" title="Find and remove PCR/optical duplicates">Pairtools dedup</a>
+<a href="https://usegalaxy.org/root?tool_id=pairtools_parse" target="_top" title="Find ligation pairs in alignments and create pairs.">Pairtools parse</a>
+<a href="https://usegalaxy.org/root?tool_id=pairtools_sort" target="_top" title="Sort a 4dn pairs/pairsam file">Pairtools sort</a>
+<a href="https://usegalaxy.org/root?tool_id=pairtools_split" target="_top" title="Split a pairsam file into pairs and SAM/BAM">Pairtools split</a>
+<a href="https://usegalaxy.org/root?tool_id=pretext_snapshot" target="_top" title="image generator for Pretext contact maps">Pretext Snapshot</a>
+<a href="https://usegalaxy.org/root?tool_id=pretext_map" target="_top" title="converts SAM or BAM files into genome contact maps">PretextMap</a>
+<a href="https://usegalaxy.org/root?tool_id=pretext_graph" target="_top" title="Embed bedgraph formatted data inside a Pretext contact map.">Pretextgraph</a>
+<a href="https://usegalaxy.org/root?tool_id=purge_dups" target="_top" title="and haplotigs in an assembly based on read depth (purge_dups)">Purge overlaps</a>
+<a href="https://usegalaxy.org/root?tool_id=quast" target="_top" title="Genome assembly Quality">Quast</a>
+<a href="https://usegalaxy.org/root?tool_id=racon" target="_top" title="Consensus module for raw de novo DNA assembly of long uncorrected reads">Racon</a>
+<a href="https://usegalaxy.org/root?tool_id=ragtag" target="_top" title="reference-guided scaffolding of draft genomes">RagTag</a>
+<a href="https://usegalaxy.org/root?tool_id=refseq_masher_contains" target="_top" title="Find NCBI RefSeq Genomes contained in your sequences">RefSeq Masher Contains</a>
+<a href="https://usegalaxy.org/root?tool_id=refseq_masher_matches" target="_top" title="Find closest matching NCBI RefSeq Genomes to your sequences">RefSeq Masher Matches</a>
+<a href="https://usegalaxy.org/root?tool_id=salsa" target="_top" title="scaffold long read assemblies with Hi-C">SALSA</a>
+<a href="https://usegalaxy.org/root?tool_id=spades" target="_top" title="genome assembler for genomes of regular and single-cell projects">SPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=shovill" target="_top" title="Faster SPAdes assembly of Illumina reads">Shovill</a>
+<a href="https://usegalaxy.org/root?tool_id=smudgeplot" target="_top" title="inference of ploidy and heterozygosity structure using whole genome sequencing">Smudgeplot</a>
+<a href="https://usegalaxy.org/root?tool_id=teloscope" target="_top" title="Assembly telomere annotation">Teloscope</a>
+<a href="https://usegalaxy.org/root?tool_id=vgp_chromosome_assignment" target="_top" title="Assign chromosome names to scaffolds">VGP Chromosome Assignment</a>
+<a href="https://usegalaxy.org/root?tool_id=vgp_sak_generation" target="_top" title="Generate gfastats SAK instructions for sequence reversal and renaming">VGP SAK Generation</a>
+<a href="https://usegalaxy.org/root?tool_id=vgp_split_agp" target="_top" title="Correct AGP files and split haplotypes">VGP Split AGP</a>
+<a href="https://usegalaxy.org/root?tool_id=velvetoptimiser" target="_top" title="Automatically optimize Velvet assemblies">VelvetOptimiser</a>
+<a href="https://usegalaxy.org/root?tool_id=yahs" target="_top" title="yet another HI-C scaffolding tool">YAHS</a>
+<a href="https://usegalaxy.org/root?tool_id=spades_biosyntheticspades" target="_top" title="biosynthetic gene cluster assembly">biosyntheticSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=spades_coronaspades" target="_top" title="SARS-CoV-2 de novo genome assembler">coronaSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=gfastats" target="_top" title="The swiss army knife for Genome Assembly">gfastats</a>
+<a href="https://usegalaxy.org/root?tool_id=kmindex_build" target="_top" title="build k-mer index from sequencing samples">kmindex build</a>
+<a href="https://usegalaxy.org/root?tool_id=kmindex_query" target="_top" title="query k-mer index with sequencing data">kmindex query</a>
+<a href="https://usegalaxy.org/root?tool_id=metaspades" target="_top" title="metagenome assembler">metaSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=spades_metaplasmidspades" target="_top" title="extract and assembly plasmids from metagenomic data">metaplasmidSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=spades_metaviralspades" target="_top" title="extract and assembly viral genomes from metagenomic data">metaviralSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=miniasm" target="_top" title="Ultrafast de novo assembly for long noisy reads">miniasm</a>
+<a href="https://usegalaxy.org/root?tool_id=pilon" target="_top" title="An automated genome assembly improvement and variant detection tool">pilon</a>
+<a href="https://usegalaxy.org/root?tool_id=spades_plasmidspades" target="_top" title="extract and assembly plasmids from WGS data">plasmidSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=rna_quast" target="_top" title="A quality assessment tool for De Novo transcriptome assemblies">rnaQUAST</a>
+<a href="https://usegalaxy.org/root?tool_id=rnaspades" target="_top" title="de novo transcriptome assembler">rnaSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=spades_rnaviralspades" target="_top" title="de novo assembler for transcriptomes, metatranscriptomes and metaviromes">rnaviralSPAdes</a>
+<a href="https://usegalaxy.org/root?tool_id=velvetg" target="_top" title="Velvet sequence assembler for very short reads">velvetg</a>
+<a href="https://usegalaxy.org/root?tool_id=velveth" target="_top" title="Prepare a dataset for the Velvet velvetg Assembler">velveth</a>
+
+</div>
+
+### Annotation
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=abricate" target="_top" title="Mass screening of contigs for antimicrobial and virulence genes">ABRicate</a>
+<a href="https://usegalaxy.org/root?tool_id=abricate_list" target="_top" title="List all of abricate&#x27;s available databases.">ABRicate List</a>
+<a href="https://usegalaxy.org/root?tool_id=abricate_summary" target="_top" title="Combine ABRicate results into a simple matrix of gene presence/absence">ABRicate Summary</a>
+<a href="https://usegalaxy.org/root?tool_id=agat" target="_top" title="GTF/GFF analysis toolkit">AGAT</a>
+<a href="https://usegalaxy.org/root?tool_id=amrfinderplus" target="_top" title="NCBI Antimicrobial Resistance Gene Finder">AMRFinderPlus</a>
+<a href="https://usegalaxy.org/root?tool_id=antismash" target="_top" title="allows the genome-wide identification, annotation and analysis of secondary metabolite biosynthesis gene clusters">Antismash</a>
+<a href="https://usegalaxy.org/root?tool_id=augustus" target="_top" title="gene prediction for prokaryotic and eukaryotic genomes">Augustus</a>
+<a href="https://usegalaxy.org/root?tool_id=braker3" target="_top" title="genome annotation">BRAKER3</a>
+<a href="https://usegalaxy.org/root?tool_id=bakta" target="_top" title="Rapid and standardized annotation of bacterial genomes, MAGs and plasmids">Bakta</a>
+<a href="https://usegalaxy.org/root?tool_id=blastxml_to_gapped_gff3" target="_top" title="">BlastXML to gapped GFF3</a>
+<a href="https://usegalaxy.org/root?tool_id=busco" target="_top" title="Assess genome assembly and annotation completeness">Busco</a>
+<a href="https://usegalaxy.org/root?tool_id=cpat" target="_top" title="coding potential assessment">CPAT</a>
+<a href="https://usegalaxy.org/root?tool_id=cooc_mutbamscan" target="_top" title="scans an alignment file for mutation co-occurrences">Cojac: mutbamscan</a>
+<a href="https://usegalaxy.org/root?tool_id=cooc_tabmut" target="_top" title="exports co-occurrence results from mutbamscan as a table">Cojac: tabmut</a>
+<a href="https://usegalaxy.org/root?tool_id=xmfa2gff3" target="_top" title="">Convert XMFA to gapped GFF3</a>
+<a href="https://usegalaxy.org/root?tool_id=coreprofiler_allele_calling" target="_top" title="Calls cgMLST alleles from a bacterial genome using a reference scheme">CoreProfiler allele_calling</a>
+<a href="https://usegalaxy.org/root?tool_id=deeparg_short_reads" target="_top" title="pipeline to detect Antibiotic Resistance Genes (ARGs) from raw reads">DeepARG short reads</a>
+<a href="https://usegalaxy.org/root?tool_id=exonerate" target="_top" title="pairwise sequence comparison">Exonerate</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_sortmerna" target="_top" title="of ribosomal RNAs in metatranscriptomic data">Filter with SortMeRNA</a>
+<a href="https://usegalaxy.org/root?tool_id=find_nested_alt_orfs" target="_top" title="from BED and 2bit/FASTA">Find Nested Alternate ORFs (nAlt-ORFs)</a>
+<a href="https://usegalaxy.org/root?tool_id=freyja_aggregate_plot" target="_top" title="demixed results">Freyja: Aggregate and visualize</a>
+<a href="https://usegalaxy.org/root?tool_id=freyja_demix" target="_top" title="lineage abundances">Freyja: Demix</a>
+<a href="https://usegalaxy.org/root?tool_id=funannotate_compare" target="_top" title="annotations">Funannotate compare</a>
+<a href="https://usegalaxy.org/root?tool_id=funannotate_annotate" target="_top" title="annotation">Funannotate functional</a>
+<a href="https://usegalaxy.org/root?tool_id=funannotate_predict" target="_top" title="">Funannotate predict annotation</a>
+<a href="https://usegalaxy.org/root?tool_id=goenrichment" target="_top" title="performs GO enrichment analysis of a set of gene products">GOEnrichment</a>
+<a href="https://usegalaxy.org/root?tool_id=goslimmer" target="_top" title="converts a set of annotation from GO to a given GOSlim version">GOSlimmer</a>
+<a href="https://usegalaxy.org/root?tool_id=gseapy_enrichr" target="_top" title="run Enrichr-style over-representation analysis">GSEApy Enrichr</a>
+<a href="https://usegalaxy.org/root?tool_id=bp_genbank2gff3" target="_top" title="converter">Genbank to GFF3</a>
+<a href="https://usegalaxy.org/root?tool_id=jcvi_gff_stats" target="_top" title="">Genome annotation statistics</a>
+<a href="https://usegalaxy.org/root?tool_id=bicodon_counts_from_fasta" target="_top" title="from FASTA files">Get Codon and Bicodon frequency</a>
+<a href="https://usegalaxy.org/root?tool_id=codon_freq_from_bicodons" target="_top" title="from bicodons">Get Codon frequency</a>
+<a href="https://usegalaxy.org/root?tool_id=groot" target="_top" title="align reads to references and weight variation graphs and generate report">Groot</a>
+<a href="https://usegalaxy.org/root?tool_id=gubbins" target="_top" title="Recombination detection in Bacteria">Gubbins</a>
+<a href="https://usegalaxy.org/root?tool_id=helixer" target="_top" title="gene calling">Helixer</a>
+<a href="https://usegalaxy.org/root?tool_id=icescreen" target="_top" title="annotates ICEs and IMEs in Bacillota genomes">ICEscreen</a>
+<a href="https://usegalaxy.org/root?tool_id=isescan" target="_top" title="Insertion Sequence Elements detection in prokaryotic genomes">ISEScan</a>
+<a href="https://usegalaxy.org/root?tool_id=integron_finder" target="_top" title="is a program that detects integrons in DNA sequences">Integron Finder</a>
+<a href="https://usegalaxy.org/root?tool_id=interproscan" target="_top" title="functional annotation">InterProScan</a>
+<a href="https://usegalaxy.org/root?tool_id=kegg_ora" target="_top" title="run pathway over-representation analysis from gene lists">KEGG ORA</a>
+<a href="https://usegalaxy.org/root?tool_id=kobas_annotate" target="_top" title="KEGG Orthology Based Annotation System">KOBAS Annotate</a>
+<a href="https://usegalaxy.org/root?tool_id=kobas_identify" target="_top" title="KEGG Orthology Based Annotation System">KOBAS Identify</a>
+<a href="https://usegalaxy.org/root?tool_id=liftoff" target="_top" title="Lift gene annotations between genome assemblies">Liftoff</a>
+<a href="https://usegalaxy.org/root?tool_id=list_spaln_tables" target="_top" title="Given a query species, list the spaln settings tables that exist, from closest related species to most different">List spaln parameter tables</a>
+<a href="https://usegalaxy.org/root?tool_id=mitos2" target="_top" title="de-novo annotation of metazoan mitochondrial genomes">MITOS2</a>
+<a href="https://usegalaxy.org/root?tool_id=mlst" target="_top" title="Scans genomes against PubMLST schemes">MLST</a>
+<a href="https://usegalaxy.org/root?tool_id=mlst_list" target="_top" title="Lists available schemes for the MLST tool">MLST List</a>
+<a href="https://usegalaxy.org/root?tool_id=mmseqs2_taxonomy_assignment" target="_top" title="of sequences by comparing them to a reference database">MMseqs2 taxonomy</a>
+<a href="https://usegalaxy.org/root?tool_id=maker" target="_top" title="genome annotation pipeline">Maker</a>
+<a href="https://usegalaxy.org/root?tool_id=maker_map_ids" target="_top" title="on a Maker annotation">Map annotation ids</a>
+<a href="https://usegalaxy.org/root?tool_id=miniprot" target="_top" title="align a protein sequence against a genome with affine gap penalty, splicing and frameshift">Miniprot align</a>
+<a href="https://usegalaxy.org/root?tool_id=miniprot_index" target="_top" title="build a genome index for miniprot">Miniprot index</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_egapx" target="_top" title="annotates eukaryotic genomes">NCBI EGAPx</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_egapx_execute" target="_top" title="annotates eukaryotic genomes">NCBI EGAPx execute</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_egapx_prepare_input" target="_top" title="annotates eukaryotic genomes">NCBI EGAPx prepare input</a>
+<a href="https://usegalaxy.org/root?tool_id=clinod" target="_top" title="Find nucleolar localization signals (NoLSs) in protein sequences">Nucleolar localization sequence Detector (NoD)</a>
+<a href="https://usegalaxy.org/root?tool_id=omark" target="_top" title="proteome quality assessment">OMArk</a>
+<a href="https://usegalaxy.org/root?tool_id=orfipy" target="_top" title="a versatile ORF finder">ORFipy</a>
+<a href="https://usegalaxy.org/root?tool_id=optitype" target="_top" title="HLA genotyping predictions from NGS data">OptiType</a>
+<a href="https://usegalaxy.org/root?tool_id=orthofinder_onlygroups" target="_top" title="finds orthogroups in a set of proteomes">OrthoFinder</a>
+<a href="https://usegalaxy.org/root?tool_id=pfamscan" target="_top" title="search a FASTA sequence against a library of Pfam HMM">PfamScan</a>
+<a href="https://usegalaxy.org/root?tool_id=plasmidfinder" target="_top" title="Plasmid identification in bacteria.">PlasmidFinder</a>
+<a href="https://usegalaxy.org/root?tool_id=prodigal" target="_top" title="A tool for gene prediction in microbial genomes">Prodigal Gene Predictor</a>
+<a href="https://usegalaxy.org/root?tool_id=prokka" target="_top" title="Prokaryotic genome annotation">Prokka</a>
+<a href="https://usegalaxy.org/root?tool_id=psauron" target="_top" title="Machine learning model for rapid assessment of protein coding gene annotation">Psauron</a>
+<a href="https://usegalaxy.org/root?tool_id=read_it_and_keep" target="_top" title="">Read It and Keep</a>
+<a href="https://usegalaxy.org/root?tool_id=red" target="_top" title="repeat masking">Red</a>
+<a href="https://usegalaxy.org/root?tool_id=repeatmasker_wrapper" target="_top" title="screen DNA sequences for interspersed repeats and low complexity regions">RepeatMasker</a>
+<a href="https://usegalaxy.org/root?tool_id=repeatmodeler" target="_top" title="Model repetitive DNA">RepeatModeler</a>
+<a href="https://usegalaxy.org/root?tool_id=roary" target="_top" title="the pangenome pipeline - Quickly generate a core gene alignment from gff3 files">Roary</a>
+<a href="https://usegalaxy.org/root?tool_id=microsatbed" target="_top" title="Short Tandem Repeats to bed features from fasta">STR to bed</a>
+<a href="https://usegalaxy.org/root?tool_id=spaln" target="_top" title="Maps and aligns a set of cDNA or protein sequences onto a whole genomic sequence.">Spaln: align cDNA or Protein to genome</a>
+<a href="https://usegalaxy.org/root?tool_id=tapscan_classify" target="_top" title="Detect Transcription Associated Proteins (TAPs)">TAPScan Classify</a>
+<a href="https://usegalaxy.org/root?tool_id=tb_variant_filter" target="_top" title="M. tuberculosis H37Rv VCF filter">TB Variant Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=tbvcfreport" target="_top" title="- generate HTML report from SnpEff annotated M.tb VCF(s)">TB Variant Report</a>
+<a href="https://usegalaxy.org/root?tool_id=tb_profiler_profile" target="_top" title="Infer strain types and drug resistance markers from sequences">TB-Profiler Profile</a>
+<a href="https://usegalaxy.org/root?tool_id=tetyper" target="_top" title="Transposable Element Typer">TETyper</a>
+<a href="https://usegalaxy.org/root?tool_id=tbl2gff3" target="_top" title="">Table to GFF3</a>
+<a href="https://usegalaxy.org/root?tool_id=augustus_training" target="_top" title="ab-initio gene predictor">Train Augustus</a>
+<a href="https://usegalaxy.org/root?tool_id=snap_training" target="_top" title="ab-initio gene predictor">Train SNAP</a>
+<a href="https://usegalaxy.org/root?tool_id=transtermhp" target="_top" title="finds rho-independent transcription terminators in bacterial genomes">TransTermHP</a>
+<a href="https://usegalaxy.org/root?tool_id=windowmasker_mkcounts" target="_top" title="Construct WindowMasker unit counts table">WindowMasker mkcounts</a>
+<a href="https://usegalaxy.org/root?tool_id=windowmasker_ustat" target="_top" title="Mask sequences using a WindowMasker unit counts table">WindowMasker ustat</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_alimask" target="_top" title="append modelmask line to a multiple sequence alignments">alimask</a>
+<a href="https://usegalaxy.org/root?tool_id=argnorm" target="_top" title="a tool to normalize antibiotic resistance genes (ARGs) by mapping them to the antibiotic resistance ontology (ARO)">argNorm</a>
+<a href="https://usegalaxy.org/root?tool_id=compleasm" target="_top" title="completeness of genome assemblies">compleasm</a>
+<a href="https://usegalaxy.org/root?tool_id=fargene" target="_top" title="Fragmented antibiotic resistance gene identifier">fargene</a>
+<a href="https://usegalaxy.org/root?tool_id=fgsea" target="_top" title="- fast preranked gene set enrichment analysis">fgsea</a>
+<a href="https://usegalaxy.org/root?tool_id=gprofiler_convert" target="_top" title="converts between various types of namespaces">gProfiler Convert</a>
+<a href="https://usegalaxy.org/root?tool_id=gprofiler_gost" target="_top" title="performs functional enrichment analysis of gene lists">gProfiler GOSt</a>
+<a href="https://usegalaxy.org/root?tool_id=gprofiler_orth" target="_top" title="translates gene identifiers between organisms">gProfiler Orth</a>
+<a href="https://usegalaxy.org/root?tool_id=gprofiler_random" target="_top" title="generates a gene list">gProfiler Random</a>
+<a href="https://usegalaxy.org/root?tool_id=gprofiler_snpense" target="_top" title="maps SNP rs-codes to gene names, chromosomal coordinates and variant effects">gProfiler SNPense</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_hmmalign" target="_top" title="align sequences to a profile HMM">hmmalign</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_hmmbuild" target="_top" title="Build a profile HMM from an input multiple alignment">hmmbuild</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_hmmconvert" target="_top" title="convert profile file to a HMMER format">hmmconvert</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_hmmemit" target="_top" title="sample sequence(s) from a profile HMM">hmmemit</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_hmmfetch" target="_top" title="retrieve profile HMM(s) from a file">hmmfetch</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_hmmscan" target="_top" title="search protein sequence(s) against a protein profile database">hmmscan</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_hmmsearch" target="_top" title="search profile(s) against a sequence database">hmmsearch</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_jackhmmer" target="_top" title="iteratively search a protein sequence against a protein database (PSIBLAST-like)">jackhmmer</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_nhmmer" target="_top" title="search a DNA model or alignment against a DNA database (BLASTN-like)">nhmmer</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_nhmmscan" target="_top" title="search DNA sequence(s) against a DNA profile database">nhmmscan</a>
+<a href="https://usegalaxy.org/root?tool_id=hmmer_phmmer" target="_top" title="search a protein sequence against a protein database (BLASTP-like)">phmmer</a>
+<a href="https://usegalaxy.org/root?tool_id=progressivemauve" target="_top" title="constructs multiple genome alignments">progressiveMauve</a>
+<a href="https://usegalaxy.org/root?tool_id=seq2hla" target="_top" title="HLA genotype and expression from RNA-seq">seq2HLA</a>
+<a href="https://usegalaxy.org/root?tool_id=socru" target="_top" title="Calculate the order and orientation of complete bacterial genomes">socru</a>
+<a href="https://usegalaxy.org/root?tool_id=staramr_search" target="_top" title="Scans genome assemblies against the ResFinder, PlasmidFinder, and PointFinder databases searching for AMR genes">staramr</a>
+<a href="https://usegalaxy.org/root?tool_id=aragorn_trna" target="_top" title="prediction (Aragorn)">tRNA and tmRNA</a>
+
+</div>
+
+### Mapping
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=bioext_bealign" target="_top" title="to a reference using a codon alignment algorithm">Align sequences</a>
+<a href="https://usegalaxy.org/root?tool_id=bbtools_bbmap" target="_top" title="short-read aligner">BBTools: BBMap</a>
+<a href="https://usegalaxy.org/root?tool_id=bwa_mem2" target="_top" title="- map medium and long reads (&gt; 100 bp) against reference genome">BWA-MEM2</a>
+<a href="https://usegalaxy.org/root?tool_id=bwa_mem2_idx" target="_top" title="Build BWA-MEM2 reference index">BWA-MEM2 indexer</a>
+<a href="https://usegalaxy.org/root?tool_id=batched_lastz" target="_top" title=": align batches of sequences">Batched LASTZ</a>
+<a href="https://usegalaxy.org/root?tool_id=bowtie2" target="_top" title="- map reads against reference genome">Bowtie2</a>
+<a href="https://usegalaxy.org/root?tool_id=kegalign" target="_top" title="A Scalable GPU System for Pairwise Whole Genome Alignments based on LASTZ&#x27;s seed-filter-extend paradigm">KegAlign</a>
+<a href="https://usegalaxy.org/root?tool_id=lastz_wrapper_2" target="_top" title="align long sequences">LASTZ</a>
+<a href="https://usegalaxy.org/root?tool_id=lastz_d_wrapper" target="_top" title="estimate substitution scores matrix">LASTZ_D</a>
+<a href="https://usegalaxy.org/root?tool_id=bwa" target="_top" title="- map short reads (&lt; 100 bp) against reference genome">Map with BWA</a>
+<a href="https://usegalaxy.org/root?tool_id=bwa_mem" target="_top" title="- map medium and long reads (&gt; 100 bp) against reference genome">Map with BWA-MEM</a>
+<a href="https://usegalaxy.org/root?tool_id=minimap2" target="_top" title="A fast pairwise aligner for genomic and spliced nucleotide sequences">Map with minimap2</a>
+<a href="https://usegalaxy.org/root?tool_id=pileometh" target="_top" title="A tool for processing bisulfite sequencing alignments">MethylDackel</a>
+<a href="https://usegalaxy.org/root?tool_id=megablast_xml_parser" target="_top" title="">Parse blast XML output</a>
+<a href="https://usegalaxy.org/root?tool_id=rna_starsolo" target="_top" title="mapping, demultiplexing and gene quantification for single cell RNA-seq">RNA STARSolo</a>
+<a href="https://usegalaxy.org/root?tool_id=star_fusion" target="_top" title="detect fusion genes in RNA-Seq data">STAR-Fusion</a>
+<a href="https://usegalaxy.org/root?tool_id=segalign" target="_top" title="A Scalable GPU System for Pairwise Whole Genome Alignments based on LASTZ&#x27;s seed-filter-extend paradigm">SegAlign</a>
+<a href="https://usegalaxy.org/root?tool_id=winnowmap" target="_top" title="a mapping tool optimized for repetitive sequences">Winnowmap</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_axtchain" target="_top" title="chain together axt or psl alignments">axtChain</a>
+<a href="https://usegalaxy.org/root?tool_id=bwameth" target="_top" title="Fast and accurate aligner of BS-Seq reads">bwameth</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_chainantirepeat" target="_top" title="Remove repeated chains">chainAntiRepeat</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_chainnet" target="_top" title="make alignment nets out of alignment chains">chainNet</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_chainprenet" target="_top" title="Remove chains that don&#x27;t have a chance of being netted">chainPreNet</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_chainsort" target="_top" title="Sort chains">chainSort</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_chainswap" target="_top" title="Swap target and query in a chain.">chainSwap</a>
+<a href="https://usegalaxy.org/root?tool_id=metilene" target="_top" title="calling differentially methylated regions from bisulfite sequencing data">metilene</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_netchainsubset" target="_top" title="Create chain file with subset of chains that appear in the net">netChainSubset</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_netfilter" target="_top" title="Filter out parts of net">netFilter</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_netsyntenic" target="_top" title="Add synteny info to a net">netSyntenic</a>
+
+</div>
+
+### Variant Calling
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=lofreq_alnqual" target="_top" title="to aligned read SAM/BAM records">Add LoFreq alignment quality scores</a>
+<a href="https://usegalaxy.org/root?tool_id=arriba" target="_top" title="detect gene fusions from STAR aligned RNA-Seq data">Arriba</a>
+<a href="https://usegalaxy.org/root?tool_id=arriba_draw_fusions" target="_top" title="">Arriba Draw Fusions</a>
+<a href="https://usegalaxy.org/root?tool_id=arriba_get_filters" target="_top" title="to history">Arriba Get Filters</a>
+<a href="https://usegalaxy.org/root?tool_id=bamleftalign" target="_top" title="indels in BAM datasets">BamLeftAlign</a>
+<a href="https://usegalaxy.org/root?tool_id=lofreq_call" target="_top" title="with LoFreq">Call variants</a>
+<a href="https://usegalaxy.org/root?tool_id=deepvariant" target="_top" title="deep learning-based variant caller">DeepVariant</a>
+<a href="https://usegalaxy.org/root?tool_id=exomedepth" target="_top" title="Calls copy number variants (CNVs) from targeted sequence data">ExomeDepth</a>
+<a href="https://usegalaxy.org/root?tool_id=getalleleseq" target="_top" title="Generate major and minor allele sequences from alleles table">FASTA from allele counts</a>
+<a href="https://usegalaxy.org/root?tool_id=snp_sites" target="_top" title="from a multi-FASTA alignment file">Finds SNP sites</a>
+<a href="https://usegalaxy.org/root?tool_id=freebayes" target="_top" title="bayesian genetic variant detector">FreeBayes</a>
+<a href="https://usegalaxy.org/root?tool_id=gatk4_mutect2" target="_top" title="- Call somatic SNVs and indels via local assembly of haplotypes">GATK4 Mutect2</a>
+<a href="https://usegalaxy.org/root?tool_id=lofreq_indelqual" target="_top" title="into a BAM file">Insert indel qualities</a>
+<a href="https://usegalaxy.org/root?tool_id=jasminesv" target="_top" title="Merge structural variants across samples">JasmineSV</a>
+<a href="https://usegalaxy.org/root?tool_id=lofreq_filter" target="_top" title="called variants posteriorly">Lofreq filter</a>
+<a href="https://usegalaxy.org/root?tool_id=hetbox" target="_top" title="Minor Allele Frequency Boxplot">MAF boxplot</a>
+<a href="https://usegalaxy.org/root?tool_id=mutate_snp_codon_1" target="_top" title="with SNPs">Mutate Codons</a>
+<a href="https://usegalaxy.org/root?tool_id=naive_variant_caller" target="_top" title="- tabulate variable sites from BAM datasets">Naive Variant Caller (NVC)</a>
+<a href="https://usegalaxy.org/root?tool_id=phylorelatives" target="_top" title="Relatedness of minor alelle sequences in NJ tree">Phylorelatives</a>
+<a href="https://usegalaxy.org/root?tool_id=lofreq_viterbi" target="_top" title="with LoFreq viterbi">Realign reads</a>
+<a href="https://usegalaxy.org/root?tool_id=snp_dists" target="_top" title="Compute distance in SNPs between all sequences in a FASTA file">SNP distance matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=snpEff_build_gb" target="_top" title="database from Genbank or GFF record">SnpEff build:</a>
+<a href="https://usegalaxy.org/root?tool_id=snpEff_get_chr_names" target="_top" title="list chromosome names/lengths">SnpEff chromosome-info:</a>
+<a href="https://usegalaxy.org/root?tool_id=snpEff_databases" target="_top" title="list available databases">SnpEff databases:</a>
+<a href="https://usegalaxy.org/root?tool_id=snpEff_download" target="_top" title="download a pre-built database">SnpEff download:</a>
+<a href="https://usegalaxy.org/root?tool_id=snpEff" target="_top" title="annotate variants">SnpEff eff:</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_annotate" target="_top" title="SNPs from dbSnp">SnpSift Annotate</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_caseControl" target="_top" title="Count samples are in &#x27;case&#x27; and &#x27;control&#x27; groups.">SnpSift CaseControl</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_extractFields" target="_top" title="from a VCF file into a tabular file">SnpSift Extract Fields</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_filter" target="_top" title="Filter variants using arbitrary expressions">SnpSift Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_geneSets" target="_top" title="Annotating GeneSets, such as Gene Ontology, KEGG, Reactome">SnpSift GeneSets</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_int" target="_top" title="Filter variants using intervals">SnpSift Intervals</a>
+<a href="https://usegalaxy.org/root?tool_id=snpsift_vartype" target="_top" title="Annotate with variant type">SnpSift Variant Type</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_dbnsfp" target="_top" title="Add annotations from dbNSFP or similar annotation DBs">SnpSift dbNSFP</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_rmInfo" target="_top" title="remove INFO field annotations">SnpSift rmInfo</a>
+<a href="https://usegalaxy.org/root?tool_id=snpSift_vcfCheck" target="_top" title="basic checks for VCF specification compliance">SnpSift vcfCheck</a>
+<a href="https://usegalaxy.org/root?tool_id=strelka_germline" target="_top" title="small variant caller for germline variation in small cohorts">Strelka Germline</a>
+<a href="https://usegalaxy.org/root?tool_id=strelka_somatic" target="_top" title="small variant caller for somatic variation in tumor/normal sample pairs">Strelka Somatic</a>
+<a href="https://usegalaxy.org/root?tool_id=varscan" target="_top" title="for variant detection">VarScan</a>
+<a href="https://usegalaxy.org/root?tool_id=varscan_copynumber" target="_top" title="Determine relative tumor copy number from tumor-normal pileups">VarScan copynumber</a>
+<a href="https://usegalaxy.org/root?tool_id=varscan_mpileup" target="_top" title="for variant detection">VarScan mpileup</a>
+<a href="https://usegalaxy.org/root?tool_id=varscan_somatic" target="_top" title="Call germline/somatic and LOH variants from tumor-normal sample pairs">VarScan somatic</a>
+<a href="https://usegalaxy.org/root?tool_id=allele_counts_1" target="_top" title="process variant counts">Variant Annotator</a>
+<a href="https://usegalaxy.org/root?tool_id=snpfreqplot" target="_top" title="Generates a heatmap of allele frequencies grouped by variant type for SnpEff-annotated SARS-CoV-2 data">Variant Frequency Plot</a>
+<a href="https://usegalaxy.org/root?tool_id=basil" target="_top" title="Breakpoint detection, including large insertions">basil</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_color_chrs" target="_top" title="plugin Color shared chromosomal segments, requires phased GTs">bcftools color-chrs</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_plugin_frameshifts" target="_top" title="plugin Annotate frameshift indels">bcftools frameshifts</a>
+<a href="https://usegalaxy.org/root?tool_id=fatovcf" target="_top" title="Convert a FASTA alignment file to Variant Call Format (VCF) single-nucleotide diffs">faToVcf</a>
+<a href="https://usegalaxy.org/root?tool_id=ococo" target="_top" title="consensus caller on SAM/BAM">ococo</a>
+<a href="https://usegalaxy.org/root?tool_id=sniffles" target="_top" title="Structural variation caller using third generation sequencing">sniffles</a>
+<a href="https://usegalaxy.org/root?tool_id=snippy" target="_top" title="Snippy finds SNPs between a haploid reference genome and your NGS sequence reads.">snippy</a>
+<a href="https://usegalaxy.org/root?tool_id=snippy_clean_full_aln" target="_top" title="Replace any non-standard sequence characters in snippy &#x27;core.full.aln&#x27; file.">snippy-clean_full_aln</a>
+<a href="https://usegalaxy.org/root?tool_id=snippy_core" target="_top" title="Combine multiple Snippy outputs into a core SNP alignment">snippy-core</a>
+
+</div>
+
+### ChIP-seq
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=ngsutils_bam_filter" target="_top" title="Removes reads from a BAM file based on criteria">BAM filter</a>
+<a href="https://usegalaxy.org/root?tool_id=cwpair2" target="_top" title="find matched pairs and unmatched orphans">CWPair2</a>
+<a href="https://usegalaxy.org/root?tool_id=chipseeker" target="_top" title="for ChIP peak annotation and visualization">ChIPseeker</a>
+<a href="https://usegalaxy.org/root?tool_id=diffbind" target="_top" title="differential binding analysis of ChIP-Seq peak data">DiffBind</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta_nucleotide_color_plot" target="_top" title="">Fasta nucleotide color plot</a>
+<a href="https://usegalaxy.org/root?tool_id=genetrack" target="_top" title="peak predictor">GeneTrack</a>
+<a href="https://usegalaxy.org/root?tool_id=genrich" target="_top" title="Detecting sites of genomic enrichment">Genrich</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_bdgbroadcall" target="_top" title="Call broad peaks from bedGraph output">MACS2 bdgbroadcall</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_bdgcmp" target="_top" title="Deduct noise by comparing two signal tracks in bedGraph">MACS2 bdgcmp</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_bdgdiff" target="_top" title="Differential peak detection based on paired four bedgraph files">MACS2 bdgdiff</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_bdgpeakcall" target="_top" title="Call peaks from bedGraph output">MACS2 bdgpeakcall</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_callpeak" target="_top" title="Call peaks from alignment results">MACS2 callpeak</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_filterdup" target="_top" title="Remove duplicate reads at the same position">MACS2 filterdup</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_predictd" target="_top" title="Predict &#x27;d&#x27; or fragment size from alignment results">MACS2 predictd</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_randsample" target="_top" title="Randomly sample number or percentage of total reads">MACS2 randsample</a>
+<a href="https://usegalaxy.org/root?tool_id=macs2_refinepeak" target="_top" title="Refine peak summits and give scores measuring balance of forward- backward tags (Experimental)">MACS2 refinepeak</a>
+<a href="https://usegalaxy.org/root?tool_id=multigps" target="_top" title="analyzes collections of multi-condition ChIP-seq data">MultiGPS</a>
+<a href="https://usegalaxy.org/root?tool_id=pe_histogram" target="_top" title="of insert size frequency">Paired-end histogram</a>
+<a href="https://usegalaxy.org/root?tool_id=repmatch_gff3" target="_top" title="Match paired peaks from two or more replicates">RepMatch</a>
+<a href="https://usegalaxy.org/root?tool_id=resize_coordinate_window" target="_top" title="of GFF data">Resize coordinate window</a>
+<a href="https://usegalaxy.org/root?tool_id=seacr" target="_top" title="for sparse enrichment analysis">SEACR</a>
+<a href="https://usegalaxy.org/root?tool_id=peakcalling_sicer" target="_top" title="Statistical approach for the Identification of ChIP-Enriched Regions">SICER</a>
+<a href="https://usegalaxy.org/root?tool_id=tag_pileup_frequency" target="_top" title="">Tag pileup frequency</a>
+
+</div>
+
+### RNA-seq
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=trinity_align_and_estimate_abundance" target="_top" title="on a de novo assembly of RNA-Seq data">Align reads and estimate abundance</a>
+<a href="https://usegalaxy.org/root?tool_id=alleyoop" target="_top" title="- post-processing and QC of Slamdunk analyses">Alleyoop</a>
+<a href="https://usegalaxy.org/root?tool_id=deg_annotate" target="_top" title="Append annotation from GTF to differential expression tool outputs">Annotate DESeq2/DEXSeq output tables</a>
+<a href="https://usegalaxy.org/root?tool_id=brew3r_r" target="_top" title="Extend GTF">BREW3R.r</a>
+<a href="https://usegalaxy.org/root?tool_id=blockclust" target="_top" title="efficient clustering and classification of non-coding RNAs from short read RNA-seq profiles">BlockClust</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity_abundance_estimates_to_matrix" target="_top" title="for a de novo assembly of RNA-Seq data by Trinity">Build expression matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=cemitool" target="_top" title="gene co-expression network analyses">CEMiTool</a>
+<a href="https://usegalaxy.org/root?tool_id=heinz_scoring" target="_top" title="for each node">Calculate a Heinz score</a>
+<a href="https://usegalaxy.org/root?tool_id=chira_collapse" target="_top" title="deduplicate fastq reads">ChiRA collapse</a>
+<a href="https://usegalaxy.org/root?tool_id=chira_extract" target="_top" title="extrat the chimeras">ChiRA extract</a>
+<a href="https://usegalaxy.org/root?tool_id=chira_map" target="_top" title="map reads to trascriptome">ChiRA map</a>
+<a href="https://usegalaxy.org/root?tool_id=chira_merge" target="_top" title="merge aligned positions">ChiRA merge</a>
+<a href="https://usegalaxy.org/root?tool_id=chira_quantify" target="_top" title="quantify aligned loci to score the alignments">ChiRA qauntify</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity_contig_exn50_statistic" target="_top" title="from a Trinity assembly">Compute contig Ex90N50 statistic and Ex90 transcript count</a>
+<a href="https://usegalaxy.org/root?tool_id=crosscontamination_barcode_filter" target="_top" title="for use in plate-based barcoded analyses">Cross-contamination Barcode Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=deseq2" target="_top" title="Determines differentially expressed features from count tables">DESeq2</a>
+<a href="https://usegalaxy.org/root?tool_id=dexseq" target="_top" title="Determines differential exon usage from count tables">DEXSeq</a>
+<a href="https://usegalaxy.org/root?tool_id=dexseq_count" target="_top" title="Prepare and count exon abundancies from RNA-seq data">DEXSeq-Count</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_diamond" target="_top" title="alignment tool for short sequences against a protein database">Diamond</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_diamond_makedb" target="_top" title="Build database from a FASTA file">Diamond makedb</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_diamond_view" target="_top" title="generate formatted output from DAA files">Diamond view</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity_run_de_analysis" target="_top" title="using a Trinity assembly">Differential expression analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=egsea" target="_top" title="easy and efficient ensemble gene set testing">EGSEA</a>
+<a href="https://usegalaxy.org/root?tool_id=feelnc" target="_top" title="FlExible Extraction of LncRNA">FEELnc</a>
+<a href="https://usegalaxy.org/root?tool_id=filter_combined_via_tracking" target="_top" title="using tracking file">Filter Combined Transcripts</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity_filter_low_expr_transcripts" target="_top" title="from a Trinity assembly">Filter low expression transcripts</a>
+<a href="https://usegalaxy.org/root?tool_id=heinz_bum" target="_top" title="with p-values">Fit a BUM model</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity_super_transcripts" target="_top" title="from a Trinity assembly">Generate SuperTranscripts</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity_gene_to_trans_map" target="_top" title="for Trinity assembly">Generate gene to transcript map</a>
+<a href="https://usegalaxy.org/root?tool_id=get_read_pipeline" target="_top" title="derives the reverse transcriptase (RT) stop count on each nucleotide from a mapped file provided by the Iterative Mapping module">Get RT Stop Counts</a>
+<a href="https://usegalaxy.org/root?tool_id=gffcompare" target="_top" title="Compare assembled transcripts to a reference annotation">GffCompare</a>
+<a href="https://usegalaxy.org/root?tool_id=hisat2" target="_top" title="A fast and sensitive alignment program">HISAT2</a>
+<a href="https://usegalaxy.org/root?tool_id=idr" target="_top" title="compare ranked list of identifications">IDR</a>
+<a href="https://usegalaxy.org/root?tool_id=heinz" target="_top" title="using Heinz">Identify optimal scoring subnetwork</a>
+<a href="https://usegalaxy.org/root?tool_id=isoformswitchanalyzer" target="_top" title="statistical identification of isoform switching">IsoformSwitchAnalyzeR</a>
+<a href="https://usegalaxy.org/root?tool_id=iterative_map_pipeline" target="_top" title="iteratively maps the raw reads of RNA structural data to the reference transcriptome">Iterative Mapping</a>
+<a href="https://usegalaxy.org/root?tool_id=kallisto_pseudo" target="_top" title="run pseudoalignment on RNA-Seq transcripts">Kallisto pseudo</a>
+<a href="https://usegalaxy.org/root?tool_id=kallisto_quant" target="_top" title="quantify abundances of RNA-Seq transcripts">Kallisto quant</a>
+<a href="https://usegalaxy.org/root?tool_id=rbc_mirdeep2" target="_top" title="identification of novel and known miRNAs">MiRDeep2</a>
+<a href="https://usegalaxy.org/root?tool_id=rbc_mirdeep2_mapper" target="_top" title="process and map reads to a reference genome">MiRDeep2 Mapper</a>
+<a href="https://usegalaxy.org/root?tool_id=rbc_mirdeep2_quantifier" target="_top" title="fast quantitation of reads mapping to known miRBase precursors">MiRDeep2 Quantifier</a>
+<a href="https://usegalaxy.org/root?tool_id=qualimap_counts" target="_top" title="">QualiMap Counts QC</a>
+<a href="https://usegalaxy.org/root?tool_id=qualimap_rnaseq" target="_top" title="">QualiMap RNA-Seq QC</a>
+<a href="https://usegalaxy.org/root?tool_id=rna_star" target="_top" title="Gapped-read mapper for RNA-seq data">RNA STAR</a>
+<a href="https://usegalaxy.org/root?tool_id=predict_pipeline" target="_top" title="predict RNA structures with or without experimental constraints from the Reactivity Calculation module">RNA Structure Prediction</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity_samples_qccheck" target="_top" title="for transcript quantification">RNASeq samples quality check</a>
+<a href="https://usegalaxy.org/root?tool_id=react_cal_pipeline" target="_top" title="calculates structural reactivity on each nucleotide based on RT stop counts from the Get RT Stop Counts module">Reactivity Calculation</a>
+<a href="https://usegalaxy.org/root?tool_id=ruvseq" target="_top" title="from RNA-seq data">Remove Unwanted Variation</a>
+<a href="https://usegalaxy.org/root?tool_id=sailfish" target="_top" title="transcript quantification from RNA-seq data">Sailfish</a>
+<a href="https://usegalaxy.org/root?tool_id=salmon" target="_top" title="Perform dual-phase, reads or mapping-based estimation of transcript abundance from RNA-seq reads">Salmon quant</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat" target="_top" title="- toolkit for exploration of single-cell RNA-seq data">Seurat</a>
+<a href="https://usegalaxy.org/root?tool_id=slamdunk" target="_top" title="- streamlining SLAM-seq analysis with ultra-high sensitivity">Slamdunk</a>
+<a href="https://usegalaxy.org/root?tool_id=stringtie" target="_top" title="transcript assembly and quantification">StringTie</a>
+<a href="https://usegalaxy.org/root?tool_id=stringtie_merge" target="_top" title="transcripts">StringTie merge</a>
+<a href="https://usegalaxy.org/root?tool_id=targetfinder" target="_top" title="plant small RNA target prediction tool">TargetFinder</a>
+<a href="https://usegalaxy.org/root?tool_id=transdecoder" target="_top" title="finds coding regions within transcripts">TransDecoder</a>
+<a href="https://usegalaxy.org/root?tool_id=trinity" target="_top" title="de novo assembly of RNA-Seq data">Trinity</a>
+<a href="https://usegalaxy.org/root?tool_id=trinotate" target="_top" title="functional transcript annotation">Trinotate</a>
+<a href="https://usegalaxy.org/root?tool_id=heinz_visualization" target="_top" title="the optimal scoring subnetwork">Visualize</a>
+<a href="https://usegalaxy.org/root?tool_id=blockbuster" target="_top" title="detects blocks of overlapping reads using a gaussian-distribution approach">blockbuster</a>
+<a href="https://usegalaxy.org/root?tool_id=cummeRbund" target="_top" title="visualize Cuffdiff output">cummeRbund</a>
+<a href="https://usegalaxy.org/root?tool_id=edger" target="_top" title="Perform differential expression of count data">edgeR</a>
+<a href="https://usegalaxy.org/root?tool_id=featurecounts" target="_top" title="Measure gene expression in RNA-Seq experiments from SAM or BAM files">featureCounts</a>
+<a href="https://usegalaxy.org/root?tool_id=goseq" target="_top" title="tests for overrepresented gene categories">goseq</a>
+<a href="https://usegalaxy.org/root?tool_id=htseq_count" target="_top" title="- Count aligned reads in a BAM file that overlap features in a GFF file">htseq-count</a>
+<a href="https://usegalaxy.org/root?tool_id=limma_voom" target="_top" title="Perform differential expression with limma-voom or limma-trend">limma</a>
+<a href="https://usegalaxy.org/root?tool_id=masigpro" target="_top" title="Significant Gene Expression Profile Differences in Time Course Gene Expression Data">maSigPro</a>
+<a href="https://usegalaxy.org/root?tool_id=ngsderive_strandedness" target="_top" title="infers strandedness from RNA-seq BAM files">ngsderive strandedness</a>
+<a href="https://usegalaxy.org/root?tool_id=pizzly" target="_top" title="- fast fusion detection using kallisto">pizzly</a>
+<a href="https://usegalaxy.org/root?tool_id=plotdexseq" target="_top" title="Visualization of the per gene DEXSeq results">plotDEXSeq</a>
+<a href="https://usegalaxy.org/root?tool_id=scpipe" target="_top" title="- preprocessing pipeline for single cell RNA-seq">scPipe</a>
+<a href="https://usegalaxy.org/root?tool_id=tximport" target="_top" title="Summarize transcript-level estimates for gene-level analysis">tximport</a>
+
+</div>
+
+### Multiple Alignments
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=pipelign" target="_top" title="alignment with pipelign">Automated multiple sequence</a>
+<a href="https://usegalaxy.org/root?tool_id=clustalw" target="_top" title="multiple sequence alignment program for DNA or proteins">ClustalW</a>
+<a href="https://usegalaxy.org/root?tool_id=mummer_dnadiff" target="_top" title="Evaluate similarities/differences between two sequences">DNAdiff</a>
+<a href="https://usegalaxy.org/root?tool_id=mummer_delta_filter" target="_top" title="Filters alignment (delta) file from nucmer">Delta-Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=Interval2Maf1" target="_top" title="given a set of genomic intervals">Extract MAF blocks</a>
+<a href="https://usegalaxy.org/root?tool_id=kc-align" target="_top" title="">Kc-Align</a>
+<a href="https://usegalaxy.org/root?tool_id=maf_stats1" target="_top" title="Alignment coverage information">MAF Coverage Stats</a>
+<a href="https://usegalaxy.org/root?tool_id=rbc_mafft" target="_top" title="Multiple alignment program for amino acid or nucleotide sequences">MAFFT</a>
+<a href="https://usegalaxy.org/root?tool_id=rbc_mafft_add" target="_top" title="Align a sequence,alignment or fragments to an existing alignment.">MAFFT add</a>
+<a href="https://usegalaxy.org/root?tool_id=mmseqs2_easy_linclust_clustering" target="_top" title="of very large datasets">MMseqs2 easy-linclust</a>
+<a href="https://usegalaxy.org/root?tool_id=msaboot" target="_top" title="Output PHYLIP file with bootstrapped multiple sequence alignment data">MSABOOT</a>
+<a href="https://usegalaxy.org/root?tool_id=mummer_mummer" target="_top" title="Align two or more sequences">Mummer</a>
+<a href="https://usegalaxy.org/root?tool_id=mummer_mummerplot" target="_top" title="Generate 2-D dotplot of aligned sequences">Mummerplot</a>
+<a href="https://usegalaxy.org/root?tool_id=mummer_nucmer" target="_top" title="Align two or more sequences">Nucmer</a>
+<a href="https://usegalaxy.org/root?tool_id=sina" target="_top" title="reference based multiple sequence alignment">SINA</a>
+<a href="https://usegalaxy.org/root?tool_id=mummer_show_coords" target="_top" title="Parse delta file and report coordinates and other information">Show-Coords</a>
+<a href="https://usegalaxy.org/root?tool_id=GeneBed_Maf_Fasta2" target="_top" title="given a set of coding exon intervals">Stitch Gene blocks</a>
+<a href="https://usegalaxy.org/root?tool_id=cawlign" target="_top" title="Codon-aware (pairwise) alignment">cawlign</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_mafaddirows" target="_top" title="Add i rows to a MAF file">mafAddIRows</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_mafcoverage" target="_top" title="Analyse coverage by MAF files">mafCoverage</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_maffetch" target="_top" title="Get overlapping records from an MAF using an index table">mafFetch</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_mafFilter" target="_top" title="Filter MAF files based on various criteria">mafFilter</a>
+<a href="https://usegalaxy.org/root?tool_id=ucsc_maffrags" target="_top" title="Extract MAFs from regions specified in a BED file">mafFrags</a>
+<a href="https://usegalaxy.org/root?tool_id=mashmap" target="_top" title="Fast local alignment boundaries">mashmap</a>
+
+</div>
+
+### Phenotype Association
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=hgv_beam" target="_top" title="significant single- and multi-locus SNP associations in case-control studies">BEAM</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_david" target="_top" title="functional annotation for a list of genes">DAVID</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_funDo" target="_top" title="human genes associated with disease terms">FunDO</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_gpass" target="_top" title="significant single-SNP associations in case-control studies">GPASS</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_hilbertvis" target="_top" title="visualization of genomic data with the Hilbert curve">HVIS</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_ldtools" target="_top" title="linkage disequilibrium and tag SNPs">LD</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_lps" target="_top" title="LASSO-Patternsearch algorithm">LPS</a>
+<a href="https://usegalaxy.org/root?tool_id=master2pgSnp" target="_top" title="Convert from MasterVar to pgSnp format">MasterVar to pgSnp</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_pass" target="_top" title="significant transcription factor binding sites from ChIP data">PASS</a>
+<a href="https://usegalaxy.org/root?tool_id=dividePgSnp" target="_top" title="into columns">Separate pgSnp alleles</a>
+<a href="https://usegalaxy.org/root?tool_id=vcf2pgSnp" target="_top" title="Convert from VCF to pgSnp format">VCF to pgSnp</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_linkToGProfile" target="_top" title="tools for functional profiling of gene lists">g:Profiler</a>
+<a href="https://usegalaxy.org/root?tool_id=plink" target="_top" title="genome association analysis toolset">plink</a>
+<a href="https://usegalaxy.org/root?tool_id=hgv_snpFreq" target="_top" title="significant SNPs in case-control data">snpFreq</a>
+
+</div>
+
+### Evolution
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=tasmanian_mismatch" target="_top" title="Quantify, visualize and summarize mismatches in deep sequencing data">Analysis of artifacts with Tasmanian</a>
+<a href="https://usegalaxy.org/root?tool_id=fasttree" target="_top" title="build maximum-likelihood phylogenetic trees">FASTTREE</a>
+<a href="https://usegalaxy.org/root?tool_id=iqtree" target="_top" title="Phylogenomic / evolutionary tree construction from multiple sequences">IQ-TREE</a>
+<a href="https://usegalaxy.org/root?tool_id=rapidnj" target="_top" title="rapidly with RapidNJ">Join neighbors</a>
+<a href="https://usegalaxy.org/root?tool_id=tn93_readreduce" target="_top" title="into clusters with TN-93">Merge matching reads</a>
+<a href="https://usegalaxy.org/root?tool_id=phykit_metrics" target="_top" title="tree and alignment metrics for single files or collections">PhyKIT metrics</a>
+<a href="https://usegalaxy.org/root?tool_id=phykit_alignment_tree_based" target="_top" title="">PhyKit - Alignment- and tree-based functions</a>
+<a href="https://usegalaxy.org/root?tool_id=phykit_alignment_based" target="_top" title="">PhyKit - Alignment-based functions</a>
+<a href="https://usegalaxy.org/root?tool_id=phykit_tree_based" target="_top" title="">PhyKit - Tree-based functions</a>
+<a href="https://usegalaxy.org/root?tool_id=tn93" target="_top" title="compute distances between aligned sequences">TN93</a>
+<a href="https://usegalaxy.org/root?tool_id=tn93_cluster" target="_top" title="sequences that lie within a specific distance of each other">TN93 Cluster</a>
+<a href="https://usegalaxy.org/root?tool_id=tn93_filter" target="_top" title="- remove sequences from a reference that are within a given distance of of a cluster">TN93 Filter</a>
+
+</div>
+
+### Regional Variation
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=wtavg" target="_top" title="of the values of features overlapping an interval">Assign weighted-average</a>
+<a href="https://usegalaxy.org/root?tool_id=indelRates_3way" target="_top" title="for 3-way alignments">Estimate Indel Rates</a>
+<a href="https://usegalaxy.org/root?tool_id=microsats_mutability1" target="_top" title="by specified attributes">Estimate microsatellite mutability</a>
+<a href="https://usegalaxy.org/root?tool_id=microsats_align1" target="_top" title="from pair-wise alignments">Extract Orthologous Microsatellites</a>
+<a href="https://usegalaxy.org/root?tool_id=featureCoverage1" target="_top" title="">Feature coverage</a>
+<a href="https://usegalaxy.org/root?tool_id=indels_3way" target="_top" title="from 3-way alignments">Fetch Indels</a>
+<a href="https://usegalaxy.org/root?tool_id=getIndels_2way" target="_top" title="from pairwise alignments">Fetch Indels</a>
+<a href="https://usegalaxy.org/root?tool_id=substitutions1" target="_top" title="from pairwise alignments">Fetch substitutions </a>
+<a href="https://usegalaxy.org/root?tool_id=hmm_1" target="_top" title="on numeric data">Fit HMM </a>
+<a href="https://usegalaxy.org/root?tool_id=heatmap_1" target="_top" title="of numeric data">Heatmap </a>
+<a href="https://usegalaxy.org/root?tool_id=karyotype_Plot_1" target="_top" title="for multiple series">Karyotype Plotting tool</a>
+<a href="https://usegalaxy.org/root?tool_id=winSplitter" target="_top" title="">Make windows</a>
+<a href="https://usegalaxy.org/root?tool_id=cpgFilter" target="_top" title="from MAF file">Mask CpG/non-CpG sites</a>
+
+</div>
+
+### Chromosome Conformation
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=hifive" target="_top" title="manipulate, analyze, and plot HiC and 5C chromatin interaction data">hifive</a>
+
+</div>
+
+### Transposon Insertion Sequencing
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=tradis_essentiality" target="_top" title="">Bio-TraDis Essentiality Predictions</a>
+<a href="https://usegalaxy.org/root?tool_id=tradis_gene_insert_sites" target="_top" title="">Bio-TraDis counts to gene insertion data</a>
+<a href="https://usegalaxy.org/root?tool_id=bacteria_tradis" target="_top" title="">Bio-TraDis reads to counts</a>
+<a href="https://usegalaxy.org/root?tool_id=gff_to_prot" target="_top" title="to prot_table for TRANSIT">Convert GFF3</a>
+<a href="https://usegalaxy.org/root?tool_id=transit_gumbel" target="_top" title="- determine essential genes">TRANSIT Gumbel</a>
+<a href="https://usegalaxy.org/root?tool_id=transit_hmm" target="_top" title="- determine essentiality of a genome">TRANSIT HMM</a>
+<a href="https://usegalaxy.org/root?tool_id=transit_resampling" target="_top" title="- determine per-gene p-values">TRANSIT Resampling</a>
+<a href="https://usegalaxy.org/root?tool_id=transit_tn5gaps" target="_top" title="- determine essential genes">TRANSIT Tn5Gaps</a>
+
+</div>
+
+### Protein Modeling
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=ffindex_dbkit_create" target="_top" title="database">DBKit Create</a>
+<a href="https://usegalaxy.org/root?tool_id=dbkit_create" target="_top" title="database">DBKit Create</a>
+<a href="https://usegalaxy.org/root?tool_id=ffindex_dbkit_extract" target="_top" title="entries">DBKit Extract</a>
+<a href="https://usegalaxy.org/root?tool_id=dbkit_extract" target="_top" title="entries">DBKit Extract</a>
+<a href="https://usegalaxy.org/root?tool_id=ffindex_dbkit_merge" target="_top" title="two databases">DBKit Merge</a>
+<a href="https://usegalaxy.org/root?tool_id=dbkit_merge" target="_top" title="two databases">DBKit Merge</a>
+<a href="https://usegalaxy.org/root?tool_id=hhsearch" target="_top" title="detecting remote homologues of proteins">HHsearch</a>
+<a href="https://usegalaxy.org/root?tool_id=spring_cross" target="_top" title="reference builder">SPRING Cross</a>
+<a href="https://usegalaxy.org/root?tool_id=spring_mcc" target="_top" title="plot generator">SPRING MCC</a>
+<a href="https://usegalaxy.org/root?tool_id=spring_map" target="_top" title="with BLAST">SPRING Map</a>
+<a href="https://usegalaxy.org/root?tool_id=spring_minz" target="_top" title="filter operation">SPRING Min-Z</a>
+<a href="https://usegalaxy.org/root?tool_id=spring_model" target="_top" title="complex structures">SPRING Model</a>
+<a href="https://usegalaxy.org/root?tool_id=spring_model_all" target="_top" title="complex structures">SPRING Model-All</a>
+
+</div>
+
+### Genome Editing
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=mageck_count" target="_top" title="- collect sgRNA read counts from read mapping files">MAGeCK count</a>
+<a href="https://usegalaxy.org/root?tool_id=mageck_mle" target="_top" title="- perform maximum-likelihood estimation of gene essentiality scores">MAGeCK mle</a>
+<a href="https://usegalaxy.org/root?tool_id=mageck_test" target="_top" title="- given a table of read counts, perform the sgRNA and gene ranking">MAGeCKs test</a>
+
+</div>
+
+### Biodiversity data exploration
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=obisindicators" target="_top" title="from OBIS">Ocean biodiversity indicators</a>
+
+</div>
+
+### Sequence Contamination Filtering
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=ncbi_fcs_adaptor" target="_top" title="detects contamination from foreign organisms in genome sequences">NCBI FCS Adaptor</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_fcs_gx" target="_top" title="detects contamination from foreign organisms in genome sequences">NCBI FCS GX</a>
+
+</div>
+
+### Genome Diversity
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=raxml" target="_top" title="Maximum Likelihood based inference of large phylogenetic trees">RAxML</a>
+
+</div>
+
+---
+
+## Statistics and Visualization
+
+
+### Statistics
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=abims_anova" target="_top" title="N-way anova. With ou Without interactions">Anova</a>
+<a href="https://usegalaxy.org/root?tool_id=biosigner" target="_top" title="Molecular signature discovery from omics data">Biosigner</a>
+<a href="https://usegalaxy.org/root?tool_id=seqcomplexity" target="_top" title="total and per read">Calculate sequence complexity</a>
+<a href="https://usegalaxy.org/root?tool_id=rcve1" target="_top" title="">Compute RCVE</a>
+<a href="https://usegalaxy.org/root?tool_id=partialRsq" target="_top" title="">Compute partial R square</a>
+<a href="https://usegalaxy.org/root?tool_id=Count1" target="_top" title="occurrences of each record">Count</a>
+<a href="https://usegalaxy.org/root?tool_id=count_gff_features" target="_top" title="">Count GFF Features</a>
+<a href="https://usegalaxy.org/root?tool_id=plot_for_lda_output1" target="_top" title="on &quot;Perform LDA&quot; output">Draw ROC plot</a>
+<a href="https://usegalaxy.org/root?tool_id=featurewise_correlation" target="_top" title="compute per-feature Spearman or Pearson correlations between matched matrices">Feature-wise Correlation Tests</a>
+<a href="https://usegalaxy.org/root?tool_id=generate_matrix_for_pca_and_lda1" target="_top" title="for using PC and LDA">Generate A Matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=graphembed" target="_top" title="Compute and plot a 2D embedding of a data matrix given supervised class information">GraphEmbed</a>
+<a href="https://usegalaxy.org/root?tool_id=Heatmap" target="_top" title="Heatmap of the dataMatrix">Heatmap</a>
+<a href="https://usegalaxy.org/root?tool_id=kcca1" target="_top" title="">Kernel Canonical Correlation Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=kpca1" target="_top" title="">Kernel Principal Component Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=maximal_information_based_nonparametric_exploration" target="_top" title="- Maximal Information-based Nonparametric Exploration">MINE</a>
+<a href="https://usegalaxy.org/root?tool_id=Multivariate" target="_top" title="PCA, PLS and OPLS">Multivariate</a>
+<a href="https://usegalaxy.org/root?tool_id=nonparametric_rank_tests" target="_top" title="run rank-based tests on tabular data">Nonparametric rank tests</a>
+<a href="https://usegalaxy.org/root?tool_id=BestSubsetsRegression1" target="_top" title="">Perform Best-subsets Regression</a>
+<a href="https://usegalaxy.org/root?tool_id=lda_analy1" target="_top" title="Linear Discriminant Analysis">Perform LDA</a>
+<a href="https://usegalaxy.org/root?tool_id=LinearRegression1" target="_top" title="">Perform Linear Regression</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_landmark_registration" target="_top" title="">Perform affine image registration (landmark-based)</a>
+<a href="https://usegalaxy.org/root?tool_id=pca1" target="_top" title="">Principal Component Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=rgcca" target="_top" title="performs multiblock data analysis of several sets of variables (blocks) observed on the same group of individuals.">RGCCA</a>
+<a href="https://usegalaxy.org/root?tool_id=pandas_rolling_window" target="_top" title="over a dataframe (e.g. for data smoothing)">Rolling window</a>
+<a href="https://usegalaxy.org/root?tool_id=seq_composition" target="_top" title="Count bases or amino-acids">Sequence composition</a>
+<a href="https://usegalaxy.org/root?tool_id=scipy_sparse" target="_top" title="for manipulating 2-D Scipy sparse numeric data">Sparse Matrix Functions</a>
+<a href="https://usegalaxy.org/root?tool_id=Summary_Statistics1" target="_top" title="for any numerical column">Summary Statistics</a>
+<a href="https://usegalaxy.org/root?tool_id=t_test_two_samples" target="_top" title="">T Test for Two Samples</a>
+<a href="https://usegalaxy.org/root?tool_id=Transformation" target="_top" title="Transforms the dataMatrix intensity values">Transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=Univariate" target="_top" title="Univariate statistics">Univariate</a>
+<a href="https://usegalaxy.org/root?tool_id=dwt_var1" target="_top" title="using Discrete Wavelet Transfoms">Wavelet variance</a>
+<a href="https://usegalaxy.org/root?tool_id=rdeval" target="_top" title="Multithreaded read analysis and manipulation tool.">rdeval</a>
+<a href="https://usegalaxy.org/root?tool_id=rdeval_report" target="_top" title="Read summary and figures.">rdeval report</a>
+
+</div>
+
+### Machine Learning
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=keras_batch_models" target="_top" title="with online data generator for Genomic/Protein sequences and images">Build Deep learning Batch Training Models</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_regression_metrics" target="_top" title="for regression performance">Calculate metrics</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_clf_metrics" target="_top" title="for classification performance">Calculate metrics</a>
+<a href="https://usegalaxy.org/root?tool_id=keras_model_config" target="_top" title="using Keras">Create a deep learning model architecture</a>
+<a href="https://usegalaxy.org/root?tool_id=create_tool_recommendation_model" target="_top" title="using deep learning">Create a model to recommend tools</a>
+<a href="https://usegalaxy.org/root?tool_id=keras_model_builder" target="_top" title="with an optimizer, loss function and fit parameters">Create deep learning model</a>
+<a href="https://usegalaxy.org/root?tool_id=keras_train_and_eval" target="_top" title="conduct deep training and evaluation either implicitly or explicitly">Deep learning training and evaluation</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_discriminant_classifier" target="_top" title="">Discriminant Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_ensemble" target="_top" title="for classification and regression">Ensemble methods</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_estimator_attributes" target="_top" title="get important attributes from an estimator or scikit object">Estimator attributes</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_fitted_model_eval" target="_top" title="using a new batch of labeled data">Evaluate a Fitted Model</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_pairwise_metrics" target="_top" title="or compute affinity or kernel for sets of samples">Evaluate pairwise distances</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_feature_selection" target="_top" title="module, including univariate filter selection methods and recursive feature elimination algorithm">Feature Selection</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_model_fit" target="_top" title="or other models using a labeled dataset">Fit a Pipeline, Ensemble</a>
+<a href="https://usegalaxy.org/root?tool_id=flexynesis" target="_top" title="A deep-learning based multi-omics bulk sequencing data integration suite">Flexynesis</a>
+<a href="https://usegalaxy.org/root?tool_id=flexynesis_infer" target="_top" title="Run inference using a pretrained Flexynesis model">Flexynesis Inference</a>
+<a href="https://usegalaxy.org/root?tool_id=flexynesis_cbioportal_import" target="_top" title="and prepare cBioPortal data for Flexynesis analysis">Flexynesis cBioPortal import</a>
+<a href="https://usegalaxy.org/root?tool_id=flexynesis_plot" target="_top" title="tool for visualizing flexynesis results">Flexynesis plot</a>
+<a href="https://usegalaxy.org/root?tool_id=flexynesis_utils" target="_top" title="Utility functions for Flexynesis">Flexynesis utils</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_generalized_linear" target="_top" title="for classification and regression">Generalized linear models</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_sample_generator" target="_top" title="random samples with controlled size and complexity">Generate</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_config_generator" target="_top" title="builds a Ludwig machine learning configuration file for a dataset">Generic Learner Config Creator</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_evaluate" target="_top" title="loads a pretrained model and evaluates its performance by comparing its predictions with ground truth">Generic Learner Evaluate</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_experiment" target="_top" title="trains and evaluates a model">Generic Learner Experiment</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_hyperopt" target="_top" title="searches for optimal Hyperparameters">Generic Learner Hyperopt</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_predict" target="_top" title="loads a pretrained model to do prediction">Generic Learner Predict</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_render_config" target="_top" title="renders thefull config based on user input">Generic Learner Render Config</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_train" target="_top" title="trains a deep learning model">Generic Learner Train</a>
+<a href="https://usegalaxy.org/root?tool_id=ludwig_visualize" target="_top" title="analyzes results and shows in plots">Generic Learner Visualize</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_searchcv" target="_top" title="performs hyperparameter optimization using various SearchCVs">Hyperparameter Search</a>
+<a href="https://usegalaxy.org/root?tool_id=image_learner" target="_top" title="trains and evaluates an image classification/regression model">Image Learner</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_lightgbm" target="_top" title="- train and apply LightGBM models">LightGBM</a>
+<a href="https://usegalaxy.org/root?tool_id=model_prediction" target="_top" title="predicts on new data using a preffited model">Model Prediction</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_model_validation" target="_top" title="includes cross_validate, cross_val_predict, learning_curve, and more">Model Validation</a>
+<a href="https://usegalaxy.org/root?tool_id=multimodal_learner" target="_top" title="Train and evaluate an AutoGluon Multimodal model (tabular + image + text)">Multimodal Learner</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_nn_classifier" target="_top" title="">Nearest Neighbors Classification</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_numeric_clustering" target="_top" title="">Numeric Clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_build_pipeline" target="_top" title="an all-in-one platform to build pipeline, single estimator, preprocessor and custom wrappers">Pipeline Builder</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_data_preprocess" target="_top" title="raw feature vectors into standardized datasets">Preprocess</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_pca" target="_top" title="with scikit-learn">Principal component analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=pycaret_predict" target="_top" title="predicts/evaluates your pycaret ML model on a dataset.">PyCaret Predictor/Evaluator</a>
+<a href="https://usegalaxy.org/root?tool_id=scipy_sparse" target="_top" title="for manipulating 2-D Scipy sparse numeric data">Sparse Matrix Functions</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_train_test_split" target="_top" title="into training and test subsets">Split Dataset</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_stacking_ensemble_models" target="_top" title="builds stacking, voting ensemble models with numerous base options">Stacking Ensembles</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_svm_classifier" target="_top" title="for classification">Support vector machines (SVMs)</a>
+<a href="https://usegalaxy.org/root?tool_id=tabular_learner" target="_top" title="applies and evaluates multiple machine learning models on a tabular dataset">Tabular Learner</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_to_categorical" target="_top" title="Encodes labels to a one-hot encoded matrix and DNA sequences to one-hot and k-mer representations">To categorical</a>
+<a href="https://usegalaxy.org/root?tool_id=sklearn_train_test_eval" target="_top" title="fit a model using part of dataset and evaluate using the rest">Train, Test and Evaluation</a>
+<a href="https://usegalaxy.org/root?tool_id=chopin2" target="_top" title="Domain-Agnostic Supervised Learning with Hyperdimensional Computing">chopin2</a>
+
+</div>
+
+### Graph/Display Data
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=jvarkit_wgscoverageplotter" target="_top" title="Plot read coverage across a genomic contig">BAM Coverage Plotter</a>
+<a href="https://usegalaxy.org/root?tool_id=build_ucsc_custom_track_1" target="_top" title="for UCSC genome browser">Build custom track</a>
+<a href="https://usegalaxy.org/root?tool_id=circos" target="_top" title="visualizes data in a circular layout">Circos</a>
+<a href="https://usegalaxy.org/root?tool_id=circgraph" target="_top" title="creates circos plots from standard bioinformatics datatypes.">Circos Builder</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_aln_to_links" target="_top" title="reformats alignment files to prepare for Circos">Circos: Alignments to links</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_bundlelinks" target="_top" title="reduce numbers of links in datasets before plotting">Circos: Bundle Links</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_interval_to_text" target="_top" title="reformats interval files to prepare for Circos text labels">Circos: Interval to Circos Text Labels</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_interval_to_tile" target="_top" title="reformats interval files to prepare for Circos tile plots">Circos: Interval to Tiles</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_binlinks" target="_top" title="reduce links to a density plot">Circos: Link Density Track</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_resample" target="_top" title="reduce numbers of points in a dataset before plotting">Circos: Resample 1/2D data</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_wiggle_to_stacked" target="_top" title="reformats for use in Circos stacked histogram plots">Circos: Stack bigWigs as Histogram</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_tableviewer" target="_top" title="easily creates circos plots from tabular data">Circos: Table viewer</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_wiggle_to_scatter" target="_top" title="reformats bigWig files to prepare for Circos 2d scatter/line/histogram plots">Circos: bigWig to Scatter</a>
+<a href="https://usegalaxy.org/root?tool_id=export2graphlan" target="_top" title="">Export to GraPhlAn</a>
+<a href="https://usegalaxy.org/root?tool_id=circos_gc_skew" target="_top" title="calculates skew over genomic sequences">GC Skew</a>
+<a href="https://usegalaxy.org/root?tool_id=gmaj_1" target="_top" title="Multiple Alignment Viewer">GMAJ</a>
+<a href="https://usegalaxy.org/root?tool_id=graphlan_annotate" target="_top" title="for GraPhlAn">Generation, personalization and annotation of tree</a>
+<a href="https://usegalaxy.org/root?tool_id=graphlan" target="_top" title="to produce graphical output of an input tree">GraPhlAn</a>
+<a href="https://usegalaxy.org/root?tool_id=ggplot2_heatmap" target="_top" title="">Heatmap w ggplot</a>
+<a href="https://usegalaxy.org/root?tool_id=histogram_rpy" target="_top" title="of a numeric column">Histogram</a>
+<a href="https://usegalaxy.org/root?tool_id=ggplot2_histogram" target="_top" title="">Histogram with ggplot2</a>
+<a href="https://usegalaxy.org/root?tool_id=jbrowse" target="_top" title="genome browser">JBrowse</a>
+<a href="https://usegalaxy.org/root?tool_id=jbrowse_to_standalone" target="_top" title="upgrades the bare data directory to a full JBrowse instance">JBrowse - Data Directory to Standalone</a>
+<a href="https://usegalaxy.org/root?tool_id=jbrowse2" target="_top" title="genome browser">JBrowse2</a>
+<a href="https://usegalaxy.org/root?tool_id=taxonomy_krona_chart" target="_top" title="from taxonomic profile">Krona pie chart</a>
+<a href="https://usegalaxy.org/root?tool_id=mummerplot_wrapper" target="_top" title="Combine mummer/nucmer/promer with mummerplot">MUMmer dotplot</a>
+<a href="https://usegalaxy.org/root?tool_id=ml_visualization_ex" target="_top" title="includes several types of plotting for machine learning">Machine Learning Visualization Extension</a>
+<a href="https://usegalaxy.org/root?tool_id=newick_display" target="_top" title="visualize a phylogenetic tree">Newick Display</a>
+<a href="https://usegalaxy.org/root?tool_id=ggplot2_pca" target="_top" title="">PCA plot w ggplot2</a>
+<a href="https://usegalaxy.org/root?tool_id=intervene_pairwise" target="_top" title="and heatmap for genomic intervals">Pairwise intersection</a>
+<a href="https://usegalaxy.org/root?tool_id=plotly_parallel_coordinates_plot" target="_top" title="of tabular data">Parallel Coordinates Plot</a>
+<a href="https://usegalaxy.org/root?tool_id=pathview" target="_top" title="for pathway based data integration and visualization">Pathview</a>
+<a href="https://usegalaxy.org/root?tool_id=plotly_regression_performance_plots" target="_top" title="of tabular data">Plot actual vs predicted curves and residual plots</a>
+<a href="https://usegalaxy.org/root?tool_id=plotly_ml_performance_plots" target="_top" title="of tabular data">Plot confusion matrix, precision, recall and ROC and AUC curves</a>
+<a href="https://usegalaxy.org/root?tool_id=XY_Plot_1" target="_top" title="for multiple series and graph types">Plotting tool</a>
+<a href="https://usegalaxy.org/root?tool_id=scatterplot_rpy" target="_top" title="of two numeric columns">Scatterplot</a>
+<a href="https://usegalaxy.org/root?tool_id=ggplot2_point" target="_top" title="">Scatterplot with ggplot2</a>
+<a href="https://usegalaxy.org/root?tool_id=intervene_upset" target="_top" title="of intersection of genomic regions or list sets">UpSet diagram</a>
+<a href="https://usegalaxy.org/root?tool_id=vcf_to_maf_customtrack1" target="_top" title="for display at UCSC">VCF to MAF Custom Track</a>
+<a href="https://usegalaxy.org/root?tool_id=venn_list" target="_top" title="from lists">Venn Diagram</a>
+<a href="https://usegalaxy.org/root?tool_id=ggplot2_violin" target="_top" title="">Violin plot w ggplot2</a>
+<a href="https://usegalaxy.org/root?tool_id=krona-text" target="_top" title="Visualise any hierarchical data">Visualize  with Krona</a>
+<a href="https://usegalaxy.org/root?tool_id=volcanoplot" target="_top" title="create a volcano plot">Volcano Plot</a>
+<a href="https://usegalaxy.org/root?tool_id=autogenjb2" target="_top" title="Track collection to JBrowse2">autogenjb2</a>
+<a href="https://usegalaxy.org/root?tool_id=ggplot2_heatmap2" target="_top" title="">heatmap2</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicplottads" target="_top" title="plot Hi-C contact matrices heatmaps alongside other data tracks">hicPlotTADs</a>
+<a href="https://usegalaxy.org/root?tool_id=pygenomeTracks" target="_top" title="plot genomic data tracks">pyGenomeTracks</a>
+<a href="https://usegalaxy.org/root?tool_id=tsne" target="_top" title="">rtsne</a>
+
+</div>
+
+### Interactive Tools
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_chat_analysis" target="_top" title="Interactively chats using natural language to explore, visualize, and analyze your data">Data Analysis Agent</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_blobtoolkit" target="_top" title="genome assembly QC viewer">Interactive BlobToolKit</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_jupyter_notebook" target="_top" title="">Interactive JupyterLab Notebook</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_panoply" target="_top" title="interative plotting tool for geo-referenced data">Panoply</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_pavian" target="_top" title="Interactive analysis of metagenomics data">Pavian</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_phinch" target="_top" title="">Phinch Visualisation</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_phyloseq" target="_top" title="Explore microbiome profiles">Phyloseq</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_pcstudio" target="_top" title="Interactive tool to create, simulate, and visualize a multicellular model using PhysiCell">PhysiCell Studio</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_qiskit_jupyter_notebook" target="_top" title="interactive tool">Qiskit Jupyter notebook</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_qupath" target="_top" title="interactive Open Software for Bioimage Analysis">QuPath</a>
+<a href="https://usegalaxy.org/root?tool_id=interactive_tool_rstudio_bioconductor" target="_top" title="R 4.6 with Bioconductor 3.23">RStudio</a>
+
+</div>
+
+---
+
+## Genomics Toolkits
+
+
+### STR-FM: Microsatellite Analysis
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=microsatcompat" target="_top" title="">Check STR motif compatibility between reference and read STRs</a>
+<a href="https://usegalaxy.org/root?tool_id=PEsortedSAM2readprofile" target="_top" title="and get the reference STR allele from the reference genome">Combine mapped faux paired-end reads</a>
+<a href="https://usegalaxy.org/root?tool_id=combineproballelecom" target="_top" title="from the same allele combination">Combine read profile probabilities </a>
+<a href="https://usegalaxy.org/root?tool_id=readdepth2seqdepth" target="_top" title="for flank-based mapping of microsatellites">Convert informative read depth to sequencing depth</a>
+<a href="https://usegalaxy.org/root?tool_id=GenotypeSTR" target="_top" title="that occur during sequencing and library prep">Correct genotype for STR errors</a>
+<a href="https://usegalaxy.org/root?tool_id=heteroprob" target="_top" title="">Evaluate the probability of the allele combination to generate read profile</a>
+<a href="https://usegalaxy.org/root?tool_id=fetchflank" target="_top" title="the STRs in the reads and output two fastq files in forward-forward orientation">Fetch bases flanking</a>
+<a href="https://usegalaxy.org/root?tool_id=Profilegenerator" target="_top" title="of the consecutive allele from given error profile">Generate all possible combination of STR length profile</a>
+<a href="https://usegalaxy.org/root?tool_id=space2underscore_readname" target="_top" title="--change space to underscore in the read name column">Read name modifier</a>
+<a href="https://usegalaxy.org/root?tool_id=microsatellite" target="_top" title="for short read, reference, and mapped data">STR detection</a>
+<a href="https://usegalaxy.org/root?tool_id=microsatpurity" target="_top" title="of a specific column">Select uninterrupted STRs</a>
+
+</div>
+
+### Mothur
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=mothur_align_check" target="_top" title="Calculate the number of potentially misaligned bases">Align.check</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_align_seqs" target="_top" title="Align sequences to a template alignment">Align.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_amova" target="_top" title="Analysis of molecular variance">Amova</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_anosim" target="_top" title="Non-parametric multivariate analysis of changes in community structure">Anosim</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_bin_seqs" target="_top" title="Order Sequences by OTU">Bin.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_biom_info" target="_top" title="create shared and taxonomy files from biom">Biom.info</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_bellerophon" target="_top" title="Find putative chimeras using bellerophon">Chimera.bellerophon</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_ccode" target="_top" title="Find putative chimeras using ccode">Chimera.ccode</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_check" target="_top" title="Find putative chimeras using chimeraCheck">Chimera.check</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_perseus" target="_top" title="Find putative chimeras using chimeraCheck">Chimera.perseus</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_pintail" target="_top" title="Find putative chimeras using pintail">Chimera.pintail</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_slayer" target="_top" title="Find putative chimeras using slayer">Chimera.slayer</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_uchime" target="_top" title="Find putative chimeras using uchime">Chimera.uchime</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chimera_vsearch" target="_top" title="find potential chimeric sequences using vsearch">Chimera.vsearch</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_chop_seqs" target="_top" title="Trim sequences to a specified length">Chop.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_classify_otu" target="_top" title="Assign sequences to taxonomy">Classify.otu</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_classify_rf" target="_top" title="description">Classify.rf</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_classify_seqs" target="_top" title="Assign sequences to taxonomy">Classify.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_classify_tree" target="_top" title="Get a consensus taxonomy for each node on a tree">Classify.tree</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_clearcut" target="_top" title="Generate a tree using relaxed neighbor joining">Clearcut</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_cluster" target="_top" title="Assign sequences to OTUs (Operational Taxonomic Unit)">Cluster</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_cluster_classic" target="_top" title="Assign sequences to OTUs (Dotur implementation)">Cluster.classic</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_cluster_fragments" target="_top" title="Group sequences that are part of a larger sequence">Cluster.fragments</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_cluster_split" target="_top" title="Assign sequences to OTUs and split large matrices">Cluster.split</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_collect_shared" target="_top" title="Generate collector&#x27;s curves for calculators on OTUs">Collect.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_collect_single" target="_top" title="Generate collector&#x27;s curves for OTUs">Collect.single</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_consensus_seqs" target="_top" title="Find a consensus sequence for each OTU or phylotype">Consensus.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_cooccurrence" target="_top" title="tests whether presence-absence patterns differ from chance">Cooccurrence</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_corr_axes" target="_top" title="correlation of data to axes">Corr.axes</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_count_groups" target="_top" title="counts the number of sequences represented by a specific group or set of groups">Count.groups</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_count_seqs" target="_top" title="(aka make.table) counts the number of sequences represented by the representative">Count.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_create_database" target="_top" title="creates a database file from a list, repnames, repfasta and contaxonomy file">Create.database</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_degap_seqs" target="_top" title="Remove gap characters from sequences">Degap.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_deunique_seqs" target="_top" title="Return all sequences">Deunique.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_deunique_tree" target="_top" title="Reinsert the redundant sequence identiers back into a unique tree.">Deunique.tree</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_dist_seqs" target="_top" title="calculate uncorrected pairwise distances between aligned sequences">Dist.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_dist_shared" target="_top" title="Generate a phylip-formatted dissimilarity distance matrix among multiple groups">Dist.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_fastq_info" target="_top" title="Convert fastq to fasta and quality">Fastq.info</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_filter_seqs" target="_top" title="removes columns from alignments">Filter.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_filter_shared" target="_top" title="remove OTUs based on various critieria">Filter.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_communitytype" target="_top" title="description">Get.communitytype</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_coremicrobiome" target="_top" title="fraction of OTUs for samples or abundances">Get.coremicrobiome</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_dists" target="_top" title="selects distances from a phylip or column file">Get.dists</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_group" target="_top" title="group names from shared or from list and group">Get.group</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_groups" target="_top" title="Select groups">Get.groups</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_label" target="_top" title="label names from list, sabund, or rabund file">Get.label</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_lineage" target="_top" title="Picks by taxon">Get.lineage</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_mimarkspackage" target="_top" title="creates a mimarks package form with your groups">Get.mimarkspackage</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_otulabels" target="_top" title="Selects OTU labels">Get.otulabels</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_otulist" target="_top" title="Get otus for each distance in a otu list">Get.otulist</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_oturep" target="_top" title="Generate a fasta with a representative sequence for each OTU">Get.oturep</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_otus" target="_top" title="Get otus containing sequences from specified groups">Get.otus</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_rabund" target="_top" title="Get rabund from a otu list or sabund">Get.rabund</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_relabund" target="_top" title="Calculate the relative abundance of each otu">Get.relabund</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_sabund" target="_top" title="Get sabund from a otu list or rabund">Get.sabund</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_seqs" target="_top" title="Picks sequences by name">Get.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_get_sharedseqs" target="_top" title="Get shared sequences at each distance from list and group">Get.sharedseqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_hcluster" target="_top" title="Assign sequences to OTUs (Operational Taxonomic Unit)">Hcluster</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_heatmap_bin" target="_top" title="Generate a heatmap for OTUs">Heatmap.bin</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_heatmap_sim" target="_top" title="Generate a heatmap for pariwise similarity">Heatmap.sim</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_homova" target="_top" title="Homogeneity of molecular variance">Homova</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_indicator" target="_top" title="Identify indicator &quot;species&quot; for nodes on a tree">Indicator</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_lefse" target="_top" title="description">Lefse</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_libshuff" target="_top" title="Cramer-von Mises tests communities for the same structure">Libshuff</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_list_otulabels" target="_top" title="Lists otu labels from shared or relabund file">List.otulabels</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_list_seqs" target="_top" title="Lists the names (accnos) of the sequences">List.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_design" target="_top" title="Assign groups to Sets">Make Design</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_biom" target="_top" title="Make biom files from a shared file">Make.biom</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_contigs" target="_top" title="Aligns paired forward and reverse fastq files to contigs as fasta and quality">Make.contigs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_fastq" target="_top" title="Convert fasta and quality to fastq">Make.fastq</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_group" target="_top" title="Make a group file">Make.group</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_lefse" target="_top" title="create a lefse formatted input file from mothur&#x27;s output files">Make.lefse</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_lookup" target="_top" title="allows you to create custom lookup files for use with shhh.flows">Make.lookup</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_shared" target="_top" title="Make a shared file from a list and a group">Make.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_make_sra" target="_top" title="creates the necessary files for a NCBI submission">Make.sra</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_mantel" target="_top" title="Mantel correlation coefficient between two matrices.">Mantel</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_merge_count" target="_top" title="Merge count tables">Merge.count</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_merge_files" target="_top" title="Merge data">Merge.files</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_merge_groups" target="_top" title="Merge groups in a shared file">Merge.groups</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_merge_sfffiles" target="_top" title="Merge SFF files">Merge.sfffiles</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_merge_taxsummary" target="_top" title="Merge tax.summary files">Merge.taxsummary</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_metastats" target="_top" title="generate principle components plot data">Metastats</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_mimarks_attributes" target="_top" title="Reads bioSample Attributes xml and generates source for get.mimarkspackage command">Mimarks.attributes</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_nmds" target="_top" title="generate non-metric multidimensional scaling data">Nmds</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_normalize_shared" target="_top" title="Normalize the number of sequences per group to a specified level">Normalize.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_otu_association" target="_top" title="Calculate the correlation coefficient for the otus">Otu.association</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_otu_hierarchy" target="_top" title="Relate OTUs at different distances">Otu.hierarchy</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_pairwise_seqs" target="_top" title="calculate uncorrected pairwise distances between sequences">Pairwise.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_parse_list" target="_top" title="Generate a List file for each group">Parse.list</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_parsimony" target="_top" title="Describes whether two or more communities have the same structure">Parsimony</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_pca" target="_top" title="Principal Coordinate Analysis for a shared file">Pca</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_pcoa" target="_top" title="Principal Coordinate Analysis for a distance matrix">Pcoa</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_pcr_seqs" target="_top" title="Trim sequences">Pcr.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_phylo_diversity" target="_top" title="Alpha Diversity calculates unique branch length">Phylo.diversity</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_phylotype" target="_top" title="Assign sequences to OTUs based on taxonomy">Phylotype</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_pre_cluster" target="_top" title="Remove sequences due to pyrosequencing errors">Pre.cluster</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_primer_design" target="_top" title="identify sequence fragments that are specific to particular OTUs">Primer.design</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_rarefaction_shared" target="_top" title="Generate inter-sample rarefaction curves for OTUs">Rarefaction.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_rarefaction_single" target="_top" title="Generate intra-sample rarefaction curves for OTUs">Rarefaction.single</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_remove_dists" target="_top" title="Removes distances from a phylip or column file">Remove.dists</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_remove_groups" target="_top" title="Remove groups from groups,fasta,names,list,taxonomy">Remove.groups</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_remove_lineage" target="_top" title="Picks by taxon">Remove.lineage</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_remove_otulabels" target="_top" title="Removes OTU labels">Remove.otulabels</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_remove_otus" target="_top" title="Removes OTUs from various file formats">Remove.otus</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_remove_rare" target="_top" title="Remove rare OTUs">Remove.rare</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_remove_seqs" target="_top" title="Remove sequences by name">Remove.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_rename_seqs" target="_top" title="Rename sequences by concatenating the group name">Rename.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_reverse_seqs" target="_top" title="Reverse complement the sequences">Reverse.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_screen_seqs" target="_top" title="Screen sequences">Screen.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_sens_spec" target="_top" title="Determine the quality of OTU assignment">Sens.spec</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_seq_error" target="_top" title="assess error rates in sequencing data">Seq.error</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_sffinfo" target="_top" title="Summarize the quality of sequences">Sffinfo</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_shhh_flows" target="_top" title="Denoise flowgrams (PyroNoise algorithm)">Shhh.flows</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_shhh_seqs" target="_top" title="Denoise program (Quince SeqNoise)">Shhh.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_sort_seqs" target="_top" title="put sequences in different files in the same order">Sort.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_split_abund" target="_top" title="Separate sequences into rare and abundant groups">Split.abund</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_split_groups" target="_top" title="Generates a fasta file for each group">Split.groups</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_sub_sample" target="_top" title="Create a sub sample">Sub.sample</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_summary_qual" target="_top" title="Summarize the quality scores">Summary.qual</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_summary_seqs" target="_top" title="Summarize the quality of sequences">Summary.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_summary_shared" target="_top" title="Summary of calculator values for OTUs">Summary.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_summary_single" target="_top" title="Summary of calculator values for OTUs">Summary.single</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_summary_tax" target="_top" title="Assign sequences to taxonomy">Summary.tax</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_taxonomy_to_krona" target="_top" title="convert a mothur taxonomy file to Krona input format">Taxonomy-to-Krona</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_tree_shared" target="_top" title="Generate a newick tree for dissimilarity among groups">Tree.shared</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_trim_flows" target="_top" title="partition by barcode, trim to length, cull by length and mismatches">Trim.flows</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_trim_seqs" target="_top" title="Trim sequences - primers, barcodes, quality">Trim.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_unique_seqs" target="_top" title="Return unique sequences">Unique.seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_venn" target="_top" title="Generate Venn diagrams for groups">Venn</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_unifrac_unweighted" target="_top" title="Describes whether two or more communities have the same structure">unifrac.unweighted</a>
+<a href="https://usegalaxy.org/root?tool_id=mothur_unifrac_weighted" target="_top" title="Describes whether two or more communities have the same structure">unifrac.weighted</a>
+
+</div>
+
+### QIIME2
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=qiime2__alignment__mafft" target="_top" title="De novo multiple sequence alignment with MAFFT">qiime2 alignment mafft</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__alignment__mafft_add" target="_top" title="Add sequences to multiple sequence alignment with MAFFT.">qiime2 alignment mafft-add</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__alignment__mask" target="_top" title="Positional conservation and gap filtering.">qiime2 alignment mask</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__composition__add_pseudocount" target="_top" title="Add pseudocount to table.">qiime2 composition add-pseudocount</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__composition__ancom" target="_top" title="Apply ANCOM to identify features that differ in abundance.">qiime2 composition ancom</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__composition__ancombc" target="_top" title="Analysis of Composition of Microbiomes with Bias Correction">qiime2 composition ancombc</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__composition__tabulate" target="_top" title="View tabular output from ANCOM-BC or ANCOM-BC2.">qiime2 composition tabulate</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__cutadapt__demux_paired" target="_top" title="Demultiplex paired-end sequence data with barcodes in-sequence.">qiime2 cutadapt demux-paired</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__cutadapt__demux_single" target="_top" title="Demultiplex single-end sequence data with barcodes in-sequence.">qiime2 cutadapt demux-single</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__cutadapt__trim_paired" target="_top" title="Find and remove adapters in demultiplexed paired-end sequences.">qiime2 cutadapt trim-paired</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__cutadapt__trim_single" target="_top" title="Find and remove adapters in demultiplexed single-end sequences.">qiime2 cutadapt trim-single</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__dada2__denoise_ccs" target="_top" title="Denoise and dereplicate single-end Pacbio CCS">qiime2 dada2 denoise-ccs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__dada2__denoise_paired" target="_top" title="Denoise and dereplicate paired-end sequences">qiime2 dada2 denoise-paired</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__dada2__denoise_pyro" target="_top" title="Denoise and dereplicate single-end pyrosequences">qiime2 dada2 denoise-pyro</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__dada2__denoise_single" target="_top" title="Denoise and dereplicate single-end sequences">qiime2 dada2 denoise-single</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__deblur__denoise_16S" target="_top" title="Deblur sequences using a 16S positive filter.">qiime2 deblur denoise-16S</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__deblur__denoise_other" target="_top" title="Deblur sequences using a user-specified positive filter.">qiime2 deblur denoise-other</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__deblur__visualize_stats" target="_top" title="Visualize Deblur stats per sample.">qiime2 deblur visualize-stats</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__demux__emp_paired" target="_top" title="Demultiplex paired-end sequence data generated with the EMP protocol.">qiime2 demux emp-paired</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__demux__emp_single" target="_top" title="Demultiplex sequence data generated with the EMP protocol.">qiime2 demux emp-single</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__demux__filter_samples" target="_top" title="Filter samples out of demultiplexed data.">qiime2 demux filter-samples</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__demux__subsample_paired" target="_top" title="Subsample paired-end sequences without replacement.">qiime2 demux subsample-paired</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__demux__subsample_single" target="_top" title="Subsample single-end sequences without replacement.">qiime2 demux subsample-single</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__demux__summarize" target="_top" title="Summarize counts per sample.">qiime2 demux summarize</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__adonis" target="_top" title="adonis PERMANOVA test for beta group significance">qiime2 diversity adonis</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__alpha" target="_top" title="Alpha diversity">qiime2 diversity alpha</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__alpha_correlation" target="_top" title="Alpha diversity correlation">qiime2 diversity alpha-correlation</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__alpha_group_significance" target="_top" title="Alpha diversity comparisons">qiime2 diversity alpha-group-significance</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__alpha_phylogenetic" target="_top" title="Alpha diversity (phylogenetic)">qiime2 diversity alpha-phylogenetic</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__alpha_rarefaction" target="_top" title="Alpha rarefaction curves">qiime2 diversity alpha-rarefaction</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__beta" target="_top" title="Beta diversity">qiime2 diversity beta</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__beta_correlation" target="_top" title="Beta diversity correlation">qiime2 diversity beta-correlation</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__beta_group_significance" target="_top" title="Beta diversity group significance">qiime2 diversity beta-group-significance</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__beta_phylogenetic" target="_top" title="Beta diversity (phylogenetic)">qiime2 diversity beta-phylogenetic</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__beta_rarefaction" target="_top" title="Beta diversity rarefaction">qiime2 diversity beta-rarefaction</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__bioenv" target="_top" title="bioenv">qiime2 diversity bioenv</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__core_metrics" target="_top" title="Core diversity metrics (non-phylogenetic)">qiime2 diversity core-metrics</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__core_metrics_phylogenetic" target="_top" title="Core diversity metrics (phylogenetic and non-phylogenetic)">qiime2 diversity core-metrics-phylogenetic</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__filter_distance_matrix" target="_top" title="Filter samples from a distance matrix.">qiime2 diversity filter-distance-matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__mantel" target="_top" title="Apply the Mantel test to two distance matrices">qiime2 diversity mantel</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__pcoa" target="_top" title="Principal Coordinate Analysis">qiime2 diversity pcoa</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__pcoa_biplot" target="_top" title="Principal Coordinate Analysis Biplot">qiime2 diversity pcoa-biplot</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__procrustes_analysis" target="_top" title="Procrustes Analysis">qiime2 diversity procrustes-analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__tsne" target="_top" title="t-distributed stochastic neighbor embedding">qiime2 diversity tsne</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity__umap" target="_top" title="Uniform Manifold Approximation and Projection">qiime2 diversity umap</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__alpha_passthrough" target="_top" title="Alpha Passthrough (non-phylogenetic)">qiime2 diversity-lib alpha-passthrough</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__beta_passthrough" target="_top" title="Beta Passthrough (non-phylogenetic)">qiime2 diversity-lib beta-passthrough</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__beta_phylogenetic_meta_passthrough" target="_top" title="Beta Phylogenetic Meta Passthrough">qiime2 diversity-lib beta-phylogenetic-meta-passthrough</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__beta_phylogenetic_passthrough" target="_top" title="Beta Phylogenetic Passthrough">qiime2 diversity-lib beta-phylogenetic-passthrough</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__bray_curtis" target="_top" title="Bray-Curtis Dissimilarity">qiime2 diversity-lib bray-curtis</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__faith_pd" target="_top" title="Faith&#x27;s Phylogenetic Diversity">qiime2 diversity-lib faith-pd</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__jaccard" target="_top" title="Jaccard Distance">qiime2 diversity-lib jaccard</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__observed_features" target="_top" title="Observed Features">qiime2 diversity-lib observed-features</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__pielou_evenness" target="_top" title="Pielou&#x27;s Evenness">qiime2 diversity-lib pielou-evenness</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__shannon_entropy" target="_top" title="Shannon&#x27;s Entropy">qiime2 diversity-lib shannon-entropy</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__unweighted_unifrac" target="_top" title="Unweighted Unifrac">qiime2 diversity-lib unweighted-unifrac</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__diversity_lib__weighted_unifrac" target="_top" title="Weighted Unifrac">qiime2 diversity-lib weighted-unifrac</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__emperor__biplot" target="_top" title="Visualize and Interact with Principal Coordinates Analysis Biplot">qiime2 emperor biplot</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__emperor__plot" target="_top" title="Visualize and Interact with Principal Coordinates Analysis Plots">qiime2 emperor plot</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__emperor__procrustes_plot" target="_top" title="Visualize and Interact with a procrustes plot">qiime2 emperor procrustes-plot</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__blast" target="_top" title="BLAST+ local alignment search.">qiime2 feature-classifier blast</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__classify_consensus_blast" target="_top" title="BLAST+ consensus taxonomy classifier">qiime2 feature-classifier classify-consensus-blast</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__classify_consensus_vsearch" target="_top" title="VSEARCH-based consensus taxonomy classifier">qiime2 feature-classifier classify-consensus-vsearch</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__classify_hybrid_vsearch_sklearn" target="_top" title="ALPHA Hybrid classifier: VSEARCH exact match + sklearn classifier">qiime2 feature-classifier classify-hybrid-vsearch-sklearn</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__classify_sklearn" target="_top" title="Pre-fitted sklearn-based taxonomy classifier">qiime2 feature-classifier classify-sklearn</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__extract_reads" target="_top" title="Extract reads from reference sequences.">qiime2 feature-classifier extract-reads</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__find_consensus_annotation" target="_top" title="Find consensus among multiple annotations.">qiime2 feature-classifier find-consensus-annotation</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__fit_classifier_naive_bayes" target="_top" title="Train the naive_bayes classifier">qiime2 feature-classifier fit-classifier-naive-bayes</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__fit_classifier_sklearn" target="_top" title="Train an almost arbitrary scikit-learn classifier">qiime2 feature-classifier fit-classifier-sklearn</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_classifier__vsearch_global" target="_top" title="VSEARCH global alignment search">qiime2 feature-classifier vsearch-global</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__core_features" target="_top" title="Identify core features in table">qiime2 feature-table core-features</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__filter_features" target="_top" title="Filter features from table">qiime2 feature-table filter-features</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__filter_features_conditionally" target="_top" title="Filter features from a table based on abundance and prevalence">qiime2 feature-table filter-features-conditionally</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__filter_samples" target="_top" title="Filter samples from table">qiime2 feature-table filter-samples</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__filter_seqs" target="_top" title="Filter features from sequences">qiime2 feature-table filter-seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__group" target="_top" title="Group samples or features by a metadata column">qiime2 feature-table group</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__heatmap" target="_top" title="Generate a heatmap representation of a feature table">qiime2 feature-table heatmap</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__merge" target="_top" title="Combine multiple tables">qiime2 feature-table merge</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__merge_seqs" target="_top" title="Combine collections of feature sequences">qiime2 feature-table merge-seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__merge_taxa" target="_top" title="Combine collections of feature taxonomies">qiime2 feature-table merge-taxa</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__presence_absence" target="_top" title="Convert to presence/absence">qiime2 feature-table presence-absence</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__rarefy" target="_top" title="Rarefy table">qiime2 feature-table rarefy</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__relative_frequency" target="_top" title="Convert to relative frequencies">qiime2 feature-table relative-frequency</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__rename_ids" target="_top" title="Renames sample or feature ids in a table">qiime2 feature-table rename-ids</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__subsample" target="_top" title="Subsample table">qiime2 feature-table subsample</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__summarize" target="_top" title="Summarize table">qiime2 feature-table summarize</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__tabulate_seqs" target="_top" title="View sequence associated with each feature">qiime2 feature-table tabulate-seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__feature_table__transpose" target="_top" title="Transpose a feature table.">qiime2 feature-table transpose</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__fragment_insertion__classify_otus_experimental" target="_top" title="Experimental: Obtain taxonomic lineages, by finding closest OTU in reference phylogeny.">qiime2 fragment-insertion classify-otus-experimental</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__fragment_insertion__filter_features" target="_top" title="Filter fragments in tree from table.">qiime2 fragment-insertion filter-features</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__fragment_insertion__sepp" target="_top" title="Insert fragment sequences using SEPP into reference phylogenies.">qiime2 fragment-insertion sepp</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__assign_ids" target="_top" title="Assigns ids on internal nodes in the tree, and makes sure that they are consistent with the table columns.">qiime2 gneiss assign-ids</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__correlation_clustering" target="_top" title="Hierarchical clustering using feature correlation.">qiime2 gneiss correlation-clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__dendrogram_heatmap" target="_top" title="Dendrogram heatmap.">qiime2 gneiss dendrogram-heatmap</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__gradient_clustering" target="_top" title="Hierarchical clustering using gradient information.">qiime2 gneiss gradient-clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__ilr_hierarchical" target="_top" title="Isometric Log-ratio Transform applied to a hierarchical clustering">qiime2 gneiss ilr-hierarchical</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__ilr_phylogenetic" target="_top" title="Isometric Log-ratio Transform applied to a phylogenetic tree">qiime2 gneiss ilr-phylogenetic</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__ilr_phylogenetic_differential" target="_top" title="Differentially abundant Phylogenetic Log Ratios.">qiime2 gneiss ilr-phylogenetic-differential</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__gneiss__ilr_phylogenetic_ordination" target="_top" title="Ordination through a phylogenetic Isometric Log Ratio transform.">qiime2 gneiss ilr-phylogenetic-ordination</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__anova" target="_top" title="ANOVA test">qiime2 longitudinal anova</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__feature_volatility" target="_top" title="Feature volatility analysis">qiime2 longitudinal feature-volatility</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__first_differences" target="_top" title="Compute first differences or difference from baseline between sequential states">qiime2 longitudinal first-differences</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__first_distances" target="_top" title="Compute first distances or distance from baseline between sequential states">qiime2 longitudinal first-distances</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__linear_mixed_effects" target="_top" title="Linear mixed effects modeling">qiime2 longitudinal linear-mixed-effects</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__maturity_index" target="_top" title="Microbial maturity index prediction.">qiime2 longitudinal maturity-index</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__nmit" target="_top" title="Nonparametric microbial interdependence test">qiime2 longitudinal nmit</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__pairwise_differences" target="_top" title="Paired difference testing and boxplots">qiime2 longitudinal pairwise-differences</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__pairwise_distances" target="_top" title="Paired pairwise distance testing and boxplots">qiime2 longitudinal pairwise-distances</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__plot_feature_volatility" target="_top" title="Plot longitudinal feature volatility and importances">qiime2 longitudinal plot-feature-volatility</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__longitudinal__volatility" target="_top" title="Generate interactive volatility plot">qiime2 longitudinal volatility</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__metadata__distance_matrix" target="_top" title="Create a distance matrix from a numeric Metadata column">qiime2 metadata distance-matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__metadata__shuffle_groups" target="_top" title="Shuffle values in a categorical sample metadata column.">qiime2 metadata shuffle-groups</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__metadata__tabulate" target="_top" title="Interactively explore Metadata in an HTML table">qiime2 metadata tabulate</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__align_to_tree_mafft_fasttree" target="_top" title="Build a phylogenetic tree using fasttree and mafft alignment">qiime2 phylogeny align-to-tree-mafft-fasttree</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__align_to_tree_mafft_iqtree" target="_top" title="Build a phylogenetic tree using iqtree and mafft alignment.">qiime2 phylogeny align-to-tree-mafft-iqtree</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__align_to_tree_mafft_raxml" target="_top" title="Build a phylogenetic tree using raxml and mafft alignment.">qiime2 phylogeny align-to-tree-mafft-raxml</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__fasttree" target="_top" title="Construct a phylogenetic tree with FastTree.">qiime2 phylogeny fasttree</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__filter_table" target="_top" title="Remove features from table if they&#x27;re not present in tree.">qiime2 phylogeny filter-table</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__filter_tree" target="_top" title="Remove features from tree based on metadata">qiime2 phylogeny filter-tree</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__iqtree" target="_top" title="Construct a phylogenetic tree with IQ-TREE.">qiime2 phylogeny iqtree</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__iqtree_ultrafast_bootstrap" target="_top" title="Construct a phylogenetic tree with IQ-TREE with bootstrap supports.">qiime2 phylogeny iqtree-ultrafast-bootstrap</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__midpoint_root" target="_top" title="Midpoint root an unrooted phylogenetic tree.">qiime2 phylogeny midpoint-root</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__raxml" target="_top" title="Construct a phylogenetic tree with RAxML.">qiime2 phylogeny raxml</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__raxml_rapid_bootstrap" target="_top" title="Construct a phylogenetic tree with bootstrap supports using RAxML.">qiime2 phylogeny raxml-rapid-bootstrap</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__phylogeny__robinson_foulds" target="_top" title="Calculate Robinson-Foulds distance between phylogenetic trees.">qiime2 phylogeny robinson-foulds</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__quality_control__bowtie2_build" target="_top" title="Build bowtie2 index from reference sequences.">qiime2 quality-control bowtie2-build</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__quality_control__evaluate_composition" target="_top" title="Evaluate expected vs. observed taxonomic composition of samples">qiime2 quality-control evaluate-composition</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__quality_control__evaluate_seqs" target="_top" title="Compare query (observed) vs. reference (expected) sequences.">qiime2 quality-control evaluate-seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__quality_control__evaluate_taxonomy" target="_top" title="Evaluate expected vs. observed taxonomic assignments">qiime2 quality-control evaluate-taxonomy</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__quality_control__exclude_seqs" target="_top" title="Exclude sequences by alignment">qiime2 quality-control exclude-seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__quality_control__filter_reads" target="_top" title="Filter demultiplexed sequences by alignment to reference database.">qiime2 quality-control filter-reads</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__quality_filter__q_score" target="_top" title="Quality filter based on sequence quality scores.">qiime2 quality-filter q-score</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__classify_samples" target="_top" title="Train and test a cross-validated supervised learning classifier.">qiime2 sample-classifier classify-samples</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__classify_samples_from_dist" target="_top" title="Run k-nearest-neighbors on a labeled distance matrix.">qiime2 sample-classifier classify-samples-from-dist</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__classify_samples_ncv" target="_top" title="Nested cross-validated supervised learning classifier.">qiime2 sample-classifier classify-samples-ncv</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__confusion_matrix" target="_top" title="Make a confusion matrix from sample classifier predictions.">qiime2 sample-classifier confusion-matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__fit_classifier" target="_top" title="Fit a supervised learning classifier.">qiime2 sample-classifier fit-classifier</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__fit_regressor" target="_top" title="Fit a supervised learning regressor.">qiime2 sample-classifier fit-regressor</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__heatmap" target="_top" title="Generate heatmap of important features.">qiime2 sample-classifier heatmap</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__metatable" target="_top" title="Convert (and merge) positive numeric metadata (in)to feature table.">qiime2 sample-classifier metatable</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__predict_classification" target="_top" title="Use trained classifier to predict target values for new samples.">qiime2 sample-classifier predict-classification</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__predict_regression" target="_top" title="Use trained regressor to predict target values for new samples.">qiime2 sample-classifier predict-regression</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__regress_samples" target="_top" title="Train and test a cross-validated supervised learning regressor.">qiime2 sample-classifier regress-samples</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__regress_samples_ncv" target="_top" title="Nested cross-validated supervised learning regressor.">qiime2 sample-classifier regress-samples-ncv</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__scatterplot" target="_top" title="Make 2D scatterplot and linear regression of regressor predictions.">qiime2 sample-classifier scatterplot</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__split_table" target="_top" title="Split a feature table into training and testing sets.">qiime2 sample-classifier split-table</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__sample_classifier__summarize" target="_top" title="Summarize parameter and feature extraction information for a trained estimator.">qiime2 sample-classifier summarize</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__taxa__barplot" target="_top" title="Visualize taxonomy with an interactive bar plot">qiime2 taxa barplot</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__taxa__collapse" target="_top" title="Collapse features by their taxonomy at the specified level">qiime2 taxa collapse</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__taxa__filter_seqs" target="_top" title="Taxonomy-based feature sequence filter.">qiime2 taxa filter-seqs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__taxa__filter_table" target="_top" title="Taxonomy-based feature table filter.">qiime2 taxa filter-table</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2_core__tools__export" target="_top" title="Export data from a QIIME 2 artifact">qiime2 tools export</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2_core__tools__import" target="_top" title="Import data into a QIIME 2 artifact">qiime2 tools import</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2_core__tools__import_fastq" target="_top" title="Import fastq data into a QIIME 2 artifact">qiime2 tools import-fastq</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__cluster_features_closed_reference" target="_top" title="Closed-reference clustering of features.">qiime2 vsearch cluster-features-closed-reference</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__cluster_features_de_novo" target="_top" title="De novo clustering of features.">qiime2 vsearch cluster-features-de-novo</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__cluster_features_open_reference" target="_top" title="Open-reference clustering of features.">qiime2 vsearch cluster-features-open-reference</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__dereplicate_sequences" target="_top" title="Dereplicate sequences.">qiime2 vsearch dereplicate-sequences</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__fastq_stats" target="_top" title="Fastq stats with vsearch.">qiime2 vsearch fastq-stats</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__merge_pairs" target="_top" title="Merge paired-end reads.">qiime2 vsearch merge-pairs</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__uchime_denovo" target="_top" title="De novo chimera filtering.">qiime2 vsearch uchime-denovo</a>
+<a href="https://usegalaxy.org/root?tool_id=qiime2__vsearch__uchime_ref" target="_top" title="Reference-based chimera filtering.">qiime2 vsearch uchime-ref</a>
+
+</div>
+
+### Picard
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=picard_AddCommentsToBam" target="_top" title="add comments to BAM dataset">AddCommentsToBam</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_AddOrReplaceReadGroups" target="_top" title="add or replaces read group information">AddOrReplaceReadGroups</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_BedToIntervalList" target="_top" title="convert coordinate data into picard interval list format">BedToIntervalList</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CleanSam" target="_top" title="perform SAM/BAM grooming">CleanSam</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CASM" target="_top" title="writes a file containing summary alignment metrics">Collect Alignment Summary Metrics</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CollectBaseDistributionByCycle" target="_top" title="charts the nucleotide distribution per cycle in a SAM or BAM dataset">CollectBaseDistributionByCycle</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CollectGcBiasMetrics" target="_top" title="charts the GC bias metrics">CollectGcBiasMetrics</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CollectHsMetrics" target="_top" title="compute metrics about datasets generated through hybrid-selection (e.g. exome)">CollectHsMetrics</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CollectInsertSizeMetrics" target="_top" title="plots distribution of insert sizes">CollectInsertSizeMetrics</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CollectRnaSeqMetrics" target="_top" title="collect metrics about the alignment of RNA to various functional classes of loci in the genome">CollectRnaSeqMetrics</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_CollectWgsMetrics" target="_top" title="compute metrics for evaluating of whole genome sequencing experiments">CollectWgsMetrics</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_DownsampleSam" target="_top" title="Downsample a file to retain a subset of the reads">Downsample SAM/BAM</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_EstimateLibraryComplexity" target="_top" title="assess sequence library complexity from read sequences">EstimateLibraryComplexity</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_FastqToSam" target="_top" title="convert Fastq data into unaligned BAM">FastqToSam</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_FilterSamReads" target="_top" title="include or exclude aligned and unaligned reads and read lists">FilterSamReads</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_FixMateInformation" target="_top" title="ensure that all mate-pair information is in sync between each read and it&#x27;s mate pair">FixMateInformation</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_MarkDuplicates" target="_top" title="examine aligned records in BAM datasets to locate duplicate molecules">MarkDuplicates</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_MarkDuplicatesWithMateCigar" target="_top" title="examine aligned records in BAM datasets to locate duplicate molecules">MarkDuplicatesWithMateCigar</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_MeanQualityByCycle" target="_top" title="chart distribution of base qualities">MeanQualityByCycle</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_MergeBamAlignment" target="_top" title="merge alignment data with additional info stored in an unmapped BAM dataset">MergeBamAlignment</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_MergeSamFiles" target="_top" title="merges multiple SAM/BAM datasets into one">MergeSamFiles</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_NormalizeFasta" target="_top" title="normalize fasta datasets">NormalizeFasta</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_artifact_metrics" target="_top" title="Collect metrics to quantify single-base sequencing artifacts">Picard Collect Sequencing Artifact Metrics</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_QualityScoreDistribution" target="_top" title="chart quality score distribution">QualityScoreDistribution</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_ReorderSam" target="_top" title="reorder reads to match ordering in reference sequences">ReorderSam</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_ReplaceSamHeader" target="_top" title="replace header in a SAM/BAM dataset">ReplaceSamHeader</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_RevertOriginalBaseQualitiesAndAddMateCigar" target="_top" title="revert the original base qualities and add the mate cigar tag">RevertOriginalBaseQualitiesAndAddMateCigar</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_RevertSam" target="_top" title="revert SAM/BAM datasets to a previous state">RevertSam</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_SamToFastq" target="_top" title="extract reads and qualities from SAM/BAM dataset and convert to fastq">SamToFastq</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_SortSam" target="_top" title="sort SAM/BAM dataset">SortSam</a>
+<a href="https://usegalaxy.org/root?tool_id=picard_ValidateSamFile" target="_top" title="assess validity of SAM/BAM dataset">ValidateSamFile</a>
+
+</div>
+
+### deepTools
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=deeptools_bam_compare" target="_top" title="normalizes and compares two BAM or CRAM files to obtain the ratio, log2ratio or difference between them">bamCompare</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_bam_coverage" target="_top" title="generates a coverage bigWig file from a given BAM or CRAM file">bamCoverage</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_bam_pe_fragmentsize" target="_top" title="Estimate the predominant cDNA fragment length from paired-end sequenced BAM/CRAM files">bamPEFragmentSize</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_bigwig_average" target="_top" title="normalizes and average multiple bigWig files">bigwigAverage</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_bigwig_compare" target="_top" title="normalizes and compares two bigWig files to obtain the ratio, log2ratio or difference between them">bigwigCompare</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_compute_gc_bias" target="_top" title="Determine the GC bias of your sequenced reads">computeGCBias</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_compute_matrix" target="_top" title="prepares data for plotting a heatmap or a profile of given regions">computeMatrix</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_correct_gc_bias" target="_top" title="uses the output from computeGCBias to generate GC-corrected BAM/CRAM files">correctGCBias</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_multi_bam_summary" target="_top" title="calculates average read coverages for a list of two or more BAM/CRAM files">multiBamSummary</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_multi_bigwig_summary" target="_top" title="calculates average scores for a list of two or more bigwig files">multiBigwigSummary</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_plot_correlation" target="_top" title="Create a heatmap or scatterplot of correlation scores between different samples">plotCorrelation</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_plot_coverage" target="_top" title="assesses the sequencing depth of BAM/CRAM files">plotCoverage</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_plot_enrichment" target="_top" title="plots read/fragment coverage over sets of regions">plotEnrichment</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_plot_fingerprint" target="_top" title="plots profiles of BAM files; useful for assessing ChIP signal strength">plotFingerprint</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_plot_heatmap" target="_top" title="creates a heatmap for score distributions across genomic regions">plotHeatmap</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_plot_pca" target="_top" title="Generate principal component analysis (PCA) plots from multiBamSummary or multiBigwigSummary output">plotPCA</a>
+<a href="https://usegalaxy.org/root?tool_id=deeptools_plot_profile" target="_top" title="creates a profile plot for score distributions across genomic regions">plotProfile</a>
+
+</div>
+
+### EMBOSS
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20antigenic1" target="_top" title="Predicts potentially antigenic regions of a protein sequence, using the method of Kolaskar and Tongaonkar.">antigenic</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20backtranseq2" target="_top" title="Back translate a protein sequence">backtranseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20banana3" target="_top" title="Bending and curvature plot in B-DNA">banana</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20biosed4" target="_top" title="Replace or delete sequence sections">biosed</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20btwisted5" target="_top" title="Calculates the twisting in a B-DNA sequence">btwisted</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20cai6" target="_top" title="CAI codon adaptation index">cai</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20cai_custom6" target="_top" title="CAI codon adaptation index using custom codon usage file">cai custom</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20chaos7" target="_top" title="Create a chaos game representation plot for a sequence">chaos</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20charge8" target="_top" title="Protein charge plot">charge</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20checktrans9" target="_top" title="Reports STOP codons and ORF statistics of a protein">checktrans</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20chips10" target="_top" title="Codon usage statistics">chips</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20cirdna11" target="_top" title="Draws circular maps of DNA constructs">cirdna</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20codcmp12" target="_top" title="Codon usage table comparison">codcmp</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20coderet13" target="_top" title="Extract CDS, mRNA and translations from feature tables">coderet</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20compseq14" target="_top" title="Count composition of dimer/trimer/etc words in a sequence">compseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20cpgplot15" target="_top" title="Plot CpG rich areas">cpgplot</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20cpgreport16" target="_top" title="Reports all CpG rich regions">cpgreport</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20cusp17" target="_top" title="Create a codon usage table">cusp</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20cutseq18" target="_top" title="Removes a specified section from a sequence">cutseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20dan19" target="_top" title="Calculates DNA RNA/DNA melting temperature">dan</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20degapseq20" target="_top" title="Removes gap characters from sequences">degapseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20descseq21" target="_top" title="Alter the name or description of a sequence">descseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20diffseq22" target="_top" title="Find differences between nearly identical sequences">diffseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20digest23" target="_top" title="Protein proteolytic enzyme or reagent cleavage digest">digest</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20dotmatcher24" target="_top" title="Displays a thresholded dotplot of two sequences">dotmatcher</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20dotpath25" target="_top" title="Non-overlapping wordmatch dotplot of two sequences">dotpath</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20dottup26" target="_top" title="Displays a wordmatch dotplot of two sequences">dottup</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20dreg27" target="_top" title="Regular expression search of a nucleotide sequence">dreg</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20einverted28" target="_top" title="Finds DNA inverted repeats">einverted</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20epestfind29" target="_top" title="Finds PEST motifs as potential proteolytic cleavage sites">epestfind</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20equicktandem31" target="_top" title="Finds tandem repeats">equicktandem</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20est2genome32" target="_top" title="Align EST and genomic DNA sequences">est2genome</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20etandem33" target="_top" title="Looks for tandem repeats in a nucleotide sequence">etandem</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20extractfeat34" target="_top" title="Extract features from a sequence">extractfeat</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20extractseq35" target="_top" title="Extract regions from a sequence">extractseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20freak36" target="_top" title="Residue/base frequency table or plot">freak</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20fuzznuc37" target="_top" title="Nucleic acid pattern search">fuzznuc</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20fuzzpro38" target="_top" title="Protein pattern search">fuzzpro</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20fuzztran39" target="_top" title="Protein pattern search after translation">fuzztran</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20garnier40" target="_top" title="Predicts protein secondary structure">garnier</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20geecee41" target="_top" title="Calculates fractional GC content of nucleic acid sequences">geecee</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20getorf42" target="_top" title="Finds and extracts open reading frames (ORFs)">getorf</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20helixturnhelix43" target="_top" title="Report nucleic acid binding motifs">helixturnhelix</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20hmoment44" target="_top" title="Hydrophobic moment calculation">hmoment</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20iep45" target="_top" title="Calculates the isoelectric point of a protein">iep</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20infoseq46" target="_top" title="Displays some simple information about sequences">infoseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20isochore47" target="_top" title="Plots isochores in large DNA sequences">isochore</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20lindna48" target="_top" title="Draws linear maps of DNA constructs">lindna</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20marscan49" target="_top" title="Finds MAR/SAR sites in nucleic sequences">marscan</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20maskfeat50" target="_top" title="Mask off features of a sequence">maskfeat</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20maskseq51" target="_top" title="Mask off regions of a sequence">maskseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20matcher52" target="_top" title="Finds the best local alignments between two sequences">matcher</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20megamerger53" target="_top" title="Merge two large overlapping nucleic acid sequences">megamerger</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20merger54" target="_top" title="Merge two overlapping nucleic acid sequences">merger</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20msbar55" target="_top" title="Mutate sequence beyond all recognition">msbar</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20needle56" target="_top" title="Needleman-Wunsch global alignment">needle</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20newcpgreport57" target="_top" title="Report CpG rich areas">newcpgreport</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20newcpgseek58" target="_top" title="Reports CpG rich region">newcpgseek</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20newseq59" target="_top" title="Type in a short new sequence">newseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20noreturn60" target="_top" title="Removes carriage return from ASCII files">noreturn</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20notseq61" target="_top" title="Exclude a set of sequences and write out the remaining ones">notseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20nthseq62" target="_top" title="Writes one sequence from a multiple set of sequences">nthseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20octanol63" target="_top" title="Displays protein hydropathy">octanol</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20oddcomp64" target="_top" title="Find protein sequence regions with a biased composition">oddcomp</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20palindrome65" target="_top" title="Looks for inverted repeats in a nucleotide sequence">palindrome</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pasteseq66" target="_top" title="Insert one sequence into another">pasteseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20patmatdb67" target="_top" title="Search a protein sequence with a motif">patmatdb</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pepcoil68" target="_top" title="Predicts coiled coil regions">pepcoil</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pepinfo69" target="_top" title="Plots simple amino acid properties in parallel">pepinfo</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pepnet70" target="_top" title="Displays proteins as a helical net">pepnet</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pepstats71" target="_top" title="Protein statistics">pepstats</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pepwheel72" target="_top" title="Shows protein sequences as helices">pepwheel</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pepwindow73" target="_top" title="Displays protein hydropathy">pepwindow</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20pepwindowall74" target="_top" title="Displays protein hydropathy of a set of sequences">pepwindowall</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20plotcon75" target="_top" title="Plot quality of conservation of a sequence alignment">plotcon</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20plotorf76" target="_top" title="Plot potential open reading frames">plotorf</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20polydot77" target="_top" title="Displays all-against-all dotplots of a set of sequences">polydot</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20preg78" target="_top" title="Regular expression search of a protein sequence">preg</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20prettyplot79" target="_top" title="Displays aligned sequences, with colouring and boxing">prettyplot</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20prettyseq80" target="_top" title="Output sequence with translated ranges">prettyseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20primersearch81" target="_top" title="Searches DNA sequences for matches with primer pairs">primersearch</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20revseq82" target="_top" title="Reverse and complement a sequence">revseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20seqmatchall83" target="_top" title="All-against-all comparison of a set of sequences">seqmatchall</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20seqret84" target="_top" title="Reads and writes sequences">seqret</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20showfeat85" target="_top" title="Show features of a sequence">showfeat</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20shuffleseq87" target="_top" title="Shuffles a set of sequences maintaining composition">shuffleseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20sigcleave88" target="_top" title="Reports protein signal cleavage sites">sigcleave</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20sirna89" target="_top" title="Finds siRNA duplexes in mRNA">sirna</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20sixpack90" target="_top" title="Display a DNA sequence with 6-frame translation and ORFs">sixpack</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20skipseq91" target="_top" title="Reads and writes sequences, skipping first few">skipseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20splitter92" target="_top" title="Split a sequence into (overlapping) smaller sequences">splitter</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20supermatcher95" target="_top" title="Match large sequences against one or more other sequences">supermatcher</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20syco96" target="_top" title="Synonymous codon usage Gribskov statistic plot">syco</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20tcode97" target="_top" title="Fickett TESTCODE statistic to identify protein-coding DNA">tcode</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20textsearch98" target="_top" title="Search sequence documentation. Slow, use SRS and Entrez!">textsearch</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20tmap99" target="_top" title="Displays membrane spanning regions">tmap</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20tranalign100" target="_top" title="Align nucleic coding regions given the aligned proteins">tranalign</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20transeq101" target="_top" title="Translate nucleic acid sequences">transeq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20trimest102" target="_top" title="Trim poly-A tails off EST sequences">trimest</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20trimseq103" target="_top" title="Trim ambiguous bits off the ends of sequences">trimseq</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20twofeat104" target="_top" title="Finds neighbouring pairs of features in sequences">twofeat</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20union105" target="_top" title="Reads sequence fragments and builds one sequence">union</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20vectorstrip106" target="_top" title="Strips out DNA between a pair of vector sequences">vectorstrip</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20water107" target="_top" title="Smith-Waterman local alignment">water</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20wobble108" target="_top" title="Wobble base plot">wobble</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20wordcount109" target="_top" title="Counts words of a specified size in a DNA sequence">wordcount</a>
+<a href="https://usegalaxy.org/root?tool_id=EMBOSS%3A%20wordmatch110" target="_top" title="Finds all exact matches of a given size between 2 sequences">wordmatch</a>
+
+</div>
+
+### NCBI BLAST+
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=blastxml_to_tabular" target="_top" title="Convert BLAST XML output to tabular">BLAST XML to tabular</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_blastdbcmd_wrapper" target="_top" title="Extract sequence(s) from BLAST database">NCBI BLAST+ blastdbcmd entry(s)</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_blastn_wrapper" target="_top" title="Search nucleotide database with nucleotide query sequence(s)">NCBI BLAST+ blastn</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_blastp_wrapper" target="_top" title="Search protein database with protein query sequence(s)">NCBI BLAST+ blastp</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_blastx_wrapper" target="_top" title="Search protein database with translated nucleotide query sequence(s)">NCBI BLAST+ blastx</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_convert2blastmask_wrapper" target="_top" title="Convert masking information in lower-case masked FASTA input to file formats suitable for makeblastdb">NCBI BLAST+ convert2blastmask</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_blastdbcmd_info" target="_top" title="Show BLAST database information from blastdbcmd">NCBI BLAST+ database info</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_dustmasker_wrapper" target="_top" title="masks low complexity regions">NCBI BLAST+ dustmasker</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_makeblastdb" target="_top" title="Make BLAST database">NCBI BLAST+ makeblastdb</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_makeprofiledb" target="_top" title="Make profile database">NCBI BLAST+ makeprofiledb</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_rpsblast_wrapper" target="_top" title="Search protein domain database (PSSMs) with protein query sequence(s)">NCBI BLAST+ rpsblast</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_rpstblastn_wrapper" target="_top" title="Search protein domain database (PSSMs) with translated nucleotide query sequence(s)">NCBI BLAST+ rpstblastn</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_segmasker_wrapper" target="_top" title="low-complexity regions in protein sequences">NCBI BLAST+ segmasker</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_tblastn_wrapper" target="_top" title="Search translated nucleotide database with protein query sequence(s)">NCBI BLAST+ tblastn</a>
+<a href="https://usegalaxy.org/root?tool_id=ncbi_tblastx_wrapper" target="_top" title="Search translated nucleotide database with translated nucleotide query sequence(s)">NCBI BLAST+ tblastx</a>
+<a href="https://usegalaxy.org/root?tool_id=get_species_taxids" target="_top" title="">NCBI get species taxids</a>
+
+</div>
+
+### HyPhy
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=hyphy_annotate" target="_top" title="a newick tree with HyPhy">Annotate</a>
+<a href="https://usegalaxy.org/root?tool_id=drhip" target="_top" title="Data Reduction for HyPhy with Inference Processing">DRHIP</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_bgm" target="_top" title="- Detecting coevolving sites via Bayesian graphical models">HyPhy-BGM</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_busted" target="_top" title="Branch-site Unrestricted Statistical Test for Episodic Diversification">HyPhy-BUSTED</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_cfel" target="_top" title="Test for Differences in Selective Pressures at Individual Sites among Clades and Sets of Branches">HyPhy-CFEL</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_cln" target="_top" title="Clean and normalize alignment">HyPhy-CLN</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_conv" target="_top" title="translate an in-frame codon alignment to proteins">HyPhy-Conv</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_fade" target="_top" title=": FUBAR* Approach to Directional Evolution (*Fast    Unconstrained Bayesian Approximation)">HyPhy-FADE</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_fel" target="_top" title="Fixed Effects Likelihood">HyPhy-FEL</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_fubar" target="_top" title="Fast Unconstrained Bayesian AppRoximation">HyPhy-FUBAR</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_gard" target="_top" title="Genetic Algorithm for Recombination Detection">HyPhy-GARD</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_meme" target="_top" title="Mixed Effects Model of Evolution">HyPhy-MEME</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_prime" target="_top" title="Property Informed Models of Evolution">HyPhy-PRIME</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_relax" target="_top" title="Detect relaxed selection in a codon-based    phylogenetic framework">HyPhy-RELAX</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_slac" target="_top" title="Single Likelihood Ancestor Counting">HyPhy-SLAC</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_sm19" target="_top" title="Partition Tree using Modified Slatkin-Maddison Test">HyPhy-SM2019</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_summary" target="_top" title="generate summary report of HyPhy analyses">HyPhy-Summary</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_absrel" target="_top" title="adaptive Branch Site Random Effects Likelihood">HyPhy-aBSREL</a>
+<a href="https://usegalaxy.org/root?tool_id=remove_terminal_stop_codons" target="_top" title="from coding sequences">Remove terminal stop codons</a>
+<a href="https://usegalaxy.org/root?tool_id=hyphy_strike_ambigs" target="_top" title="in a multiple alignment using HyPhy">Replace ambiguous codons</a>
+<a href="https://usegalaxy.org/root?tool_id=sarscov2formatter" target="_top" title="">sarscov2formatter</a>
+<a href="https://usegalaxy.org/root?tool_id=sarscov2summary" target="_top" title="">sarscov2summary</a>
+
+</div>
+
+### RSeQC
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=rseqc_bam2wig" target="_top" title="converts all types of RNA-seq data from BAM to Wiggle">BAM to Wiggle</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_bam_stat" target="_top" title="reads mapping statistics for a provided BAM or SAM file.">BAM/SAM Mapping Stats</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_clipping_profile" target="_top" title="estimates clipping profile of RNA-seq reads from BAM or SAM file">Clipping Profile</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_deletion_profile" target="_top" title="calculates the distributions of deleted nucleotides across reads">Deletion Profile</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_FPKM_count" target="_top" title="calculates raw read count, FPM, and FPKM for each gene">FPKM Count</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_geneBody_coverage" target="_top" title="read coverage over gene body">Gene Body Coverage (BAM)</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_geneBody_coverage2" target="_top" title="read coverage over gene body">Gene Body Coverage (Bigwig)</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_read_hexamer" target="_top" title="calculates hexamer (6mer) frequency for reads, genomes, and mRNA sequences">Hexamer frequency</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_infer_experiment" target="_top" title="speculates how RNA-seq were configured">Infer Experiment</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_inner_distance" target="_top" title="calculate the inner distance (or insert size) between two paired RNA reads">Inner Distance</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_insertion_profile" target="_top" title="calculates the distribution of inserted nucleotides across reads">Insertion Profile</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_junction_annotation" target="_top" title="compares detected splice junctions to reference gene model">Junction Annotation</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_junction_saturation" target="_top" title="detects splice junctions from each subset and compares them to reference gene model">Junction Saturation</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_mismatch_profile" target="_top" title="calculates the distribution of mismatches across reads">Mismatch Profile</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_RNA_fragment_size" target="_top" title="calculates the fragment size for each gene/transcript">RNA fragment size</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_RPKM_saturation" target="_top" title="calculates raw count and RPKM values for transcript at exon, intron, and mRNA level">RPKM Saturation</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_read_distribution" target="_top" title="calculates how mapped reads were distributed over genome feature">Read Distribution</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_read_duplication" target="_top" title="determines reads duplication rate with sequence-based and mapping-based strategies">Read Duplication</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_read_GC" target="_top" title="determines GC% and read count">Read GC</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_read_NVC" target="_top" title="to check the nucleotide composition bias">Read NVC</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_read_quality" target="_top" title="determines Phred quality score">Read Quality</a>
+<a href="https://usegalaxy.org/root?tool_id=rseqc_tin" target="_top" title="evaluates RNA integrity at a transcript level">Transcript Integrity Number</a>
+
+</div>
+
+### MiModD
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=mimodd_convert" target="_top" title="converts sequence data into different formats">MiModD Convert</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_covstats" target="_top" title="calculates coverage statistics for a BCF file as generated by the MiModd Variant Calling tool">MiModD Coverage Statistics</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_delcall" target="_top" title="predicts deletions in one or more aligned paired-end read samples based on coverage of the reference genome and on insert sizes">MiModD Deletion Calling (for PE data)</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_varextract" target="_top" title="from a BCF file">MiModD Extract Variant Sites</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_info" target="_top" title="provides summary reports for supported sequence data formats.">MiModD File Information</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_map" target="_top" title="maps phenotypically selected variants by multi-variant linkage analysis">MiModD NacreousMap</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_align" target="_top" title="maps sequence reads to a reference genome using SNAP">MiModD Read Alignment</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_rebase" target="_top" title="from a VCF file">MiModD Rebase Sites</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_reheader" target="_top" title="takes a BAM file and generates a copy with the original header (if any) replaced or modified by that found in a template SAM file">MiModD Reheader</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_varreport" target="_top" title="in a human-friendly format that simplifies data exploration">MiModD Report Variants</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_header" target="_top" title="writes run metadata in SAM format for attaching it to sequenced reads data">MiModD Run Annotation</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_sort" target="_top" title="takes a SAM/BAM dataset and generates a coordinate/name-sorted copy">MiModD Sort</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_vcf_filter" target="_top" title="extracts lines from a vcf variant file based on field-specific filters">MiModD VCF Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=mimodd_varcall" target="_top" title="generates a BCF file of position-specific variant likelihoods and coverage information based on a reference sequence and reads aligned against it">MiModD Variant Calling</a>
+
+</div>
+
+### HCA-Scanpy
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=seurat_plot" target="_top" title="with Seurat">Plot</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_integrate_bbknn" target="_top" title="batch-balanced K-nearest neighbours">Scanpy BBKNN</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_integrate_combat" target="_top" title="adjust expression for variables that might introduce batch effect">Scanpy ComBat</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_integrate_mnn" target="_top" title="correct batch effects by matching mutual nearest neighbors">Scanpy MNN</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_plot_scrublet" target="_top" title="visualise multiplet scoring distribution">Scanpy Plot Scrublet</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_multiplet_scrublet" target="_top" title="remove multiplets from annData objects with Scrublet">Scanpy Scrublet</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_run_umap" target="_top" title="dimensionality reduction">Seurat UMAP</a>
+
+</div>
+
+### HiCExplorer
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicaggregatestatistic" target="_top" title="computes with a target file the to be tested regions for chicDifferentialTest">chicAggregateStatistic</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicdifferentialtest" target="_top" title="computes differential interactions of viewpoints">chicDifferentialTest</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicexportdata" target="_top" title="exports data of hdf to txt based files">chicExportData</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicplotviewpoint" target="_top" title="creates plots for viewpoints">chicPlotViewpoint</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicqualitycontrol" target="_top" title="generates an estimate of the quality of each viewpoint">chicQualityControl</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicsignificantinteractions" target="_top" title="computes viewpoints with the given reference points and a background model">chicSignificantInteractions</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicviewpoint" target="_top" title="computes viewpoints with the given reference points and a background model.">chicViewpoint</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_chicviewpointbackgroundmodel" target="_top" title="compute a background model for cHi-C / HiChIP data">chicViewpointBackgroundModel</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicadjustmatrix" target="_top" title="adjust the shape of a Hi-C matrix">hicAdjustMatrix</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicaggregatecontacts" target="_top" title="allow plotting of aggregated Hi-C contacts between regions specified in a file">hicAggregateContacts</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicaverageregions" target="_top" title="sums Hi-C contacts around given reference points and computes their average.">hicAverageRegions</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicbuildmatrix" target="_top" title="create a contact matrix">hicBuildMatrix</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hiccomparematrices" target="_top" title="normalize and compare two Hi-C contact matrices">hicCompareMatrices</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hiccompartmentspolarization" target="_top" title="compute pairwise correlations between multiple Hi-C contact matrices">hicCompartmentalization</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicconvertformat" target="_top" title="Convert between different file formats">hicConvertFormat</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hiccorrectmatrix" target="_top" title="run a Hi-C matrix correction algorithm">hicCorrectMatrix</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hiccorrelate" target="_top" title="compute pairwise correlations between multiple Hi-C contact matrices">hicCorrelate</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicdetectloops" target="_top" title="searches for enriched regions">hicDetectLoops</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicdifferentialtad" target="_top" title="searches for differential TADs">hicDifferentialTAD</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicfindrestrictionsites" target="_top" title="identify restriction enzyme sites">hicFindRestSite</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicfindtads" target="_top" title="identify TAD boundaries by computing the degree of separation of each Hi-C matrix bin">hicFindTADs</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hichyperoptDetectLoops" target="_top" title="optimizes parameters for hicDetectLoops">hicHyperoptDetectLoops</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicinfo" target="_top" title="get information about the content of a Hi-C matrix">hicInfo</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicinterintratad" target="_top" title="computes the ratio of inter TAD-scores vs. intra TADs">hicInterIntraTAD</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicmergedomains" target="_top" title="Merges TAD domains">hicMergeDomains</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicmergeloops" target="_top" title="merge detected loops of different resolutions.">hicMergeLoops</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicmergematrixbins" target="_top" title="merge adjacent bins from a Hi-C contact matrix to reduce its resolution">hicMergeMatrixBins</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicnormalize" target="_top" title="normalizes a matrix to norm range or smallest read count">hicNormalize</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicpca" target="_top" title="compute the principal components for A / B compartment analysis">hicPCA</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicplotaverageregions" target="_top" title="plot the average regions from hicAverageRegions">hicPlotAverageRegions</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicplotdistvscounts" target="_top" title="compute distance vs Hi-C counts plot per chromosome">hicPlotDistVsCounts</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicplotmatrix" target="_top" title="plot a Hi-C contact matrix heatmap">hicPlotMatrix</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicplotsvl" target="_top" title="plots the relation of short vs long range contacts">hicPlotSVL</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicplotviewpoint" target="_top" title="plot interactions around a viewpoint">hicPlotViewpoint</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicquickqc" target="_top" title="get a first quality estimate of Hi-C data">hicQuickQC</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicsummatrices" target="_top" title="combine Hi-C matrices of the same size">hicSumMatrices</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hictadclassifier" target="_top" title="TAD detection based on ML models">hicTADClassifier</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hictraintadclassifier" target="_top" title="train a TAD detection ML model">hicTrainTADClassifier</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hictransform" target="_top" title="transform a matrix to obs/exp, pearson and covariance matrices">hicTransform</a>
+<a href="https://usegalaxy.org/root?tool_id=hicexplorer_hicvalidatelocations" target="_top" title="validate detected loops with protein peaks.">hicValidateLocations</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicadjustmatrix" target="_top" title="clusters single-cell Hi-C interaction matrices on the raw data">scHicAdjustMatrix</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schiccluster" target="_top" title="clusters single-cell Hi-C interaction matrices on the raw data">scHicCluster</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicclustercompartments" target="_top" title="clusters single-cell Hi-C interaction matrices with A/B compartments dimension reduction">scHicClusterCompartments</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicclusterminhash" target="_top" title="clusters single-cell Hi-C interaction matrices with MinHash dimension reduction">scHicClusterMinHash</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicclustersvl" target="_top" title="clusters single-cell Hi-C interaction matrices with svl dimension reduction">scHicClusterSVL</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicconsensusmatrices" target="_top" title="creates per cluster one average matrix">scHicConsensusMatrices</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schiccorrectmatrices" target="_top" title="correct with KR algorithm single-cell Hi-C interaction matrices">scHicCorrectMatrices</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schiccreatebulkmatrix" target="_top" title="creates the bulk matrix out of  single-cell Hi-C interaction matrices">scHicCreateBulkMatrix</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicdemultiplex" target="_top" title="demultiplexes Nagano 2017 raw fastq files">scHicDemultiplex</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicinfo" target="_top" title="information about a single-cell scool matrix">scHicInfo</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicmergematrixbins" target="_top" title="change the resolution of the scHi-C matrices">scHicMergeMatrixBins</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicmergetoscool" target="_top" title="merge multiple cool files to one scool file">scHicMergeToSCool</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicnormalize" target="_top" title="normalize single-cell Hi-C interaction matrices to the same read coverage">scHicNormalize</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicplotclusterprofiles" target="_top" title="plot single-cell Hi-C interaction matrices cluster profiles">scHicPlotClusterProfiles</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicplotconsensusmatrices" target="_top" title="plot single-cell Hi-C interaction matrices cluster consensus matrices">scHicPlotConsensusMatrices</a>
+<a href="https://usegalaxy.org/root?tool_id=schicexplorer_schicqualitycontrol" target="_top" title="quality control for single-cell Hi-C interaction matrices">scHicQualityControl</a>
+
+</div>
+
+### Du Novo
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=read2mut" target="_top" title="Looks for reads with mutation at known positions and calculates frequencies and stats.">Call specific mutations in reads:</a>
+<a href="https://usegalaxy.org/root?tool_id=mut2sscs" target="_top" title="Extracts all tags from the single stranded consensus sequence (SSCS) bam file that carry a mutation at the same position a mutation is called in the duplex consensus sequence (DCS) and calculates their frequencies">DCS mutations to SSCS stats:</a>
+<a href="https://usegalaxy.org/root?tool_id=mut2read" target="_top" title="Extracts all tags that carry a mutation in the duplex consensus sequence (DCS)">DCS mutations to tags/reads:</a>
+<a href="https://usegalaxy.org/root?tool_id=align_families" target="_top" title="of duplex sequencing reads">Du Novo: Align families</a>
+<a href="https://usegalaxy.org/root?tool_id=precheck" target="_top" title="for family content">Du Novo: Check input</a>
+<a href="https://usegalaxy.org/root?tool_id=correct_barcodes" target="_top" title="of duplex sequencing reads">Du Novo: Correct barcodes</a>
+<a href="https://usegalaxy.org/root?tool_id=dunovo" target="_top" title="from duplex sequencing alignments">Du Novo: Make consensus reads</a>
+<a href="https://usegalaxy.org/root?tool_id=make_families" target="_top" title="of duplex sequencing reads">Du Novo: Make families</a>
+<a href="https://usegalaxy.org/root?tool_id=fsd_beforevsafter" target="_top" title="Family Size Distribution of duplex sequencing tags during Du Novo analysis">FSD Before/After:</a>
+<a href="https://usegalaxy.org/root?tool_id=fsd_regions" target="_top" title="Family size distribution of user-specified regions in the reference genome">FSD regions:</a>
+<a href="https://usegalaxy.org/root?tool_id=fsd" target="_top" title="Family Size Distribution of duplex sequencing tags">FSD:</a>
+<a href="https://usegalaxy.org/root?tool_id=sequence_content_trimmer" target="_top" title="trim reads based on certain bases">Sequence Content Trimmer</a>
+<a href="https://usegalaxy.org/root?tool_id=td" target="_top" title="Tag distance analysis of duplex tags">TD:</a>
+
+</div>
+
+### Seqtk
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=seqtk_comp" target="_top" title="get the nucleotide composition of FASTA/Q">seqtk_comp</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_cutN" target="_top" title="cut sequence at long N">seqtk_cutN</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_dropse" target="_top" title="drop unpaired from interleaved Paired End FASTA/Q">seqtk_dropse</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_fqchk" target="_top" title="fastq QC (base/quality summary)">seqtk_fqchk</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_hety" target="_top" title="regional heterozygosity">seqtk_hety</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_listhet" target="_top" title="extract the position of each het">seqtk_listhet</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_mergefa" target="_top" title="Merge two FASTA/Q files into a FASTA file output">seqtk_mergefa</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_mergepe" target="_top" title="interleave two unpaired FASTA/Q files for a paired-end file">seqtk_mergepe</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_mutfa" target="_top" title="point mutate FASTA at specified positions">seqtk_mutfa</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_randbase" target="_top" title="choose a random base from hets">seqtk_randbase</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_sample" target="_top" title="random subsample of fasta or fastq sequences">seqtk_sample</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_seq" target="_top" title="common transformation of FASTA/Q">seqtk_seq</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_subseq" target="_top" title="extract subsequences from FASTA/Q files">seqtk_subseq</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_telo" target="_top" title="find telomeres">seqtk_telo</a>
+<a href="https://usegalaxy.org/root?tool_id=seqtk_trimfq" target="_top" title="trim FASTQ using the Phred algorithm">seqtk_trimfq</a>
+
+</div>
+
+### Monocle3
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=monocle3_create" target="_top" title="a Monocle3 object from input data">Monocle3 create</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_diffExp" target="_top" title="of genes along a trajectory">Monocle3 diffExp</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_learnGraph" target="_top" title="between cells in dimensionality reduced space">Monocle3 learnGraph</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_orderCells" target="_top" title="along trajectories">Monocle3 orderCells</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_partition" target="_top" title="of cells into groups">Monocle3 partition</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_plotCells" target="_top" title="in the reduced dimensionality space">Monocle3 plotCells</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_preprocess" target="_top" title="a Monocle3 object to an initially dimensionally reduced space">Monocle3 preprocess</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_reduceDim" target="_top" title="for downstream analysis">Monocle3 reduceDim</a>
+<a href="https://usegalaxy.org/root?tool_id=monocle3_topmarkers" target="_top" title="for cell groups">Monocle3 top markers</a>
+
+</div>
+
+### Gemini
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=gemini_actionable_mutations" target="_top" title="Retrieve genes with actionable somatic mutations via COSMIC and DGIdb">GEMINI actionable_mutations</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_amend" target="_top" title="Amend an already loaded GEMINI database.">GEMINI amend</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_annotate" target="_top" title="the variants in an existing GEMINI database with additional information">GEMINI annotate</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_burden" target="_top" title="perform sample-wise gene-level burden calculations">GEMINI burden</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_db_info" target="_top" title="Retrieve information about tables, columns and annotation data stored in a GEMINI database">GEMINI database info</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_de_novo" target="_top" title="Identifying potential de novo mutations">GEMINI de_novo</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_inheritance" target="_top" title="based identification of candidate genes">GEMINI inheritance pattern</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_interactions" target="_top" title="Find genes among variants that are interacting partners">GEMINI interactions</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_load" target="_top" title="Loading a VCF file into GEMINI">GEMINI load</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_lof_sieve" target="_top" title="Filter LoF variants by transcript position and type">GEMINI lof_sieve</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_query" target="_top" title="Querying the GEMINI database">GEMINI query</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_set_somatic" target="_top" title="Tag somatic mutations in a GEMINI database">GEMINI set_somatic</a>
+<a href="https://usegalaxy.org/root?tool_id=gemini_stats" target="_top" title="Compute useful variant statistics">GEMINI stats</a>
+
+</div>
+
+### BBTools
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=bbtools_bbmap" target="_top" title="short-read aligner">BBTools: BBMap</a>
+<a href="https://usegalaxy.org/root?tool_id=bbtools_bbmerge" target="_top" title="Merge overlapping mates of a read pair">BBTools: BBMerge</a>
+<a href="https://usegalaxy.org/root?tool_id=bbtools_bbnorm" target="_top" title="Normalise sequencing coverage">BBTools: BBNorm</a>
+<a href="https://usegalaxy.org/root?tool_id=bbtools_bbduk" target="_top" title="kmer- and entropy-based decontamination">BBTools: BBduk</a>
+<a href="https://usegalaxy.org/root?tool_id=bbtools_tadpole" target="_top" title="Kmer-based assembler">BBTools: Tadpole</a>
+<a href="https://usegalaxy.org/root?tool_id=bbtools_callvariants" target="_top" title="in aligned Bam files">BBTools: call variants</a>
+
+</div>
+
+### IWTomics
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=iwtomics_loadandplot" target="_top" title="Smooth and Plot">IWTomics Load</a>
+<a href="https://usegalaxy.org/root?tool_id=iwtomics_plotwithscale" target="_top" title="on Test Scale">IWTomics Plot with Threshold</a>
+<a href="https://usegalaxy.org/root?tool_id=iwtomics_testandplot" target="_top" title="and Plot">IWTomics Test</a>
+
+</div>
+
+### pRESTO
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=migmap" target="_top" title="mapper for full-length T- and B-cell repertoire sequencing">MiGMAP</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_alignsets" target="_top" title="Multiple-align sequences with the same barcodes.">pRESTO AlignSets</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_assemblepairs" target="_top" title="Assembles paired-end reads into a single sequence.">pRESTO AssemblePairs</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_buildconsensus" target="_top" title="Builds a consensus sequence for each set of input sequences">pRESTO BuildConsensus</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_collapseseq" target="_top" title="Remove/collapse duplicate sequences">pRESTO CollapseSeq</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_filterseq" target="_top" title="Filters and/or masks reads based on length, quality, missing bases and repeats.">pRESTO FilterSeq</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_maskprimers" target="_top" title="Removes primers and annotates sequences with primer and barcode identifiers.">pRESTO MaskPrimers</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_pairseq" target="_top" title="Sorts and matches sequence records with matching coordinates across files">pRESTO PairSeq</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_parseheaders" target="_top" title="Manage annotations in FASTQ headers.">pRESTO ParseHeaders</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_parselog" target="_top" title="Create tabular report from pRESTO log file">pRESTO ParseLog</a>
+<a href="https://usegalaxy.org/root?tool_id=presto_partition" target="_top" title="Partition a file in two">pRESTO Partition</a>
+<a href="https://usegalaxy.org/root?tool_id=prestor_abseq3" target="_top" title="Create HTML QC report from pRESTO outputs">pRESTOr AbSeq3 Report</a>
+
+</div>
+
+### PlantTribes
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=plant_tribes_assembly_post_processor" target="_top" title="post-processes de novo transcriptome assembly">AssemblyPostProcessor</a>
+<a href="https://usegalaxy.org/root?tool_id=plant_tribes_gene_family_aligner" target="_top" title="aligns integrated orthologous gene family clusters">GeneFamilyAligner</a>
+<a href="https://usegalaxy.org/root?tool_id=plant_tribes_gene_family_classifier" target="_top" title="classifies gene sequences into pre-computed orthologous gene family clusters">GeneFamilyClassifier</a>
+<a href="https://usegalaxy.org/root?tool_id=plant_tribes_gene_family_integrator" target="_top" title="integrates gene models in pre-computed orthologous gene family clusters with classified gene coding sequences">GeneFamilyIntegrator</a>
+<a href="https://usegalaxy.org/root?tool_id=plant_tribes_gene_family_phylogeny_builder" target="_top" title="builds phylogenetic trees of aligned orthologous gene family clusters">GeneFamilyPhylogenyBuilder</a>
+<a href="https://usegalaxy.org/root?tool_id=plant_tribes_kaks_analysis" target="_top" title="estimates paralogous and orthologous pairwise synonymous (Ks) and non-synonymous (Ka) substitution rates">KaKsAnalysis</a>
+<a href="https://usegalaxy.org/root?tool_id=ks_distribution" target="_top" title="plots the distribution of synonymous substitution (Ks) rates and fits significant component(s)">KsDistribution</a>
+
+</div>
+
+### Motif
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=meme_fimo" target="_top" title="- Scan a set of sequences for motifs">FIMO</a>
+<a href="https://usegalaxy.org/root?tool_id=meme_meme" target="_top" title="- Multiple EM for Motif Elicitation">MEME</a>
+<a href="https://usegalaxy.org/root?tool_id=meme_psp_gen" target="_top" title="- perform discriminative motif discovery">MEME psp-gen</a>
+<a href="https://usegalaxy.org/root?tool_id=meme_chip" target="_top" title="- motif discovery, enrichment analysis and clustering on large nucleotide datasets">MEME-ChIP</a>
+<a href="https://usegalaxy.org/root?tool_id=rgweblogo3" target="_top" title="generator for fasta (eg Clustal alignments)">Sequence Logo</a>
+<a href="https://usegalaxy.org/root?tool_id=longdust" target="_top" title="Detect low-complexity regions in long sequences">longdust</a>
+
+</div>
+
+### SCCAF
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=run_sccaf" target="_top" title="to assess and optimise clustering">Run SCCAF</a>
+<a href="https://usegalaxy.org/root?tool_id=sccaf_asses" target="_top" title="runs an assesment of an SCCAF optimisation result or an existing clustering.">SCCAF Assesment</a>
+<a href="https://usegalaxy.org/root?tool_id=sccaf_asses_merger" target="_top" title="brings together distributed assesments.">SCCAF Assesment Merger</a>
+<a href="https://usegalaxy.org/root?tool_id=sccaf_regress_out" target="_top" title="with multiple categorical keys on an AnnData object.">SCCAF mulitple regress out</a>
+
+</div>
+
+### Seurat
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=seurat_create_seurat_object" target="_top" title="create a Seurat object">Seurat CreateSeuratObject</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_export_cellbrowser" target="_top" title="produces files for UCSC CellBrowser import.">Seurat Export2CellBrowser</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_filter_cells" target="_top" title="filter cells in a Seurat object">Seurat FilterCells</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_find_clusters" target="_top" title="find clusters of cells">Seurat FindClusters</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_find_markers" target="_top" title="find markers (differentially expressed genes)">Seurat FindMarkers</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_find_neighbours" target="_top" title="constructs a Shared Nearest Neighbor (SNN) Graph">Seurat FindNeighbours</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_find_variable_genes" target="_top" title="identify variable genes">Seurat FindVariableGenes</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_normalise_data" target="_top" title="normalise data">Seurat NormaliseData</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_dim_plot" target="_top" title="graphs the output of a dimensional reduction technique (PCA by default). Cells are colored by their identity class.">Seurat Plot dimension reduction</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_read10x" target="_top" title="Loads Tabular or 10x data into a serialized seurat R object">Seurat Read10x</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_run_pca" target="_top" title="run a PCA dimensionality reduction">Seurat RunPCA</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_run_tsne" target="_top" title="run t-SNE dimensionality reduction">Seurat RunTSNE</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_scale_data" target="_top" title="scale and center genes">Seurat ScaleData</a>
+
+</div>
+
+---
+
+## Domain Tools
+
+
+### Virology
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=nextclade" target="_top" title="Viral genome clade assignment, mutation calling, and sequence quality checks">Nextclade</a>
+<a href="https://usegalaxy.org/root?tool_id=pangolin" target="_top" title="Phylogenetic Assignment of Outbreak Lineages">Pangolin</a>
+<a href="https://usegalaxy.org/root?tool_id=snpeff_sars_cov_2" target="_top" title="annotate variants for SARS-CoV-2">SnpEff eff:</a>
+<a href="https://usegalaxy.org/root?tool_id=vibrant" target="_top" title="">VIBRANT</a>
+<a href="https://usegalaxy.org/root?tool_id=ivar_consensus" target="_top" title="Call consensus from aligned BAM file">ivar consensus</a>
+<a href="https://usegalaxy.org/root?tool_id=ivar_filtervariants" target="_top" title="Filter variants across replicates or multiple samples aligned using the same reference">ivar filtervariants</a>
+<a href="https://usegalaxy.org/root?tool_id=ivar_getmasked" target="_top" title="Detect primer mismatches and get primer indices for the amplicon to be masked">ivar getmasked</a>
+<a href="https://usegalaxy.org/root?tool_id=ivar_removereads" target="_top" title="Remove reads from trimmed BAM file">ivar removereads</a>
+<a href="https://usegalaxy.org/root?tool_id=ivar_trim" target="_top" title="Trim reads in aligned BAM">ivar trim</a>
+<a href="https://usegalaxy.org/root?tool_id=ivar_variants" target="_top" title="Call variants from aligned BAM file">ivar variants</a>
+<a href="https://usegalaxy.org/root?tool_id=snipit" target="_top" title="Summarise snps relative to a reference sequence">snipit</a>
+
+</div>
+
+### Metagenomic Analysis
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=biom_add_metadata" target="_top" title="to a BIOM table">Add metadata</a>
+<a href="https://usegalaxy.org/root?tool_id=scikit_bio_diversity_beta_diversity" target="_top" title="using scikit-bio">Beta Diversity</a>
+<a href="https://usegalaxy.org/root?tool_id=binette" target="_top" title="Binning refinement tool">Binette</a>
+<a href="https://usegalaxy.org/root?tool_id=biobox_add_taxid" target="_top" title="Add taxid output from BAT or GTDB to biobox binning data">Biobox add taxid</a>
+<a href="https://usegalaxy.org/root?tool_id=est_abundance" target="_top" title="to re-estimate abundance at a taxonomic level from kraken output">Bracken</a>
+<a href="https://usegalaxy.org/root?tool_id=cami_amber" target="_top" title="Evaluation package for MAGs">CAMI AMBER</a>
+<a href="https://usegalaxy.org/root?tool_id=cami_amber_add" target="_top" title="Create gold standard file for CAMI AMBER">CAMI AMBER add length column</a>
+<a href="https://usegalaxy.org/root?tool_id=cami_amber_convert" target="_top" title="Create binning file(s) for CAMI AMBER">CAMI AMBER convert to biobox</a>
+<a href="https://usegalaxy.org/root?tool_id=cat_add_names" target="_top" title="annotate with taxonomic names">CAT add_names</a>
+<a href="https://usegalaxy.org/root?tool_id=cat_bins" target="_top" title="annotate with taxonomic classification">CAT bins</a>
+<a href="https://usegalaxy.org/root?tool_id=cat_contigs" target="_top" title="annotate with taxonomic classification">CAT contigs</a>
+<a href="https://usegalaxy.org/root?tool_id=cat_prepare" target="_top" title="a database for CAT - Contig Annotation Tool">CAT prepare</a>
+<a href="https://usegalaxy.org/root?tool_id=cat_summarise" target="_top" title="the number of contigs or bins assigned to each taxonomic name">CAT summarise</a>
+<a href="https://usegalaxy.org/root?tool_id=comebin" target="_top" title="Binning of metagenomic contigs using COntrastive Multi-viEw representation learning">COMEBin</a>
+<a href="https://usegalaxy.org/root?tool_id=concoct" target="_top" title="for metagenome binning">CONCOCT</a>
+<a href="https://usegalaxy.org/root?tool_id=concoct_cut_up_fasta" target="_top" title="in non-overlapping or overlapping parts of equal length">CONCOCT: Cut up contigs</a>
+<a href="https://usegalaxy.org/root?tool_id=concoct_extract_fasta_bins" target="_top" title="for each cluster">CONCOCT: Extract a fasta file</a>
+<a href="https://usegalaxy.org/root?tool_id=concoct_coverage_table" target="_top" title="for CONCOCT">CONCOCT: Generate the input coverage table</a>
+<a href="https://usegalaxy.org/root?tool_id=concoct_merge_cut_up_clustering" target="_top" title="and assign concensus clusters for the original contigs">CONCOCT: Merge cut clusters</a>
+<a href="https://usegalaxy.org/root?tool_id=kegg_pathways_completeness" target="_top" title="Compute KEGG pathway/module completeness from KOs or per-contig annotation">Calculate KEGG Pathways completeness</a>
+<a href="https://usegalaxy.org/root?tool_id=metabat2_jgi_summarize_bam_contig_depths" target="_top" title="for MetaBAT2">Calculate contig depths</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_analyze" target="_top" title="Identify marker genes in bins and calculate genome statistics">CheckM analyze</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_lineage_set" target="_top" title="Infer lineage-specific marker sets for each bin">CheckM lineage_set</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_lineage_wf" target="_top" title="Assessing the completeness and contamination of genome bins using lineage-specific marker sets">CheckM lineage_wf</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_plot" target="_top" title="for assessing the quality of genome bins">CheckM plot</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_qa" target="_top" title="Assess bins for contamination and completeness">CheckM qa</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_taxon_set" target="_top" title="Generate taxonomic-specific marker set">CheckM taxon_set</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_taxonomy_wf" target="_top" title="Analyze all genome bins with the same marker set">CheckM taxonomy_wf</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_tetra" target="_top" title="Calculate tetranucleotide signature of sequences">CheckM tetra</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_tree" target="_top" title="Place bins in the genome tree">CheckM tree</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm_tree_qa" target="_top" title="Assess phylogenetic markers in the genome tree">CheckM tree_qa</a>
+<a href="https://usegalaxy.org/root?tool_id=checkv_end_to_end" target="_top" title="">CheckV end to end</a>
+<a href="https://usegalaxy.org/root?tool_id=combine_metaphlan_humann" target="_top" title="to relate genus/species abundances and gene families/pathways abundances">Combine MetaPhlAn and HUMAnN outputs</a>
+<a href="https://usegalaxy.org/root?tool_id=combine_metaphlan2_humann2" target="_top" title="to relate genus/species abundances and gene families/pathways abundances">Combine MetaPhlAn2 and HUMAnN2 outputs</a>
+<a href="https://usegalaxy.org/root?tool_id=biom_convert" target="_top" title="between BIOM table formats">Convert</a>
+<a href="https://usegalaxy.org/root?tool_id=Kraken2Tax" target="_top" title="data to Galaxy taxonomy representation">Convert Kraken</a>
+<a href="https://usegalaxy.org/root?tool_id=Fasta_to_Contig2Bin" target="_top" title="to scaffolds-to-bin table">Converts genome bins in fasta format</a>
+<a href="https://usegalaxy.org/root?tool_id=coverm_contig" target="_top" title="Calculate read coverage per contig">CoverM contig</a>
+<a href="https://usegalaxy.org/root?tool_id=coverm_genome" target="_top" title="Calculate coverage of individual genomes">CoverM genome</a>
+<a href="https://usegalaxy.org/root?tool_id=phyloseq_from_dada2" target="_top" title="from dada2 sequence and taxonomy tables">Create phyloseq object</a>
+<a href="https://usegalaxy.org/root?tool_id=phyloseq_from_biom" target="_top" title="from a BIOM file">Create phyloseq object</a>
+<a href="https://usegalaxy.org/root?tool_id=das_tool" target="_top" title="for genome-resolved metagenomics">DAS Tool</a>
+<a href="https://usegalaxy.org/root?tool_id=defense_finder" target="_top" title="systematically detect known anti-phage systems">DefenseFinder</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_diamond" target="_top" title="align sequences against a protein database">Diamond</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_diamond_makedb" target="_top" title="build database from a FASTA file">Diamond makedb</a>
+<a href="https://usegalaxy.org/root?tool_id=bg_diamond_view" target="_top" title="generate formatted output from DAA files">Diamond view</a>
+<a href="https://usegalaxy.org/root?tool_id=gtdbtk_classify_wf" target="_top" title="by placement in GTDB reference tree">GTDB-Tk Classify genomes</a>
+<a href="https://usegalaxy.org/root?tool_id=humann" target="_top" title="to profile presence/absence and abundance of microbial pathways and gene families">HUMAnN</a>
+<a href="https://usegalaxy.org/root?tool_id=kneaddata" target="_top" title="Quality control and contaminant removal for metagenomic data">KneadData</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken" target="_top" title="assign taxonomic labels to sequencing reads">Kraken</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken_taxonomy_report" target="_top" title="view report of classification for multiple samples">Kraken taxonomic report</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken_biom" target="_top" title="Create BIOM-format tables from kraken output">Kraken-biom</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken-filter" target="_top" title="filter classification by confidence score">Kraken-filter</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken-mpa-report" target="_top" title="view report of classification for multiple samples">Kraken-mpa-report</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken-report" target="_top" title="view sample report of a classification">Kraken-report</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken-translate" target="_top" title="convert taxonomy IDs to names">Kraken-translate</a>
+<a href="https://usegalaxy.org/root?tool_id=kraken2" target="_top" title="assign taxonomic labels to sequencing reads">Kraken2</a>
+<a href="https://usegalaxy.org/root?tool_id=krakentools_alpha_diversity" target="_top" title="from the Bracken abundance estimation file">Krakentools: Calculates alpha diversity</a>
+<a href="https://usegalaxy.org/root?tool_id=krakentools_combine_kreports" target="_top" title="into a combined report file">Krakentools: Combine multiple Kraken reports</a>
+<a href="https://usegalaxy.org/root?tool_id=krakentools_kreport2mpa" target="_top" title="to MetaPhlAn-style">Krakentools: Convert kraken report file</a>
+<a href="https://usegalaxy.org/root?tool_id=krakentools_kreport2krona" target="_top" title="to krona text file">Krakentools: Convert kraken report file</a>
+<a href="https://usegalaxy.org/root?tool_id=krakentools_extract_kraken_reads" target="_top" title="Extract reads that were classified by the Kraken family at specified taxonomic IDs">Krakentools: Extract Kraken Reads By ID</a>
+<a href="https://usegalaxy.org/root?tool_id=krakentools_beta_diversity" target="_top" title="from Kraken, Krona and Bracken files">Krakentools: calculates beta diversity (Bray-Curtis dissimilarity)</a>
+<a href="https://usegalaxy.org/root?tool_id=taxonomy_krona_chart" target="_top" title="from taxonomic profile">Krona pie chart</a>
+<a href="https://usegalaxy.org/root?tool_id=mapseq" target="_top" title="sequence read classification designed to assign taxonomy and OTU classifications">MAPseq</a>
+<a href="https://usegalaxy.org/root?tool_id=motus_map_snv" target="_top" title="Map reads to the marker gene database for SNV calling">Map SNV</a>
+<a href="https://usegalaxy.org/root?tool_id=maxbin2" target="_top" title="clusters metagenomic contigs into bins">MaxBin2</a>
+<a href="https://usegalaxy.org/root?tool_id=mereg_mOTUs_tables" target="_top" title="Merge mOTUs aboundance or count tables">Merge</a>
+<a href="https://usegalaxy.org/root?tool_id=mgnify_seqprep" target="_top" title="Merge and Trim Adapter Sequences from Paired-End Illumina Reads">Merging paired-end Illumina reads (SeqPrep, modified for use with MGnify piplines)</a>
+<a href="https://usegalaxy.org/root?tool_id=metabat2" target="_top" title="metagenome binning">MetaBAT2</a>
+<a href="https://usegalaxy.org/root?tool_id=metaphlan" target="_top" title="to profile the composition of microbial communities">MetaPhlAn</a>
+<a href="https://usegalaxy.org/root?tool_id=gtdb_to_taxdump" target="_top" title="Map taxonomic classifications between the NCBI and GTDB taxonomies">NCBI-GTDB map</a>
+<a href="https://usegalaxy.org/root?tool_id=name2taxid" target="_top" title="Convert taxon names to NCBI Taxids">Name2taxid</a>
+<a href="https://usegalaxy.org/root?tool_id=nonpareil" target="_top" title="to estimate average coverage and generate Nonpareil curves">Nonpareil</a>
+<a href="https://usegalaxy.org/root?tool_id=phi_toolkit_report" target="_top" title="">PHI toolkit report</a>
+<a href="https://usegalaxy.org/root?tool_id=phyloseq_plot_richness" target="_top" title="">Phyloseq: plot alpha diverstiy measure</a>
+<a href="https://usegalaxy.org/root?tool_id=phyloseq_plot_ordination" target="_top" title="">Phyloseq: plot ordination</a>
+<a href="https://usegalaxy.org/root?tool_id=PlasFlow" target="_top" title="Prediction of plasmid sequences in metagenomic contigs">PlasFlow</a>
+<a href="https://usegalaxy.org/root?tool_id=rgi_bwt" target="_top" title="align metagenomic reads to CARD to identify AMR genes">RGI bwt</a>
+<a href="https://usegalaxy.org/root?tool_id=rgi_main" target="_top" title="identify antimicrobial resistance genes using CARD">RGI main</a>
+<a href="https://usegalaxy.org/root?tool_id=recentrifuge" target="_top" title="Robust comparative analysis and contamination removal for metagenomics">Recentrifuge</a>
+<a href="https://usegalaxy.org/root?tool_id=humann_regroup_table" target="_top" title="HUMAnN table features">Regroup</a>
+<a href="https://usegalaxy.org/root?tool_id=humann_rename_table" target="_top" title="of a HUMAnN generated table">Rename features</a>
+<a href="https://usegalaxy.org/root?tool_id=humann_renorm_table" target="_top" title="a HUMAnN generated table">Renormalize</a>
+<a href="https://usegalaxy.org/root?tool_id=rgi" target="_top" title="This tool predicts resistome(s) from protein or nucleotide data based on homology and SNP models.">Resistance Gene Identifier (RGI)</a>
+<a href="https://usegalaxy.org/root?tool_id=bio_hansel" target="_top" title="">Salmonella Subtyping</a>
+<a href="https://usegalaxy.org/root?tool_id=samestr_compare" target="_top" title="performs pairwise clade-specific comparison of metagenomic alignments">SameStr Compare</a>
+<a href="https://usegalaxy.org/root?tool_id=samestr_convert" target="_top" title="MetaPhlAn or mOTUS marker alignments to nucleotide variant profiles">SameStr Convert</a>
+<a href="https://usegalaxy.org/root?tool_id=samestr_extract" target="_top" title="MetaPhlAn or mOTUS marker sequences from reference genomes using BLASTN">SameStr Extract</a>
+<a href="https://usegalaxy.org/root?tool_id=samestr_filter" target="_top" title="nucleotide variant profiles by coverage, sample, marker, and position-based criteria">SameStr Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=samestr_merge" target="_top" title="nucleotide variant profiles obtained from metagenomic samples for filtering and pairwise comparisons">SameStr Merge</a>
+<a href="https://usegalaxy.org/root?tool_id=samestr_stats" target="_top" title="generates statistics for SameStr variant profiles including coverage and diversity metrics">SameStr Stats</a>
+<a href="https://usegalaxy.org/root?tool_id=samestr_summarize" target="_top" title="identfies and reports shared bacterial strains across samples using variant profile similarity">SameStr Summarize</a>
+<a href="https://usegalaxy.org/root?tool_id=semibin" target="_top" title="for Semi-supervised Metagenomic Binning">SemiBin</a>
+<a href="https://usegalaxy.org/root?tool_id=humann_split_stratified_table" target="_top" title="into 2 tables (one stratified and one unstratified)">Split a HUMAnN table</a>
+<a href="https://usegalaxy.org/root?tool_id=humann_unpack_pathways" target="_top" title="to show the genes for each">Unpack pathway abundances</a>
+<a href="https://usegalaxy.org/root?tool_id=valet" target="_top" title="to detect mis-assemblies in metagenomic assemblies">VALET</a>
+<a href="https://usegalaxy.org/root?tool_id=vapor" target="_top" title="Classify Influenza samples from short reads sequence data">VAPOR</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_alignment" target="_top" title="">VSearch alignment</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_chimera_detection" target="_top" title="">VSearch chimera detection</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_clustering" target="_top" title="">VSearch clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_dereplication" target="_top" title="">VSearch dereplication</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_masking" target="_top" title="">VSearch masking</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_search" target="_top" title="">VSearch search</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_shuffling" target="_top" title="">VSearch shuffling</a>
+<a href="https://usegalaxy.org/root?tool_id=vsearch_sorting" target="_top" title="">VSearch sorting</a>
+<a href="https://usegalaxy.org/root?tool_id=vegan_diversity" target="_top" title="index">Vegan Diversity</a>
+<a href="https://usegalaxy.org/root?tool_id=vegan_fisher_alpha" target="_top" title="index">Vegan Fisher Alpha</a>
+<a href="https://usegalaxy.org/root?tool_id=vegan_rarefaction" target="_top" title="curve and statistics">Vegan Rarefaction</a>
+<a href="https://usegalaxy.org/root?tool_id=ampvis2_load" target="_top" title="">ampvis2 load</a>
+<a href="https://usegalaxy.org/root?tool_id=cd_hit_dup" target="_top" title="remove duplicates and detect chimaeras in sequencing reads">cd-hit-dup</a>
+<a href="https://usegalaxy.org/root?tool_id=checkm2" target="_top" title="Rapid assessment of genome bin quality using machine learning">checkm2</a>
+<a href="https://usegalaxy.org/root?tool_id=drep_compare" target="_top" title="compare a list of genomes">dRep compare</a>
+<a href="https://usegalaxy.org/root?tool_id=drep_dereplicate" target="_top" title="De-replicate a list of genomes">dRep dereplicate</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_assignTaxonomyAddspecies" target="_top" title="Learn Error rates">dada2: assignTaxonomy and addSpecies</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_dada" target="_top" title="Remove sequencing errors">dada2: dada</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_filterAndTrim" target="_top" title="Filter and trim short read data">dada2: filterAndTrim</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_learnErrors" target="_top" title="Learn Error rates">dada2: learnErrors</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_makeSequenceTable" target="_top" title="construct a sequence table (analogous to OTU table)">dada2: makeSequenceTable</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_mergePairs" target="_top" title="Merge denoised forward and reverse reads">dada2: mergePairs</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_plotComplexity" target="_top" title="Plot sequence complexity profile">dada2: plotComplexity</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_plotQualityProfile" target="_top" title="plot a visual summary of the quality scores">dada2: plotQualityProfile</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_removeBimeraDenovo" target="_top" title="Remove bimeras from collections of unique sequences">dada2: removeBimeraDenovo</a>
+<a href="https://usegalaxy.org/root?tool_id=dada2_seqCounts" target="_top" title="">dada2: sequence counts</a>
+<a href="https://usegalaxy.org/root?tool_id=genomad_end_to_end" target="_top" title="identify virus and plasmid genomes from nucleotide sequences">geNomad</a>
+<a href="https://usegalaxy.org/root?tool_id=iphop_predict" target="_top" title="host of input bacteriophage/archaeal virus genomes">iPHoP predict</a>
+<a href="https://usegalaxy.org/root?tool_id=metasbt_index" target="_top" title="genomes with Sequence Bloom Trees or update an existing database">index</a>
+<a href="https://usegalaxy.org/root?tool_id=kmetashot" target="_top" title="an alignment-free taxonomic classifier based on k-mer/minimizer counting">kMetaShot</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_abundance_distribution" target="_top" title="Calculate abundance distribution of k-mers using pre-made k-mer countgraphs">khmer: Abundance Distribution</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_abundance_distribution_single" target="_top" title="Calculate abundance distribution of k-mers">khmer: Abundance Distribution (all-in-one)</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_count_median" target="_top" title="Count the median/avg k-mer abundance for each sequence">khmer: Count Median</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_extract_partitions" target="_top" title="Separate sequences that are annotated with partitions into grouped files">khmer: Extract partitions</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_filter_abundance" target="_top" title="by minimal k-mer abundance">khmer: Filter reads</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_filter_below_abundance_cutoff" target="_top" title="below k-mer abundance of 50">khmer: Filter reads</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_normalize_by_median" target="_top" title="Filter reads using digital normalization via k-mer abundances">khmer: Normalize By Median</a>
+<a href="https://usegalaxy.org/root?tool_id=khmer_partition" target="_top" title="Load, partition, and annotate sequences">khmer: Sequence partition all-in-one</a>
+<a href="https://usegalaxy.org/root?tool_id=motus_profiler" target="_top" title="performs taxonomic profiling of metagenomics and metatrancriptomics samples">mOTUs_profiler</a>
+<a href="https://usegalaxy.org/root?tool_id=mash_dist" target="_top" title="Estimate distance between query sequences">mash dist</a>
+<a href="https://usegalaxy.org/root?tool_id=mash_paste" target="_top" title="Create a single sketch file from multiple sketch files.">mash paste</a>
+<a href="https://usegalaxy.org/root?tool_id=mash_screen" target="_top" title="Determine sequence conservation">mash screen</a>
+<a href="https://usegalaxy.org/root?tool_id=mash_sketch" target="_top" title="Create a reduced sequence representation based on min-hashes">mash sketch</a>
+<a href="https://usegalaxy.org/root?tool_id=megahit_contig2fastg" target="_top" title="for converting MEGAHIT&#x27;s contigs (.fa) to assembly graphs (.fastg)">megahit contig2fastg</a>
+<a href="https://usegalaxy.org/root?tool_id=metamdbg_asm" target="_top" title="Assemble long-read metagenomes (HiFi / ONT)">metaMDBG assemble (ASM)</a>
+<a href="https://usegalaxy.org/root?tool_id=metamdbg_gfa" target="_top" title="Generate a GFA graph from a metaMDBG assembly or list available k-values">metaMDBG graph (GFA)</a>
+<a href="https://usegalaxy.org/root?tool_id=metagenomeseq_normalizaton" target="_top" title="Cumulative sum scaling">metagenomeSeq Normalization</a>
+<a href="https://usegalaxy.org/root?tool_id=metasbt_profile" target="_top" title="genomes with MetaSBT to infer their taxonomic">profile</a>
+<a href="https://usegalaxy.org/root?tool_id=staramr_search" target="_top" title="Scans genome assemblies against the ResFinder, PlasmidFinder, and PointFinder databases searching for AMR genes.">staramr</a>
+<a href="https://usegalaxy.org/root?tool_id=sylph_profile" target="_top" title="Profile a metagenome including taxonomic and sequence abundances">sylph profile</a>
+<a href="https://usegalaxy.org/root?tool_id=sylph_query" target="_top" title="compare metagenome similarity to a reference genome">sylph query</a>
+
+</div>
+
+### Single-cell
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=alevin" target="_top" title="Quantification and analysis of 3-prime tagged-end single-cell sequencing data">Alevin</a>
+<a href="https://usegalaxy.org/root?tool_id=anndata_ops" target="_top" title="is a Swiss army knife for AnnData files">AnnData Operations</a>
+<a href="https://usegalaxy.org/root?tool_id=episcanpy_build_matrix" target="_top" title="with EpiScanpy">Build count matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=cite_seq_count" target="_top" title="Count CMO/HTO">CITE-seq-Count</a>
+<a href="https://usegalaxy.org/root?tool_id=raceid_inspectclusters" target="_top" title="examines gene expression within clusters">Cluster Inspection using RaceID</a>
+<a href="https://usegalaxy.org/root?tool_id=raceid_clustering" target="_top" title="performs clustering, outlier detection, dimensional reduction">Clustering using RaceID</a>
+<a href="https://usegalaxy.org/root?tool_id=baredsc_combine_1d" target="_top" title="from baredSC">Combine multiple 1D Models</a>
+<a href="https://usegalaxy.org/root?tool_id=baredsc_combine_2d" target="_top" title="from baredSC">Combine multiple 2D Models</a>
+<a href="https://usegalaxy.org/root?tool_id=music_construct_eset" target="_top" title="Create an ExpressionSet object from tabular and textual data">Construct Expression Set Object</a>
+<a href="https://usegalaxy.org/root?tool_id=decoupler_pseudobulk" target="_top" title="aggregates single cell RNA-seq data for running bulk RNA-seq methods">Decoupler pseudo-bulk</a>
+<a href="https://usegalaxy.org/root?tool_id=_dropletBarcodePlot" target="_top" title="Creates a barcode rank plot for quality control of droplet single-cell RNA-seq data">Droplet barcode rank plot</a>
+<a href="https://usegalaxy.org/root?tool_id=dropletutils" target="_top" title="Utilities for handling droplet-based single-cell RNA-seq data">DropletUtils</a>
+<a href="https://usegalaxy.org/root?tool_id=dropletutils_read_10x" target="_top" title="into SingleCellExperiment object">DropletUtils Read10x</a>
+<a href="https://usegalaxy.org/root?tool_id=dropletutils_empty_drops" target="_top" title="Distinguish between droplets containing cells and ambient RNA in a droplet-based single-cell RNA sequencing experiment.">DropletUtils emptyDrops</a>
+<a href="https://usegalaxy.org/root?tool_id=retrieve_scxa" target="_top" title="Retrieves expression matrixes and metadata from EBI Single Cell Expression Atlas (SCXA)">EBI SCXA Data Retrieval</a>
+<a href="https://usegalaxy.org/root?tool_id=anndata_export" target="_top" title="matrix and annotations">Export AnnData</a>
+<a href="https://usegalaxy.org/root?tool_id=_ensembl_gtf2gene_list" target="_top" title="extracts a complete annotation table or subsets thereof from an Ensembl GTF using rtracklayer">GTF2GeneList</a>
+<a href="https://usegalaxy.org/root?tool_id=anndata_import" target="_top" title="from different formats">Import Anndata</a>
+<a href="https://usegalaxy.org/root?tool_id=raceid_filtnormconf" target="_top" title="performs filtering, normalisation, and confounder removal to generate a normalised and filtered count matrix of single-cell RNA data">Initial processing using RaceID</a>
+<a href="https://usegalaxy.org/root?tool_id=anndata_inspect" target="_top" title="object">Inspect AnnData</a>
+<a href="https://usegalaxy.org/root?tool_id=music_inspect_eset" target="_top" title="Inspect an ExpressionSet object by a variety of attributes">Inspect Expression Set Object</a>
+<a href="https://usegalaxy.org/root?tool_id=raceid_inspecttrajectory" target="_top" title="inspects branches of a lineage tree">Lineage Branch Analysis using StemID</a>
+<a href="https://usegalaxy.org/root?tool_id=raceid_trajectory" target="_top" title="generates lineage from prior clustering">Lineage computation using StemID</a>
+<a href="https://usegalaxy.org/root?tool_id=modify_loom" target="_top" title="Manipulate, export and import loom data">Loom operations</a>
+<a href="https://usegalaxy.org/root?tool_id=anndata_manipulate" target="_top" title="object">Manipulate AnnData</a>
+<a href="https://usegalaxy.org/root?tool_id=music_manipulate_eset" target="_top" title="Manipulate ExpressionSet objects by a variety of attributes">Manipulate Expression Set Object</a>
+<a href="https://usegalaxy.org/root?tool_id=music_compare" target="_top" title="estimate and compare cell type proportions in multiple sets of bulk RNA-seq data">MuSiC Compare</a>
+<a href="https://usegalaxy.org/root?tool_id=music_deconvolution" target="_top" title="estimate cell type proportions in bulk RNA-seq data">MuSiC Deconvolution</a>
+<a href="https://usegalaxy.org/root?tool_id=sceasy_convert" target="_top" title="Convert between common single cell formats">SCEasy Converter</a>
+<a href="https://usegalaxy.org/root?tool_id=sceasy_convert" target="_top" title="a data object between formats">SCEasy convert</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_compute_graph" target="_top" title="to derive kNN graph">Scanpy ComputeGraph</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_run_dpt" target="_top" title="diffusion pseudotime inference">Scanpy DPT</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_run_diffmap" target="_top" title="calculate diffusion components">Scanpy DiffusionMap</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_filter_cells" target="_top" title="based on counts and numbers of genes expressed">Scanpy FilterCells</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_filter_genes" target="_top" title="based on counts and numbers of cells expressed">Scanpy FilterGenes</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_find_cluster" target="_top" title="based on community detection on KNN graph">Scanpy FindCluster</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_find_markers" target="_top" title="to find differentially expressed genes between groups">Scanpy FindMarkers</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_find_variable_genes" target="_top" title="based on normalised dispersion of expression">Scanpy FindVariableGenes</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_integrate_harmony" target="_top" title="adjust principal components for variables that might introduce batch effect">Scanpy Harmony</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_inspect" target="_top" title="">Scanpy Inspect and manipulate</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_normalise_data" target="_top" title="to make all cells having the same total expression">Scanpy NormaliseData</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_run_paga" target="_top" title="trajectory inference">Scanpy PAGA</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_parameter_iterator" target="_top" title="produce an iteration over a defined parameter">Scanpy ParameterIterator</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_plot_embed" target="_top" title="visualise cell embeddings">Scanpy PlotEmbed</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_plot_trajectory" target="_top" title="visualise cell trajectories">Scanpy PlotTrajectory</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_read_10x" target="_top" title="into hdf5 object handled by scanpy">Scanpy Read10x</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_regress_variable" target="_top" title="variables that might introduce batch effect">Scanpy RegressOut</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_run_fdg" target="_top" title="visualise cell clusters using force-directed graph">Scanpy RunFDG</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_run_pca" target="_top" title="for dimensionality reduction">Scanpy RunPCA</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_run_tsne" target="_top" title="visualise cell clusters using tSNE">Scanpy RunTSNE</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_run_umap" target="_top" title="visualise cell clusters using UMAP">Scanpy RunUMAP</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_scale_data" target="_top" title="to make expression variance the same for all genes">Scanpy ScaleData</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_cluster_reduce_dimension" target="_top" title="and infer trajectories">Scanpy cluster, embed</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_filter" target="_top" title="mark and subsample">Scanpy filter</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_normalize" target="_top" title="and impute">Scanpy normalize</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_plot" target="_top" title="">Scanpy plot</a>
+<a href="https://usegalaxy.org/root?tool_id=scanpy_remove_confounders" target="_top" title="with scanpy">Scanpy remove confounders</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_create" target="_top" title="- Prepare data for the pipeline">Seurat Create</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_data" target="_top" title="- Inspect and Manipulate">Seurat Data Management</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_clustering" target="_top" title="- Neighbors and Markers">Seurat Find Clusters</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_integrate" target="_top" title="and manipulate layers">Seurat Integrate</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_preprocessing" target="_top" title="- Normalize, Find Variable Features, Scale and Regress">Seurat Preprocessing</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_reduce_dimension" target="_top" title="- PCA, tSNE or UMAP">Seurat Run Dimensional Reduction</a>
+<a href="https://usegalaxy.org/root?tool_id=seurat_plot" target="_top" title="- Plot cells, features and dimensions">Seurat Visualize</a>
+<a href="https://usegalaxy.org/root?tool_id=sinto_barcode" target="_top" title="add cell barcodes to FASTQ read names">Sinto barcode</a>
+<a href="https://usegalaxy.org/root?tool_id=sinto_fragments" target="_top" title="Create an ATAC-seq fragment file from a BAM file">Sinto fragments</a>
+<a href="https://usegalaxy.org/root?tool_id=snapatac2_clustering" target="_top" title="and dimension reduction">SnapATAC2 Clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=snapatac2_plotting" target="_top" title="">SnapATAC2 Plotting</a>
+<a href="https://usegalaxy.org/root?tool_id=snapatac2_preprocessing" target="_top" title="and integration">SnapATAC2 Preprocessing</a>
+<a href="https://usegalaxy.org/root?tool_id=snapatac2_peaks_and_motif" target="_top" title="analysis">SnapATAC2 peaks and motif</a>
+<a href="https://usegalaxy.org/root?tool_id=baredsc_1d" target="_top" title="Compute distribution for a single gene">baredSC 1d</a>
+<a href="https://usegalaxy.org/root?tool_id=baredsc_2d" target="_top" title="Compute distribution for a pair of genes">baredSC 2d</a>
+<a href="https://usegalaxy.org/root?tool_id=_salmon_kallisto_mtx_to_10x" target="_top" title="Transforms .mtx matrix and associated labels into a format compatible with tools expecting old-style 10X data">salmonKallistoMtxTo10x</a>
+<a href="https://usegalaxy.org/root?tool_id=episcanpy_preprocess" target="_top" title="with EpiScanpy">scATAC-seq Preprocessing</a>
+<a href="https://usegalaxy.org/root?tool_id=velocyto_cli" target="_top" title="pre-process data for the analysis of RNA velocity">velocyto CLI</a>
+
+</div>
+
+### Import/manipulate sc data
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=10x_bamtofastq" target="_top" title="">Convert a 10X BAM file to FASTQ</a>
+<a href="https://usegalaxy.org/root?tool_id=scater_read_10x_results" target="_top" title="Loads 10x data into a serialized scater R object">Scater read 10x data</a>
+<a href="https://usegalaxy.org/root?tool_id=scran_normalize" target="_top" title="Normalize raw counts expression values using deconvolution size factors">scran_normalize</a>
+
+</div>
+
+### Imaging
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_adapt_transform" target="_top" title="with ImageJ2">Adapt an elastic transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_noise" target="_top" title="with ImageJ2">Add or remove noise</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_shadows" target="_top" title="with ImageJ2">Add shadow effect</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_adjust_threshold_binary" target="_top" title="with ImageJ2">Adjust threshold</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_align" target="_top" title="with ImageJ2">Align two images</a>
+<a href="https://usegalaxy.org/root?tool_id=squidpy_spatial" target="_top" title="with Squidpy">Analyze and visualize spatial multi-omics data</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_analyze_particles_binary" target="_top" title="with ImageJ2">Analyze particles</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_analyze_skeleton" target="_top" title="with ImageJ2">Analyze skeleton</a>
+<a href="https://usegalaxy.org/root?tool_id=morphological_operations" target="_top" title="with SciPy">Apply a morphological operation</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_anisotropic_diffusion" target="_top" title="with MedPy">Apply anisotropic diffusion</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_elastic_transform" target="_top" title="with ImageJ">Apply elastic transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_raw_transform" target="_top" title="with ImageJ2">Apply raw transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=ridge_filter_skimage" target="_top" title="with scikit-image">Apply ridge filter</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_filter_standard" target="_top" title="with scipy">Apply standard image filter</a>
+<a href="https://usegalaxy.org/root?tool_id=backsub" target="_top" title="for sequential immunofluorescence images">Background subtraction</a>
+<a href="https://usegalaxy.org/root?tool_id=clip_image" target="_top" title="with giatools">Clip image intensities</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_colocalization" target="_top" title="of two segmentation maps">Colocalization</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_color_to_gray" target="_top" title="with CellProfiler">ColorToGray</a>
+<a href="https://usegalaxy.org/root?tool_id=colorize_labels" target="_top" title="with NetworkX">Colorize label map</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_compare_elastic_raw" target="_top" title="with ImageJ2">Compare elastic and raw deformation</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_compare_elastic" target="_top" title="with ImageJ2">Compare opposite elastic deformations</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_compare_raw" target="_top" title="with ImageJ2">Compare two raw deformations</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_compose_raw_elastic" target="_top" title="into a raw transformation with bUnwarpJ">Compose a raw and an elastic transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_compose_elastic" target="_top" title="with ImageJ2">Compose two elastic transformations</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_compose_raw" target="_top" title="with ImageJ2">Compose two raw transformations</a>
+<a href="https://usegalaxy.org/root?tool_id=voronoi_tessellation" target="_top" title="with scikit-image">Compute Voronoi tessellation</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_mahotas_features" target="_top" title="with Mahotas">Compute image features</a>
+<a href="https://usegalaxy.org/root?tool_id=orientationpy" target="_top" title="with OrientationPy">Compute image orientation</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_segmetrics" target="_top" title="with SegMetrics">Compute image segmentation and object detection performance measures</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_concat_channels" target="_top" title="">Concatenate images</a>
+<a href="https://usegalaxy.org/root?tool_id=highdicom_dicom2tiff" target="_top" title="with highdicom">Convert DICOM to TIFF</a>
+<a href="https://usegalaxy.org/root?tool_id=scimap_mcmicro_to_anndata" target="_top" title="to be used in scimap/scanpy">Convert McMicro Output to Anndata</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_binary_to_edm" target="_top" title="with ImageJ2">Convert binary image to EDM</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_binary_to_labelimage" target="_top" title="with giatools">Convert binary image to label map</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_binaryimage_to_points" target="_top" title="">Convert binary image to points (center of masses)</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_coordinates_of_roi" target="_top" title="">Convert binary image to points (point coordinates)</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_points_to_label" target="_top" title="">Convert coordinates to label map</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_bunwarpj_convert_to_raw" target="_top" title="with ImageJ2">Convert elastic transformation to raw</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_convertimage" target="_top" title="with Bioformats">Convert image format</a>
+<a href="https://usegalaxy.org/root?tool_id=label_to_binary" target="_top" title="with NumPy">Convert label map to binary image</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_labelimage_to_points" target="_top" title="">Convert label map to points (center of masses)</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_points_to_binaryimage" target="_top" title="">Convert point coordinates to binary image</a>
+<a href="https://usegalaxy.org/root?tool_id=repeat_channels" target="_top" title="with NumPy">Convert single-channel to multi-channel image</a>
+<a href="https://usegalaxy.org/root?tool_id=bf2raw" target="_top" title="with Bio-Formats">Convert to OME-Zarr</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_make_binary" target="_top" title="with ImageJ2">Convert to binary</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_convert_objects_to_image" target="_top" title="with CellProfiler">ConvertObjectsToImage</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_count_objects" target="_top" title="">Count objects in label map</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_create_image" target="_top" title="with ImageJ2">Create new image</a>
+<a href="https://usegalaxy.org/root?tool_id=squidpy_scatter" target="_top" title="with Squidpy">Create spatial scatterplot</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_crop_image" target="_top" title="with giatools">Crop image</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_display_data_on_image" target="_top" title="with CellProfiler">DisplayDataOnImage</a>
+<a href="https://usegalaxy.org/root?tool_id=idr_download_by_ids" target="_top" title="">Download IDR/OMERO</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_enhance_contrast" target="_top" title="with ImageJ2">Enhance contrast</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_enhance_or_suppress_features" target="_top" title="with CellProfiler">EnhanceOrSuppressFeatures</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_visceral_evaluatesegmentation" target="_top" title="with EvaluateSegmentation">Evaluate segmentation</a>
+<a href="https://usegalaxy.org/root?tool_id=highdicom_dicom2text" target="_top" title="with highdicom">Export DICOM metadata</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_export_to_spreadsheet" target="_top" title="with CellProfiler">ExportToSpreadsheet</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_2d_feature_extraction" target="_top" title="with scikit-image">Extract image features</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_wsi_extract_top_view" target="_top" title="with OpenSlide">Extract top view from whole-slide image</a>
+<a href="https://usegalaxy.org/root?tool_id=bia_download" target="_top" title="Download images from Bioimage Archive">FTP Link for Bioimage Archive</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_2d_filter_segmentation_by_features" target="_top" title="with giatools">Filter label map by rules</a>
+<a href="https://usegalaxy.org/root?tool_id=iscc_sum_similarity" target="_top" title="with ISCC-SUM">Find datasets with similar ISCC-CODEs</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_find_edges" target="_top" title="with ImageJ2">Find edges</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_find_maxima" target="_top" title="with ImageJ2">Find maxima</a>
+<a href="https://usegalaxy.org/root?tool_id=iscc_sum" target="_top" title="with ISCC-SUM">Generate ISCC-CODE</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_gray_to_color" target="_top" title="with CellProfiler">GrayToColor</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_identify_primary_objects" target="_top" title="with CellProfiler">IdentifyPrimaryObjects</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_image_math" target="_top" title="with CellProfiler">ImageMath</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_landmark_registration_ls" target="_top" title="using least squares">Landmark Registration</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_localthreshold" target="_top" title="applies a local threshold algorithm to an image">Local Threshold</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_mask_image" target="_top" title="with CellProfiler">MaskImage</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_measure_granularity" target="_top" title="with CellProfiler">MeasureGranularity</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_measure_image_area_occupied" target="_top" title="with CellProfiler">MeasureImageAreaOccupied</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_measure_image_intensity" target="_top" title="with CellProfiler">MeasureImageIntensity</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_measure_image_quality" target="_top" title="with CellProfiler">MeasureImageQuality</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_measure_object_intensity" target="_top" title="with CellProfiler">MeasureObjectIntensity</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_measure_object_size_shape" target="_top" title="with CellProfiler">MeasureObjectSizeShape</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_measure_texture" target="_top" title="with CellProfiler">MeasureTexture</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_merge_neighbours_in_label" target="_top" title="">Merge neighbors in label map</a>
+<a href="https://usegalaxy.org/root?tool_id=omero_dataset_to_plate" target="_top" title="with omero-py">OMERO Dataset to Plate</a>
+<a href="https://usegalaxy.org/root?tool_id=omero_filter" target="_top" title="with ezomero">OMERO IDs</a>
+<a href="https://usegalaxy.org/root?tool_id=omero_import" target="_top" title="with omero-py">OMERO Image Import</a>
+<a href="https://usegalaxy.org/root?tool_id=omero_metadata_import" target="_top" title="with ezomero">OMERO Metadata Import</a>
+<a href="https://usegalaxy.org/root?tool_id=omero_roi_import" target="_top" title="with ezomero">OMERO ROI Import</a>
+<a href="https://usegalaxy.org/root?tool_id=omero_get_id" target="_top" title="with ezomero">OMERO get IDs</a>
+<a href="https://usegalaxy.org/root?tool_id=omero_get_value" target="_top" title="with ezomero">OMERO get Object</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_math" target="_top" title="with ImageJ2">Operate on pixels</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_viz_overlay_moving_and_fixed_image" target="_top" title="moving and fixed image">Overlay</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_overlay_segmentation" target="_top" title="Overlay Segmentation Mask">Overlay Segmentation Mask</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_overlay_images" target="_top" title="">Overlay images</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_overlay_outlines" target="_top" title="with CellProfiler">OverlayOutlines</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_spot_detection_2d" target="_top" title="">Perform 2-D spot detection</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_image_registration" target="_top" title="">Perform affine image registration (intensity-based)</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_color_deconvolution" target="_top" title="">Perform color deconvolution or transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_curve_fitting" target="_top" title="">Perform curve fitting</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_histogram_equalization" target="_top" title="with scikit-image">Perform histogram equalization</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_points_association_nn" target="_top" title="">Perform linking in time series (nearest neighbors)</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_projective_transformation" target="_top" title="">Perform projective transformation of an image</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_projective_transformation_points" target="_top" title="">Perform projective transformation of point coordinates</a>
+<a href="https://usegalaxy.org/root?tool_id=plantseg" target="_top" title="with PlantSeg">Perform segmentation in densely packed 3-D volumetric images</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_superdsm" target="_top" title="with SuperDSM">Perform segmentation using deformable shape models</a>
+<a href="https://usegalaxy.org/root?tool_id=rfove" target="_top" title="with RFOVE">Perform segmentation using region-based fitting of overlapping ellipses</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_watershed_binary" target="_top" title="with ImageJ2">Perform segmentation using watershed transformation</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_permutate_axis" target="_top" title="">Permutate image axes</a>
+<a href="https://usegalaxy.org/root?tool_id=image_math" target="_top" title="with NumPy">Process images using arithmetic expressions</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_relate_objects" target="_top" title="with CellProfiler">RelateObjects</a>
+<a href="https://usegalaxy.org/root?tool_id=background_removal" target="_top" title="with scikit-image">Remove image background</a>
+<a href="https://usegalaxy.org/root?tool_id=rename_tiff_channels" target="_top" title="with ome-types">Rename OME-TIFF channels</a>
+<a href="https://usegalaxy.org/root?tool_id=libcarna_render" target="_top" title="with LibCarna">Render 3-D image data</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_cellprofiler4" target="_top" title="with CellProfiler 4">Run CellProfiler pipeline</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_cellprofiler" target="_top" title="with CellProfiler 3">Run CellProfiler pipeline</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_save_images" target="_top" title="with CellProfiler">SaveImages</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_scale_image" target="_top" title="with scikit-image">Scale image</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_sharpen" target="_top" title="with ImageJ2">Sharpen</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_imageinfo" target="_top" title="with Bioformats">Show image info</a>
+<a href="https://usegalaxy.org/root?tool_id=scimap_phenotyping" target="_top" title="using scimap">Single Cell Phenotyping</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_skeletonize3d" target="_top" title="with ImageJ2">Skeletonize</a>
+<a href="https://usegalaxy.org/root?tool_id=imagej2_smooth" target="_top" title="with ImageJ2">Smooth image</a>
+<a href="https://usegalaxy.org/root?tool_id=scimap_plotting" target="_top" title="from Scimap">Spatial plotting functions</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_split_image" target="_top" title="with NumPy">Split image along axes</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_split_labelmap" target="_top" title="">Split label map using morphological operators</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_2d_split_binaryimage_by_watershed" target="_top" title="Split binary image by using watershed">Split objects</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_common" target="_top" title="Load images and metadata">Starting Modules</a>
+<a href="https://usegalaxy.org/root?tool_id=imagecoordinates_flipaxis" target="_top" title="">Switch axis coordinates</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_threshold" target="_top" title="with scikit-image">Threshold image</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_tile" target="_top" title="with CellProfiler">Tile</a>
+<a href="https://usegalaxy.org/root?tool_id=cp_track_objects" target="_top" title="with CellProfiler">TrackObjects</a>
+<a href="https://usegalaxy.org/root?tool_id=iscc_sum_verify" target="_top" title="with ISCC-SUM">Verify ISCC-CODE</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_detection_viz" target="_top" title="">Visualize detections</a>
+<a href="https://usegalaxy.org/root?tool_id=vitessce_spatial" target="_top" title="Visual Integration Tool for the Exploration of Spatial Single-Cell Experiments">Vitessce</a>
+
+</div>
+
+### Proteomics
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=colabfold_alphafold" target="_top" title="Predict protein structures with Colabfold">Colabfold Alphafold</a>
+<a href="https://usegalaxy.org/root?tool_id=colabfold_msa" target="_top" title="Generate MSAs for the Alphafold step of Colabfold">Colabfold MSA</a>
+<a href="https://usegalaxy.org/root?tool_id=custom_pro_db" target="_top" title="Generate protein FASTAs from exosome or transcriptome data">CustomProDB</a>
+<a href="https://usegalaxy.org/root?tool_id=DecoyDatabase" target="_top" title="Create decoy sequence database from forward sequence database">DecoyDatabase</a>
+<a href="https://usegalaxy.org/root?tool_id=encyclopedia_quantify" target="_top" title="samples from Data-Independent Acquisition (DIA) MS/MS Data">EncyclopeDIA Quantify</a>
+<a href="https://usegalaxy.org/root?tool_id=FalseDiscoveryRate" target="_top" title="Estimates the false discovery rate on peptide and protein level using decoy searches">FalseDiscoveryRate</a>
+<a href="https://usegalaxy.org/root?tool_id=fasta_cli" target="_top" title="Appends decoy sequences to FASTA files">FastaCLI</a>
+<a href="https://usegalaxy.org/root?tool_id=FeatureFinderMultiplex" target="_top" title="Determination of peak ratios in LC-MS data">FeatureFinderMultiplex</a>
+<a href="https://usegalaxy.org/root?tool_id=fragpipe" target="_top" title="Data analysis for mass spectrometry-based proteomics">FragPipe -  Academic Research and Education User License (Non-Commercial)</a>
+<a href="https://usegalaxy.org/root?tool_id=fragpipe_manifest_generator" target="_top" title="Generate a FragPipe Manifest File (Experimental Design File)">FragPipe Manifest Generator</a>
+<a href="https://usegalaxy.org/root?tool_id=IDMapper" target="_top" title="Assigns protein/peptide identifications to features or consensus features">IDMapper</a>
+<a href="https://usegalaxy.org/root?tool_id=ident_params" target="_top" title="Sets the identification parameters to be used in SearchGUI and PeptideShaker apps">Identification Parameters</a>
+<a href="https://usegalaxy.org/root?tool_id=kstar_calculate" target="_top" title="Calculate kinase activities from phosphoproteomic datasets using the KSTAR algorithm">KSTAR Activity Prediction</a>
+<a href="https://usegalaxy.org/root?tool_id=MSGFPlusAdapter" target="_top" title="MS/MS database search using MS-GF+">MSGFPlusAdapter</a>
+<a href="https://usegalaxy.org/root?tool_id=msstats" target="_top" title="statistical relative protein significance analysis in DDA, SRM and DIA Mass Spectrometry">MSstats</a>
+<a href="https://usegalaxy.org/root?tool_id=msstatstmt" target="_top" title="protein significance analysis in shotgun mass spectrometry-based proteomic experiments with tandem mass tag (TMT) labeling">MSstatsTMT</a>
+<a href="https://usegalaxy.org/root?tool_id=maxquant" target="_top" title="">MaxQuant</a>
+<a href="https://usegalaxy.org/root?tool_id=maxquant_mqpar" target="_top" title="">MaxQuant (using mqpar.xml)</a>
+<a href="https://usegalaxy.org/root?tool_id=metanovo" target="_top" title="Produce targeted databases for mass spectrometry analysis.">MetaNovo</a>
+<a href="https://usegalaxy.org/root?tool_id=MetaProSIP" target="_top" title="Performs proteinSIP on peptide features for elemental flux analysis">MetaProSIP</a>
+<a href="https://usegalaxy.org/root?tool_id=pep_pointer" target="_top" title="classify genomic location of peptides">PepPointer</a>
+<a href="https://usegalaxy.org/root?tool_id=pepquery" target="_top" title="Peptide-centric search engine for novel peptide identification and validation.">PepQuery</a>
+<a href="https://usegalaxy.org/root?tool_id=pepquery2" target="_top" title="Peptide-centric search engine for novel peptide identification and validation.">PepQuery2</a>
+<a href="https://usegalaxy.org/root?tool_id=pepquery2_show_sets" target="_top" title="PepQueryDB datasets, Parameters, PTMs">PepQuery2 Show Sets</a>
+<a href="https://usegalaxy.org/root?tool_id=pepquery2_index" target="_top" title="MS/MS data for faster search">PepQuery2 index</a>
+<a href="https://usegalaxy.org/root?tool_id=peptide_genomic_coordinate" target="_top" title="Get Peptide&#x27;s genomic coordinate using mzsqlite DB and genomic mapping sqlite DB">Peptide Genomic Coordinate</a>
+<a href="https://usegalaxy.org/root?tool_id=peptide_shaker" target="_top" title="Perform protein identification using various search engines based on results from SearchGUI">Peptide Shaker</a>
+<a href="https://usegalaxy.org/root?tool_id=PeptideIndexer" target="_top" title="Refreshes the protein references for all peptide hits">PeptideIndexer</a>
+<a href="https://usegalaxy.org/root?tool_id=reactome" target="_top" title="Perform a Reactome analysis">Reactome Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=reactome_gsa" target="_top" title="Perform a ReactomeGSA analysis">Reactome GSA Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=search_gui" target="_top" title="Perform protein identification using various search engines and prepare results for input to Peptide Shaker">Search GUI</a>
+<a href="https://usegalaxy.org/root?tool_id=encyclopedia_searchtolib" target="_top" title="Build a Chromatogram Library from Data-Independent Acquisition (DIA) MS/MS Data">SearchToLib</a>
+<a href="https://usegalaxy.org/root?tool_id=validate_fasta_database" target="_top" title="">Validate FASTA Database</a>
+<a href="https://usegalaxy.org/root?tool_id=eggnog_mapper" target="_top" title="functional sequence annotation by orthology">eggNOG Mapper</a>
+<a href="https://usegalaxy.org/root?tool_id=eggnog_mapper_annotate" target="_top" title="annotation phase">eggNOG Mapper</a>
+<a href="https://usegalaxy.org/root?tool_id=eggnog_mapper_search" target="_top" title="search phase">eggNOG Mapper</a>
+
+</div>
+
+### Metabolomics
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=abims_CAMERA_annotateDiffreport" target="_top" title="CAMERA annotate function. Returns annotation results (isotope peaks, adducts and fragments) and a diffreport if more than one condition.">CAMERA.annotate</a>
+<a href="https://usegalaxy.org/root?tool_id=checkFormat" target="_top" title="Checking/formatting the sample and variable names of the dataMatrix, sampleMetadata, and variableMetadata files">Check Format</a>
+<a href="https://usegalaxy.org/root?tool_id=idchoice" target="_top" title="Choosing a particular column in your metadata to be considered as Identifiers">ID choice</a>
+<a href="https://usegalaxy.org/root?tool_id=intens_check" target="_top" title="Statistical measures, number of missing values and mean fold change">Intensity Check</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_findRecalSeries" target="_top" title="Selects most suitable series for recalibration">MFAssignR FindRecalSeries</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_histnoise" target="_top" title="Noise level assessment using the HistNoise">MFAssignR HistNoise</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_isofiltr" target="_top" title="Separates likely isotopic masses from monoisotopic masses in a mass list">MFAssignR IsoFiltR</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_kmdnoise" target="_top" title="Noise level assessment using the KMDNoise.">MFAssignR KMDNoise</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_mfassign" target="_top" title="Molecular formula assignment.">MFAssignR MFAssign</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_mfassignCHO" target="_top" title="Molecular formula assignment (only with CHO).">MFAssignR MFAssignCHO</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_recal" target="_top" title="Internal mass recalibration using a recalibrant series.">MFAssignR Recal</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_recallist" target="_top" title="Identification of candidate series for recalibration.">MFAssignR RecalList</a>
+<a href="https://usegalaxy.org/root?tool_id=mfassignr_snplot" target="_top" title="Noise level assessment using the SNplot function.">MFAssignR SNplot</a>
+<a href="https://usegalaxy.org/root?tool_id=msnbase_readmsdata" target="_top" title="Imports mass-spectrometry data files">MSnbase readMSData</a>
+<a href="https://usegalaxy.org/root?tool_id=ramclustr" target="_top" title="A feature clustering algorithm for non-targeted mass spectrometric metabolomics data.">RAMClustR</a>
+<a href="https://usegalaxy.org/root?tool_id=ramclustr_define_experiment" target="_top" title="Definition of experimental design used for record keeping and writing spectra data.">RAMClustR define experiment</a>
+<a href="https://usegalaxy.org/root?tool_id=riassigner" target="_top" title="compute retention indices">RIAssigner</a>
+<a href="https://usegalaxy.org/root?tool_id=waveica" target="_top" title="removal of batch effects for untargeted metabolomics data">WaveICA</a>
+<a href="https://usegalaxy.org/root?tool_id=matchms" target="_top" title="calculate the similarity score and matched peaks">matchMS similarity</a>
+<a href="https://usegalaxy.org/root?tool_id=matchms_filtering" target="_top" title="filter and normalize mass spectrometry data">matchms filtering</a>
+<a href="https://usegalaxy.org/root?tool_id=matchms_formatter" target="_top" title="reformat scores object of matchms to long format table">matchms scores formatter</a>
+<a href="https://usegalaxy.org/root?tool_id=metams_runGC" target="_top" title="GC-MS data preprocessing using metaMS package">metaMS.runGC</a>
+<a href="https://usegalaxy.org/root?tool_id=msconvert" target="_top" title="Convert and/or filter mass spectrometry files">msconvert</a>
+<a href="https://usegalaxy.org/root?tool_id=table_pandas_rename_column" target="_top" title="of a table">table rename column</a>
+<a href="https://usegalaxy.org/root?tool_id=abims_xcms_retcor" target="_top" title="Retention Time Correction">xcms adjustRtime (retcor)</a>
+<a href="https://usegalaxy.org/root?tool_id=abims_xcms_fillPeaks" target="_top" title="Integrate areas of missing peaks">xcms fillChromPeaks (fillPeaks)</a>
+<a href="https://usegalaxy.org/root?tool_id=abims_xcms_xcmsSet" target="_top" title="Chromatographic peak detection">xcms findChromPeaks (xcmsSet)</a>
+<a href="https://usegalaxy.org/root?tool_id=xcms_merge" target="_top" title="Merge xcms findChromPeaks RData into a unique file to be used by group">xcms findChromPeaks Merger</a>
+<a href="https://usegalaxy.org/root?tool_id=xcms_export_samplemetadata" target="_top" title="which need to be filled with extra information">xcms get a sampleMetadata file</a>
+<a href="https://usegalaxy.org/root?tool_id=abims_xcms_group" target="_top" title="Perform the correspondence, the grouping of chromatographic peaks within and between samples.">xcms groupChromPeaks (group)</a>
+<a href="https://usegalaxy.org/root?tool_id=xcms_plot_chromatogram" target="_top" title="Plots base peak intensity chromatogram (BPI) and total ion current chromatogram (TIC) from MSnbase or xcms experiment(s)">xcms plot chromatogram</a>
+<a href="https://usegalaxy.org/root?tool_id=abims_xcms_summary" target="_top" title="Create a summary of XCMS analysis">xcms process history</a>
+
+</div>
+
+### ChemicalToolBox
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=featurestein" target="_top" title="feature overlay scoring">&#x27;FeatureStein&#x27; fragment overlay scoring</a>
+<a href="https://usegalaxy.org/root?tool_id=apoc" target="_top" title="Large-scale structural comparison of protein pockets">APoc</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_addh" target="_top" title="at a certain pH value">Add hydrogen atoms</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_ob_addh" target="_top" title="at a certain pH value">Add hydrogen atoms</a>
+<a href="https://usegalaxy.org/root?tool_id=gromacs_modify_topology" target="_top" title="to a GROMACS topology file">Adding New Topology Information</a>
+<a href="https://usegalaxy.org/root?tool_id=alchemical_analysis" target="_top" title="Analysis of alchemical free energy calculations">Alchemical Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=biopdb_align_and_rmsd" target="_top" title="using Biopython">Align structures and compute relative RMSDs</a>
+<a href="https://usegalaxy.org/root?tool_id=alphafold" target="_top" title="- AI-guided 3D structural prediction of proteins">Alphafold 2</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_angle" target="_top" title="- time series of Angles">Angle Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=ambertools_antechamber" target="_top" title="- Amber&#x27;s molecular input file processor">AnteChamber</a>
+<a href="https://usegalaxy.org/root?tool_id=tleap" target="_top" title="interactively build and run tLEaP files to set up systems with AmberTools">Build tLEaP</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_cluster_butina" target="_top" title="using RDKit">Butina Cluster</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_cluster_butina_matrix" target="_top" title="using RDKit">Butina Cluster Matrix</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_mordred_descriptors" target="_top" title="with Mordred">Calculate molecular descriptors</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_pbf_ev" target="_top" title="using RDKit">Calculate plane of best fit for molecules</a>
+<a href="https://usegalaxy.org/root?tool_id=prepare_box" target="_top" title="for an AutoDock Vina job from a ligand or pocket input file (confounding box)">Calculate the box parameters using RDKit</a>
+<a href="https://usegalaxy.org/root?tool_id=chembl_structure_pipeline" target="_top" title="for curation and standardizing of molecular structures">ChEMBL structure pipeline</a>
+<a href="https://usegalaxy.org/root?tool_id=chembl_structure_pipeline" target="_top" title="for curation and standardizing of molecular structures">ChEMBL structure pipeline</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_change_title" target="_top" title="to meta-data value.">Change Title</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_change_title" target="_top" title="to metadata value.">Change title</a>
+<a href="https://usegalaxy.org/root?tool_id=sucos_clustering" target="_top" title="based on the overlap of 3D features">Cluster ligands using SuCOS</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_compound_convert" target="_top" title="Converts various chemistry and molecular modeling data files">Compound Convert</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_obgrep" target="_top" title="an advanced molecular grep program using SMARTS">Compound Search</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_compound_convert" target="_top" title="- interconvert between various chemistry and molecular modeling data files">Compound conversion</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_obgrep" target="_top" title="- an advanced molecular search program using SMARTS">Compound search</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_genProp" target="_top" title="for a set of molecules">Compute physico-chemical properties</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_ob_genProp" target="_top" title="for a set of molecules">Compute physico-chemical properties</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_confab" target="_top" title="for molecules (confab) with OpenBabel">Conformer calculation</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_constrained_conf_gen" target="_top" title="with RDKit">Constrained conformer generation</a>
+<a href="https://usegalaxy.org/root?tool_id=acpype_Amber2Gromacs" target="_top" title="using acpype">Convert Amber topology and coordinate files to GROMACS format</a>
+<a href="https://usegalaxy.org/root?tool_id=parmconv" target="_top" title="to AMBER prmtop in preparation for MMGBSA/MMPBSA">Convert Parameters</a>
+<a href="https://usegalaxy.org/root?tool_id=qiskit_xyz2pdb" target="_top" title="alpha carbon PDB files">Convert Qiskit&#x27;s XYZ files to</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_cosine_analysis" target="_top" title="- measure the cosine content of the PCA projection">Cosine Content</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_frankenstein_ligand" target="_top" title="for docking active site definition">Create Frankenstein ligand</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_makendx" target="_top" title="using make_ndx">Create GROMACS index files</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_restraints" target="_top" title="using genrestr">Create GROMACS position restraints files</a>
+<a href="https://usegalaxy.org/root?tool_id=bio3d_dccm" target="_top" title="- Dynamical Cross-Correlation Maps using Bio3D (DCCM)">DCCM analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_rdkit_descriptors" target="_top" title="calculated with RDKit">Descriptors</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_structure_distance_finder" target="_top" title="- determine the minimum distances between a molecule and a set of 3D points">Determine distance to defined points</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_dihedral" target="_top" title="Time series of dihedrals">Dihedral Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_distance" target="_top" title="- time series using MDAnalysis">Distance Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_silicos_qed" target="_top" title="quantitative estimation (QED) with RDKit">Drug-likeness</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_endtoend" target="_top" title="- End-to-End distance timeseries and histogram for the given selections">End-to-End Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=enumerate_charges" target="_top" title="calculated with Dimorphite DL and RDKit">Enumerate changes</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_extract_rmsd" target="_top" title="from MD ensemble with MDAnalysis">Extract RMSD distance matrix data</a>
+<a href="https://usegalaxy.org/root?tool_id=biomd_extract_clusters" target="_top" title="from linkage matrix data">Extract clusters of MD trajectories</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_energy" target="_top" title="">Extract energy components with GROMACS</a>
+<a href="https://usegalaxy.org/root?tool_id=sdf_to_tab" target="_top" title="into a tabular file using RDKit">Extract values from an SD-file</a>
+<a href="https://usegalaxy.org/root?tool_id=gromacs_extract_topology" target="_top" title="from a GROMACS topology file">Extracting Topology Information</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_filter" target="_top" title="a set of molecules from a file">Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_filter" target="_top" title="a set of molecules from a file">Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_rmsd" target="_top" title="of molecular structures">GROMACS RMSD calculation</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_rmsf" target="_top" title="of molecular structures">GROMACS RMSF calculation</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_rg" target="_top" title="of a molecular structure">GROMACS Radius of Gyration</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_get_builtin_file" target="_top" title="from built-in datasets">GROMACS copy file</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_em" target="_top" title="of the system prior to equilibration and production MD">GROMACS energy minimization</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_setup" target="_top" title="of topology and GRO structure file">GROMACS initial setup</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_md" target="_top" title="for data collection">GROMACS production simulation</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_sim" target="_top" title="for system equilibration or data collection">GROMACS simulation</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_solvate" target="_top" title="to structure and topology files">GROMACS solvation and adding ions</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_editconf" target="_top" title="using editconf">GROMACS structure configuration</a>
+<a href="https://usegalaxy.org/root?tool_id=ambertools_acpype" target="_top" title="using acpype">Generate MD topologies for small molecules</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_conformers" target="_top" title="using RDKit">Generate conformers</a>
+<a href="https://usegalaxy.org/root?tool_id=get_pdb" target="_top" title="from Protein Data Bank">Get PDB file</a>
+<a href="https://usegalaxy.org/root?tool_id=get_pdb" target="_top" title="from Protein Data Bank">Get PDB file</a>
+<a href="https://usegalaxy.org/root?tool_id=biomd_rmsd_clustering" target="_top" title="from MD RMSD matrix data">Hierarchical clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_hbonds" target="_top" title="- analyze H-bonds between two segments">Hydrogen Bond Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=vmd_hbonds" target="_top" title="between two segments of a trajectory">Hydrogen Bond Analysis using VMD</a>
+<a href="https://usegalaxy.org/root?tool_id=jmoleditor" target="_top" title="A Chemical Structure Editor">JMol Editor</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_mds_plot" target="_top" title="of molecule similarity">MDS Scatter Plot</a>
+<a href="https://usegalaxy.org/root?tool_id=md_converter" target="_top" title="- interconvert between MD trajectory file formats.">MDTraj file converter</a>
+<a href="https://usegalaxy.org/root?tool_id=mmpbsa_mmgbsa" target="_top" title="tool for estimating ligand binding affinities">MMPBSA/MMGBSA</a>
+<a href="https://usegalaxy.org/root?tool_id=sucos_max_score" target="_top" title="- determine maximum SuCOS score of ligands against clustered fragment hits">Max SuCOS score</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_merge_topology_files" target="_top" title="and GRO files">Merge GROMACS topologies</a>
+<a href="https://usegalaxy.org/root?tool_id=gmx_trj" target="_top" title="using trjconv and trjcat">Modify/convert GROMACS trajectories</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_osra" target="_top" title="in PDF documents (OSRA)">Molecule recognition</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_chemfp_mol2fps" target="_top" title="conversion to several different fingerprint formats">Molecule to fingerprint</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_multi_obgrep" target="_top" title="an advanced molecular grep program using SMARTS">Multi Compound Search</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_multi_obgrep" target="_top" title="an advanced molecular grep program using SMARTS">Multi Compound Search</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_np-likeness-calculator" target="_top" title="- calculates the similarity of the molecule to the structure space covered by known natural products">Natural Product likeness calculator</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_chemfp_nxn_clustering" target="_top" title="of molecular fingerprints">NxN clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_online_data_fetch" target="_top" title="fetching ...">Online data</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_online_data_fetch" target="_top" title="fetching">Online data</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_o3dalign" target="_top" title="with RDKit">Open 3D Align</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_openmg" target="_top" title="- exhaustive generation of chemical structures">Open Molecule Generator</a>
+<a href="https://usegalaxy.org/root?tool_id=openduck_chunk" target="_top" title="for dynamic undocking">OpenDUck chunk</a>
+<a href="https://usegalaxy.org/root?tool_id=OpenPepXL" target="_top" title="Tool for protein-protein cross-linking identification using labeled linkers">OpenPepXL</a>
+<a href="https://usegalaxy.org/root?tool_id=packmol" target="_top" title="- initial configurations for molecular dynamics simulations by packing optimization">PACKMOL</a>
+<a href="https://usegalaxy.org/root?tool_id=bio3d_pca" target="_top" title="- principal component analysis using Bio3D">PCA</a>
+<a href="https://usegalaxy.org/root?tool_id=bio3d_pca_visualize" target="_top" title="- generate trajectories of principal components of atomic motion">PCA visualization</a>
+<a href="https://usegalaxy.org/root?tool_id=pulchra" target="_top" title="from reduced representations">PULCHRA recontruction of all atom proteins</a>
+<a href="https://usegalaxy.org/root?tool_id=padel" target="_top" title="calculator">PaDEL descriptor</a>
+<a href="https://usegalaxy.org/root?tool_id=ambertools_parmchk2" target="_top" title="- Amber&#x27;s parameter checker">ParmChk2</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_alignit_create_db" target="_top" title="generation (Align-it)">Pharmacophore</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_alignit" target="_top" title="and optimization (Align-it)">Pharmacophore alignment</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_max_min_picker" target="_top" title="diverse compounds from a library with Butina clustering">Pick</a>
+<a href="https://usegalaxy.org/root?tool_id=prepare_ligand" target="_top" title="for docking with Autodock Vina">Prepare ligand</a>
+<a href="https://usegalaxy.org/root?tool_id=prepare_ligands_for_docking" target="_top" title="Tool to prepare ligands for docking with tools like Autodock Vina">Prepare ligands for docking</a>
+<a href="https://usegalaxy.org/root?tool_id=prepare_receptor" target="_top" title="Tool to prepare receptor for docking with Autodock Vina">Prepare receptor</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_pubchem_download_assays" target="_top" title="as table">PubChem Assay Downloader</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_pubchem_download_assays" target="_top" title="as canonical SMILES">PubChem Assay Downloader</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_pubchem_download_as_smiles" target="_top" title="as canonical SMILES">PubChem Download</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_pubchem_download_as_smiles" target="_top" title="as canonical SMILES">PubChem Download</a>
+<a href="https://usegalaxy.org/root?tool_id=qcxms_getres" target="_top" title="Get result of the Production run to obtain a QCxMS simulated mass spectrum">QCxMS get results</a>
+<a href="https://usegalaxy.org/root?tool_id=qcxms_neutral_run" target="_top" title="required as first step to prepare for the production runs">QCxMS neutral run</a>
+<a href="https://usegalaxy.org/root?tool_id=qcxms_production_run" target="_top" title="Production run to obtain a QCxMS simulated mass spectrum">QCxMS production run</a>
+<a href="https://usegalaxy.org/root?tool_id=rdconf" target="_top" title="using RDKit">RDConf: Low-energy ligand conformer search</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_rdf" target="_top" title="Radial Distribution Function between two atoms">RDF Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=bio3d_rmsd" target="_top" title="using Bio3D">RMSD Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=bio3d_rmsf" target="_top" title="using Bio3D">RMSF Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_ramachandran_protein" target="_top" title="- Ramachandran plot for proteins">Ramachandran Analysis</a>
+<a href="https://usegalaxy.org/root?tool_id=mdanalysis_ramachandran_plot" target="_top" title="- calculate and plot the distribution of two dihedrals in a trajectory">Ramachandran Plots</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_rxn_smarts_filter" target="_top" title="using RDKit">Reaction SMARTS filter</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_rxn_maker" target="_top" title="using RDKit">Reaction maker</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_remIons" target="_top" title="from a library of compounds">Remove counterions and fragments</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_remIons" target="_top" title="">Remove counterions and fragments</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_remDuplicates" target="_top" title="from a library of compounds">Remove duplicated molecules</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_remDuplicates" target="_top" title="">Remove duplicated molecules</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_remove_protonation_state" target="_top" title="of every atom">Remove protonation state</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_remove_protonation_state" target="_top" title="of every atom">Remove protonation state</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_remSmall" target="_top" title="from a library of compounds">Remove small molecules</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_remSmall" target="_top" title="">Remove small molecules</a>
+<a href="https://usegalaxy.org/root?tool_id=openduck_run_smd" target="_top" title="steered molecular dynamics runs">Run OpenDUck</a>
+<a href="https://usegalaxy.org/root?tool_id=rxdock_sort_filter" target="_top" title="using the sdsort provided with rxDock">SDF sort and filter</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_sdf2fps" target="_top" title="- extract fingerprints from sdf file metadata">SDF to Fingerprint</a>
+<a href="https://usegalaxy.org/root?tool_id=sucos_docking_scoring" target="_top" title="- compare shape and feature overlap of docked ligand poses to a reference molecule">Score docked poses using SuCOS</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_screen" target="_top" title="a compound against a library using RDKit">Screen</a>
+<a href="https://usegalaxy.org/root?tool_id=chembl" target="_top" title="for compounds which are similar to a SMILES string">Search ChEMBL database</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_simsearch" target="_top" title="of fingerprint data sets with chemfp">Similarity search</a>
+<a href="https://usegalaxy.org/root?tool_id=md_slicer" target="_top" title="using the MDTraj package">Slice MD trajectories</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_spectrophore_search" target="_top" title="- similarity search based on 1D chemical features">Spectrophores search</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_spectrophore_search" target="_top" title="similarity search based on 1D chemical features">Spectrophores(TM) search:</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_standardize" target="_top" title="using RDKit">Standardize SD-files</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_subsearch" target="_top" title="of fingerprint data sets">Substructure Search</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_subsearch" target="_top" title="of fingerprint data sets">Substructure Search</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_chemfp_butina_clustering" target="_top" title="of molecular fingerprints">Taylor-Butina clustering</a>
+<a href="https://usegalaxy.org/root?tool_id=traj_selections_and_merge" target="_top" title="- select specific molecules and merge multiple trajectories.">Trajectory select and merge</a>
+<a href="https://usegalaxy.org/root?tool_id=docking" target="_top" title="tool to perform protein-ligand docking with Autodock Vina">VINA Docking</a>
+<a href="https://usegalaxy.org/root?tool_id=openbabel_svg_depiction" target="_top" title="of compounds">Visualisation</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_ob_svg_depiction" target="_top" title="of compounds">Visualisation</a>
+<a href="https://usegalaxy.org/root?tool_id=xchem_transfs_scoring" target="_top" title="using deep learning">XChem TransFS pose scoring</a>
+<a href="https://usegalaxy.org/root?tool_id=ctb_im_xcos" target="_top" title="scoring">XCos</a>
+<a href="https://usegalaxy.org/root?tool_id=biomd_neqgamma" target="_top" title="for calculating friction and free energy profiles from TMD ensembles">dcTMD friction correction</a>
+<a href="https://usegalaxy.org/root?tool_id=dpocket" target="_top" title="to calculate descriptors for protein pockets">dpocket</a>
+<a href="https://usegalaxy.org/root?tool_id=fastpca" target="_top" title="- dimensionality reduction of MD simulations">fastpca</a>
+<a href="https://usegalaxy.org/root?tool_id=fpocket" target="_top" title="- find potential binding sites in protein structures">fpocket</a>
+<a href="https://usegalaxy.org/root?tool_id=goseq" target="_top" title="tests for overrepresented gene categories">goseq</a>
+<a href="https://usegalaxy.org/root?tool_id=rdock_rbcavity" target="_top" title="- generate the active site definition needed for rDock docking">rDock cavity definition</a>
+<a href="https://usegalaxy.org/root?tool_id=rdock_sort_filter" target="_top" title="using the sdsort provided with rDock">rDock docking</a>
+<a href="https://usegalaxy.org/root?tool_id=rdock_rbdock" target="_top" title="- perform protein-ligand docking with rDock">rDock docking</a>
+<a href="https://usegalaxy.org/root?tool_id=rxdock_rbcavity" target="_top" title="- generate the active site definition needed for rxDock docking">rxDock cavity definition</a>
+<a href="https://usegalaxy.org/root?tool_id=rxdock_rbdock" target="_top" title="- perform protein-ligand docking with rxDock">rxDock docking</a>
+<a href="https://usegalaxy.org/root?tool_id=smina" target="_top" title="Scoring and Minimization">smina</a>
+
+</div>
+
+### Pharmacology
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=pharmcat" target="_top" title="Pharmacogenomics Clinical Annotation Tool">pharmCAT</a>
+
+</div>
+
+### Multiomics
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=episcanpy_cluster_embed" target="_top" title="with EpiScanpy">Cluster, embed and annotate</a>
+
+</div>
+
+### Climate Analysis
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=ctsm_fates" target="_top" title="Functionally Assembled Terrestrial Ecosystem Simulator">CTSM/FATES-EMERALD</a>
+<a href="https://usegalaxy.org/root?tool_id=c3s" target="_top" title="for retrieving climate data">Copernicus Climate Data Store</a>
+<a href="https://usegalaxy.org/root?tool_id=climate_stripes" target="_top" title="from timeseries">climate stripes</a>
+
+</div>
+
+### GIS Data Handling
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=xarray_coords_info" target="_top" title="Get values for each coordinate of a Netcdf file">NetCDF xarray Coordinate Info</a>
+<a href="https://usegalaxy.org/root?tool_id=xarray_metadata_info" target="_top" title="summarize content of a Netcdf file">NetCDF xarray Metadata Info</a>
+<a href="https://usegalaxy.org/root?tool_id=xarray_select" target="_top" title="extracts variable values with custom conditions on dimensions">NetCDF xarray Selection</a>
+<a href="https://usegalaxy.org/root?tool_id=xarray_mapplot" target="_top" title="Visualize netCDF variables on a geographical map">NetCDF xarray map plotting</a>
+<a href="https://usegalaxy.org/root?tool_id=xarray_netcdf2netcdf" target="_top" title="manipulate xarray from netCDF and save back to netCDF">NetCDF xarray operations</a>
+
+</div>
+
+### Epigenetics
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=hicup_deduplicator" target="_top" title="removes duplicated di-tags (retaining one copy of each) from the data set.">Hicup Deduplicator</a>
+<a href="https://usegalaxy.org/root?tool_id=hicup_digester" target="_top" title="cuts throughout a selected genome at one or two specified restriction sites.">Hicup Digester</a>
+<a href="https://usegalaxy.org/root?tool_id=hicup_filter" target="_top" title="classifies read pairs, identifying valid Hi-C di-tags">Hicup Filter</a>
+<a href="https://usegalaxy.org/root?tool_id=hicup_mapper" target="_top" title="aligns paired reads independently to a reference genome and retains reads where both partners align.">Hicup Mapper</a>
+<a href="https://usegalaxy.org/root?tool_id=hicup_hicup" target="_top" title="controls the other programs in the HiCUP pipeline">Hicup Pipeline</a>
+<a href="https://usegalaxy.org/root?tool_id=hicup_truncater" target="_top" title="terminates sequence reads at specified Hi-C ligation junctions.">Hicup Truncater</a>
+<a href="https://usegalaxy.org/root?tool_id=hicup2juicer" target="_top" title="">Hicup to juicer converter</a>
+<a href="https://usegalaxy.org/root?tool_id=cooler_csort_tabix" target="_top" title="Sort and index a contact list.">cooler csort with tabix</a>
+<a href="https://usegalaxy.org/root?tool_id=cooler_balance" target="_top" title="Copy and balance a cool file.">cooler_balance</a>
+<a href="https://usegalaxy.org/root?tool_id=cooler_cload_tabix" target="_top" title="Create a cool file from a tabix-indexed contact file and a list of genomic bins.">cooler_cload_tabix</a>
+<a href="https://usegalaxy.org/root?tool_id=cooler_makebins" target="_top" title="Generate fixed-width genomic bins.">cooler_makebins</a>
+
+</div>
+
+### Spatial
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=squidpy_spatial" target="_top" title="with Squidpy">Analyze and visualize spatial multi-omics data</a>
+<a href="https://usegalaxy.org/root?tool_id=quantification" target="_top" title="a module for single-cell data extraction">MCQUANT</a>
+<a href="https://usegalaxy.org/root?tool_id=cell_intensity_processing" target="_top" title="">Process single-cell intensities</a>
+<a href="https://usegalaxy.org/root?tool_id=ip_slice_image" target="_top" title="">Slice image into patches</a>
+<a href="https://usegalaxy.org/root?tool_id=vitessce_spatial" target="_top" title="Visual Integration Tool for the Exploration of Spatial Single-Cell Experiments">Vitessce</a>
+<a href="https://usegalaxy.org/root?tool_id=s3segmenter" target="_top" title="single cell (nuclei and cytoplasm) label masks.">s3segmenter</a>
+
+</div>
+
+### Compute indicators for satellite remote sensing
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=srs_global_indices" target="_top" title="from remote sensing data">Compute biodiversity indices</a>
+<a href="https://usegalaxy.org/root?tool_id=srs_spectral_indices" target="_top" title="as NDVI from remote sensing data">Compute spectral indices</a>
+<a href="https://usegalaxy.org/root?tool_id=srs_diversity_maps" target="_top" title="from remote sensing data">Map diversity</a>
+<a href="https://usegalaxy.org/root?tool_id=srs_preprocess_s2" target="_top" title="read, crop, resample and write it as a raster stack">Preprocess sentinel 2 data</a>
+
+</div>
+
+---
+
+## Deprecated Tools
+
+
+### CloudMap (deprecated)
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=check_snpeff_candidates" target="_top" title="Marks up a snpEff output file with matches to a gene candidate list.">CloudMap: Check snpEff Candidates</a>
+<a href="https://usegalaxy.org/root?tool_id=ems_variant_density_mapping" target="_top" title="Map a mutation by linkage to regions of high mutation density using WGS data">CloudMap: EMS Variant Density Mapping</a>
+<a href="https://usegalaxy.org/root?tool_id=snp_mapping_using_wgs" target="_top" title="Map a mutation by plotting recombination frequencies resulting from crossing to a highly polymorphic strain">CloudMap: Hawaiian Variant Mapping with WGS data</a>
+<a href="https://usegalaxy.org/root?tool_id=cloudmap_variant_discovery_mapping" target="_top" title="Map a mutation using in silico bulk segregant linkage analysis using variants that are already present in the mutant strain of interest (rather than those introduced by a cross to a polymorphic strain).">CloudMap: Variant Discovery Mapping with WGS data</a>
+<a href="https://usegalaxy.org/root?tool_id=in_silico_complementation" target="_top" title="Perform in silico complementation analysis on multiple tabular snpEff output files">CloudMap: in silico complementation</a>
+<a href="https://usegalaxy.org/root?tool_id=bcftools_view" target="_top" title="Converts BCF format to VCF format">bcftools view</a>
+
+</div>
+
+### RNA Analysis (deprecated)
+
+<div class="tool-list">
+
+<a href="https://usegalaxy.org/root?tool_id=cuffcompare" target="_top" title="compare assembled transcripts to a reference annotation and track Cufflinks transcripts across multiple experiments">Cuffcompare</a>
+<a href="https://usegalaxy.org/root?tool_id=cuffdiff" target="_top" title="find significant changes in transcript expression, splicing, and promoter use">Cuffdiff</a>
+<a href="https://usegalaxy.org/root?tool_id=cufflinks" target="_top" title="transcript assembly and FPKM (RPKM) estimates for RNA-Seq data">Cufflinks</a>
+<a href="https://usegalaxy.org/root?tool_id=cuffmerge" target="_top" title="merge together several Cufflinks assemblies">Cuffmerge</a>
+<a href="https://usegalaxy.org/root?tool_id=cuffnorm" target="_top" title="Create normalized expression levels">Cuffnorm</a>
+<a href="https://usegalaxy.org/root?tool_id=cuffquant" target="_top" title="Precompute gene expression levels">Cuffquant</a>
+<a href="https://usegalaxy.org/root?tool_id=cummerbund_to_cuffdiff" target="_top" title="tabular files from a cummeRbund database">Extract CuffDiff</a>
+<a href="https://usegalaxy.org/root?tool_id=tophat2" target="_top" title="Gapped-read mapper for RNA-seq data">TopHat</a>
+
+</div>


### PR DESCRIPTION
Uses the exact same approach and command as `/eu/tools/` to add a new `/us/tools/` page as well.

Fixes the tools component of https://github.com/galaxyproject/galaxy-hub/issues/4216

CC: @mschatz 