### PR TITLE
fix(deps): drop stray pnpm packageManager field

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -86,6 +86,5 @@
     "typescript-eslint": "^8.64.0",
     "vitest": "^4.1.10",
     "vue-eslint-parser": "^10.4.1"
-  },
-  "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa"
+  }
 }


### PR DESCRIPTION
## Problem

Dependabot's grouped npm PRs bump `astro/package.json` but never update `astro/package-lock.json`, so every one of them fails CI:

npm error npm ci can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Invalid: lock file's eslint-plugin-astro@2.1.1 does not satisfy eslint-plugin-astro@3.1.0

Affected: #4122, #4133, #4147, and the currently open #4173.

## Cause

`astro/package.json` carried a `packageManager: "pnpm@10.26.1+..."` field. Dependabot's npm ecosystem reads that field to pick the package manager, concluded the project uses pnpm, looked for a `pnpm-lock.yaml` that has never existed in this repo, and therefore updated only the manifest.

The project is npm: `astro/package-lock.json` is tracked, and every workflow runs `npm ci` with `cache: npm` and `cache-dependency-path: astro/package-lock.json`. The field also breaks local installs for contributors who have corepack
shims enabled.

## Fix

Remove the field. `astro/package-lock.json` is unchanged and verified in sync (`npm ci --dry-run` succeeds).