### PR TITLE
Suggesting adaptation EuIntro.astro to omit faulty space

### DIFF
--- a/astro/src/components/mdx/EuIntro.astro
+++ b/astro/src/components/mdx/EuIntro.astro
@@ -11,9 +11,9 @@
           class="text-galaxy-primary underline underline-offset-2 hover:text-galaxy-gold"
           href="https://www.go-fair.org/fair-principles/"
         >
-          FAIR data analysis
+          FAIR data analysis.
         </a>
-      </strong>. It gives researchers a graphical web interface for complex analysis while keeping workflows, histories,
+      </strong>It gives researchers a graphical web interface for complex analysis while keeping workflows, histories,
       and results shareable and reproducible.
     </p>
     <p class="mt-4 text-chicago-700">


### PR DESCRIPTION
https://galaxyproject.org/eu/ currently has a faulty space:

"for FAIR data analysis ." I am suggesting an adaptation of this, but have not rendered it to make sure this completely solves the issue. Maybe someone from the frontend team can double-check. Thanks in advance!